### PR TITLE
🔀 :: 10 - email Auth 엔티티 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/auth/model/EmailAuth.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/model/EmailAuth.kt
@@ -1,0 +1,8 @@
+package com.dcd.server.core.domain.auth.model
+
+import java.util.*
+
+data class EmailAuth(
+    val email: String,
+    val code: String = UUID.randomUUID().toString().split("-")[0],
+)

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/spi/CommandEmailAuthPort.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/spi/CommandEmailAuthPort.kt
@@ -1,0 +1,9 @@
+package com.dcd.server.core.domain.auth.spi
+
+import com.dcd.server.core.domain.auth.model.EmailAuth
+
+interface CommandEmailAuthPort {
+    fun save(emailAuth: EmailAuth)
+    fun deleteByCode(code: String)
+    fun deleteByEmailAndCode(email: String, code: String)
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/spi/EmailAuthPort.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/spi/EmailAuthPort.kt
@@ -1,0 +1,5 @@
+package com.dcd.server.core.domain.auth.spi
+
+interface EmailAuthPort :
+        CommandEmailAuthPort,
+        QueryEmailAuthPort

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/spi/QueryEmailAuthPort.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/spi/QueryEmailAuthPort.kt
@@ -1,0 +1,8 @@
+package com.dcd.server.core.domain.auth.spi
+
+import com.dcd.server.core.domain.auth.model.EmailAuth
+
+interface QueryEmailAuthPort {
+    fun findByEmail(email: String): List<EmailAuth>
+    fun findByCode(code: String): EmailAuth?
+}

--- a/src/main/kotlin/com/dcd/server/persistence/auth/EmailAuthPersistenceAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/auth/EmailAuthPersistenceAdapter.kt
@@ -1,0 +1,33 @@
+package com.dcd.server.persistence.auth
+
+import com.dcd.server.core.domain.auth.model.EmailAuth
+import com.dcd.server.core.domain.auth.spi.EmailAuthPort
+import com.dcd.server.persistence.auth.adapter.toDomain
+import com.dcd.server.persistence.auth.adapter.toEntity
+import com.dcd.server.persistence.auth.repository.EmailAuthRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+
+@Component
+class EmailAuthPersistenceAdapter(
+    private val emailAuthRepository: EmailAuthRepository
+) : EmailAuthPort{
+    override fun save(emailAuth: EmailAuth) {
+        emailAuthRepository.save(emailAuth.toEntity())
+    }
+
+    override fun deleteByCode(code: String) =
+        emailAuthRepository.deleteById(code)
+
+    override fun deleteByEmailAndCode(email: String, code: String) =
+        emailAuthRepository.deleteByEmailAndCode(email, code)
+
+    override fun findByEmail(email: String): List<EmailAuth> =
+        emailAuthRepository.findByEmail(email)
+            .map { it.toDomain() }
+
+    override fun findByCode(code: String): EmailAuth? =
+        emailAuthRepository.findByIdOrNull(code)
+            ?.toDomain()
+
+}

--- a/src/main/kotlin/com/dcd/server/persistence/auth/adapter/EmailAuthAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/auth/adapter/EmailAuthAdapter.kt
@@ -1,0 +1,16 @@
+package com.dcd.server.persistence.auth.adapter
+
+import com.dcd.server.core.domain.auth.model.EmailAuth
+import com.dcd.server.persistence.auth.entity.EmailAuthEntity
+
+fun EmailAuth.toEntity(): EmailAuthEntity =
+    EmailAuthEntity(
+        email = this.email,
+        code = this.code
+    )
+
+fun EmailAuthEntity.toDomain(): EmailAuth =
+    EmailAuth(
+        email = this.email,
+        code = this.code
+    )

--- a/src/main/kotlin/com/dcd/server/persistence/auth/entity/EmailAuthEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/auth/entity/EmailAuthEntity.kt
@@ -1,0 +1,14 @@
+package com.dcd.server.persistence.auth.entity
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.redis.core.RedisHash
+import org.springframework.data.redis.core.index.Indexed
+
+@RedisHash(value = "EmailAuth")
+class EmailAuthEntity(
+    @Indexed
+    val email: String,
+    @Id
+    @Indexed
+    val code: String
+)

--- a/src/main/kotlin/com/dcd/server/persistence/auth/repository/EmailAuthRepository.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/auth/repository/EmailAuthRepository.kt
@@ -1,0 +1,9 @@
+package com.dcd.server.persistence.auth.repository
+
+import com.dcd.server.persistence.auth.entity.EmailAuthEntity
+import org.springframework.data.repository.CrudRepository
+
+interface EmailAuthRepository : CrudRepository<EmailAuthEntity, String> {
+    fun deleteByEmailAndCode(email: String, code: String)
+    fun findByEmail(email: String): List<EmailAuthEntity>
+}

--- a/src/test/kotlin/com/dcd/server/persistence/auth/EmailAuthPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/persistence/auth/EmailAuthPersistenceAdapterTest.kt
@@ -1,0 +1,72 @@
+package com.dcd.server.persistence.auth
+
+import com.dcd.server.core.domain.auth.model.EmailAuth
+import com.dcd.server.persistence.auth.adapter.toEntity
+import com.dcd.server.persistence.auth.repository.EmailAuthRepository
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.data.repository.findByIdOrNull
+
+class EmailAuthPersistenceAdapterTest : BehaviorSpec({
+    val emailAuthRepository = mockk<EmailAuthRepository>()
+    val adapter = EmailAuthPersistenceAdapter(emailAuthRepository)
+
+    given("이메일 인증객체가 주어지고") {
+        val testCode = "testCode"
+        val testEmail = "testEmail"
+        val emailAuth = EmailAuth(testEmail, testCode)
+        val emailAuthEntity = emailAuth.toEntity()
+
+        `when`("save를 실행할때") {
+            every { emailAuthRepository.save(any()) } answers { callOriginal() }
+            adapter.save(emailAuth)
+            then("repository의 save메서드가 실행되어야함") {
+                verify { emailAuthRepository.save(any()) }
+            }
+        }
+
+        `when`("deleteByCode를 실행할때") {
+            every { emailAuthRepository.deleteById(testCode) } returns Unit
+            adapter.deleteByCode(testCode)
+            then("repository의 deleteById가 실행되어야함") {
+                verify { emailAuthRepository.deleteById(testCode) }
+            }
+        }
+
+        `when`("deleteByEmailAndCode를 실행할때") {
+            every { emailAuthRepository.deleteByEmailAndCode(testEmail, testCode) } returns Unit
+            adapter.deleteByEmailAndCode(testEmail, testCode)
+            then("repository의 deleteByEmailAndCode가 실행되어야함") {
+                verify { emailAuthRepository.deleteByEmailAndCode(testEmail, testCode) }
+            }
+        }
+
+        `when`("findByEmail을 실행할때") {
+            every { emailAuthRepository.findByEmail(testEmail) } returns listOf(emailAuthEntity)
+            val result = adapter.findByEmail(testEmail)
+            then("emailAuth가 담겨있는 list가 반환되어야함") {
+                verify { emailAuthRepository.findByEmail(testEmail) }
+                result shouldBe listOf(emailAuth)
+            }
+        }
+
+        `when`("findByCode를 실행할때") {
+            every { emailAuthRepository.findByIdOrNull(testCode) } returns emailAuthEntity
+            var result = adapter.findByCode(testCode)
+            then("emailAuth가 반환되어야함") {
+                verify { emailAuthRepository.findByIdOrNull(testCode) }
+                result shouldBe emailAuth
+            }
+
+            every { emailAuthRepository.findByIdOrNull(testCode) } returns null
+            result = adapter.findByCode(testCode)
+            then("repository에서 반환되는 값이 null일때 null이 반환되어야 함") {
+                verify { emailAuthRepository.findByIdOrNull(testCode) }
+                result shouldBe null
+            }
+        }
+    }
+})


### PR DESCRIPTION
💡 개요
* 이메일 인증 엔티티 추가

📃 작업내용
* 이메일 인증 도메인 추가
* 이메일 인증 엔티티 추가
* 이메일 인증 포트 추가
* 이메일 인증 어뎁터 추가
* 이메일 인증 어뎁터 테스트 코드 추가

🔀 변경사항

🙋‍♂️ 질문사항

🍴 사용방법

🎸 기타