### PR TITLE
🔀 :: 14 - 회원가입 전 메일 보내는 API 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/annotation/UseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/annotation/UseCase.kt
@@ -1,0 +1,8 @@
+package com.dcd.server.core.common.annotation
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(rollbackFor = [Exception::class])
+annotation class UseCase()

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/dto/request/EmailSendRequestData.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/dto/request/EmailSendRequestData.kt
@@ -1,0 +1,5 @@
+package com.dcd.server.core.domain.auth.dto.request
+
+data class EmailSendRequestData(
+    val email: String
+)

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/AuthMailSendUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/AuthMailSendUseCase.kt
@@ -1,0 +1,15 @@
+package com.dcd.server.core.domain.auth.usecase
+
+import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.domain.auth.dto.request.EmailSendRequestData
+import com.dcd.server.core.domain.auth.service.EmailSendService
+
+
+@UseCase
+class AuthMailSendUseCase(
+    private val emailSendService: EmailSendService
+) {
+    fun execute(emailSendRequestData: EmailSendRequestData) {
+        emailSendService.sendEmail(emailSendRequestData.email)
+    }
+}

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
@@ -6,6 +6,7 @@ import com.dcd.server.infrastructure.global.security.CustomAuthenticationEntryPo
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
@@ -38,6 +39,9 @@ class SecurityConfig(
                 it.requestMatchers(RequestMatcher { request ->
                     CorsUtils.isPreFlightRequest(request)
                 }).permitAll()
+
+                //auth
+                .requestMatchers(HttpMethod.POST, "/auth/email").permitAll()
 
                 //when url not set
                 .anyRequest().denyAll()

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/error/handler/BasicExceptionHandler.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/error/handler/BasicExceptionHandler.kt
@@ -1,9 +1,11 @@
 package com.dcd.server.infrastructure.global.error.handler
 
 import com.dcd.server.core.common.error.BasicException
+import com.dcd.server.core.common.error.ErrorCode
 import com.dcd.server.infrastructure.global.error.response.ErrorResponse
 import jakarta.servlet.http.HttpServletRequest
 import org.slf4j.LoggerFactory
+import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 
@@ -16,6 +18,16 @@ class BasicExceptionHandler {
         log.error(request.method)
         log.error(request.requestURI)
         val errorCode = ex.errorCode
+        log.error(errorCode.msg)
+        log.error("${errorCode.code}")
+        return ErrorResponse(errorCode)
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleMethodArgumentNotValidException(request: HttpServletRequest, ex: MethodArgumentNotValidException): ErrorResponse {
+        log.error(request.method)
+        log.error(request.requestURI)
+        val errorCode = ErrorCode.BAD_REQUEST
         log.error(errorCode.msg)
         log.error("${errorCode.code}")
         return ErrorResponse(errorCode)

--- a/src/main/kotlin/com/dcd/server/presentation/domain/auth/AuthWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/auth/AuthWebAdapter.kt
@@ -1,0 +1,26 @@
+package com.dcd.server.presentation.domain.auth
+
+import com.dcd.server.core.domain.auth.usecase.AuthMailSendUseCase
+import com.dcd.server.presentation.domain.auth.data.exetension.toDto
+import com.dcd.server.presentation.domain.auth.data.request.EmailSendRequest
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/auth")
+class AuthWebAdapter(
+    private val authMailSendUseCase: AuthMailSendUseCase
+) {
+    @PostMapping("/email")
+    fun sendAuthEmail(
+        @Validated
+        @RequestBody
+        emailSendRequest: EmailSendRequest
+    ): ResponseEntity<Void> =
+        authMailSendUseCase.execute(emailSendRequest.toDto())
+            .run { ResponseEntity.ok().build() }
+}

--- a/src/main/kotlin/com/dcd/server/presentation/domain/auth/data/exetension/EmailAuthRequestExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/auth/data/exetension/EmailAuthRequestExtension.kt
@@ -1,0 +1,9 @@
+package com.dcd.server.presentation.domain.auth.data.exetension
+
+import com.dcd.server.core.domain.auth.dto.request.EmailSendRequestData
+import com.dcd.server.presentation.domain.auth.data.request.EmailSendRequest
+
+fun EmailSendRequest.toDto(): EmailSendRequestData =
+    EmailSendRequestData(
+        email = this.email
+    )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/auth/data/request/EmailSendRequest.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/auth/data/request/EmailSendRequest.kt
@@ -1,0 +1,10 @@
+package com.dcd.server.presentation.domain.auth.data.request
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+
+data class EmailSendRequest(
+    @field:NotBlank
+    @field:Email
+    val email: String
+)

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/AuthMailSendUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/AuthMailSendUseCaseTest.kt
@@ -1,0 +1,25 @@
+package com.dcd.server.core.domain.auth.usecase
+
+import com.dcd.server.core.domain.auth.dto.request.EmailSendRequestData
+import com.dcd.server.core.domain.auth.service.EmailSendService
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+class AuthMailSendUseCaseTest : BehaviorSpec({
+    val emailSendService = mockk<EmailSendService>()
+    val useCase = AuthMailSendUseCase(emailSendService)
+
+    given("EmailSendRequestData가 주어지고") {
+        val testEmail = "testEmail"
+        val request = EmailSendRequestData(testEmail)
+        `when`("execute메서드를 실행할때") {
+            every { emailSendService.sendEmail(testEmail) } returns Unit
+            useCase.execute(request)
+            then("emailSendService의 sendEmail메서드를 실행해아함") {
+                verify { emailSendService.sendEmail(testEmail) }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/dcd/server/presentation/domain/auth/AuthWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/auth/AuthWebAdapterTest.kt
@@ -1,0 +1,29 @@
+package com.dcd.server.presentation.domain.auth
+
+import com.dcd.server.core.domain.auth.usecase.AuthMailSendUseCase
+import com.dcd.server.presentation.domain.auth.data.request.EmailSendRequest
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.http.ResponseEntity
+
+class AuthWebAdapterTest : BehaviorSpec({
+    val authMailSendUseCase = mockk<AuthMailSendUseCase>()
+    val authWebAdapter = AuthWebAdapter(authMailSendUseCase)
+
+    given("EmailSendRequest가 주어지고") {
+        val testEmail = "testEmail"
+        val request = EmailSendRequest(testEmail)
+
+        `when`("sendEmail 메서드를 실행할때") {
+            every { authMailSendUseCase.execute(any()) } returns Unit
+            val result = authWebAdapter.sendAuthEmail(request)
+            then("문제가 없다면 usecase가 실행되어야함") {
+                verify { authMailSendUseCase.execute(any()) }
+                result shouldBe ResponseEntity.ok().build()
+            }
+        }
+    }
+})


### PR DESCRIPTION
💡 개요
* 회원가입 전 메일 보내는 API 추가

📃 작업내용
* AuthMailSendUseCase 추가
* AuthMailSendWebAdapter 추가
* MethodArgumentNotValidException handler 추가
* UseCase 어노테이션 추가
* 해당 API에 관련된 시큐리티 설정 추가

🔀 변경사항

🙋‍♂️ 질문사항

🍴 사용방법

🎸 기타