### PR TITLE
🔀  :: 18 - 이메일 인증 API 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/aop/EmailCertificateAspect.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/aop/EmailCertificateAspect.kt
@@ -1,0 +1,30 @@
+package com.dcd.server.core.common.aop
+
+import com.dcd.server.core.common.aop.exception.NotCertificateEmailException
+import com.dcd.server.core.domain.auth.dto.request.SignUpRequestDto
+import com.dcd.server.core.domain.auth.spi.CommandEmailAuthPort
+import com.dcd.server.core.domain.auth.spi.QueryEmailAuthPort
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.annotation.Before
+import org.aspectj.lang.annotation.Pointcut
+import org.springframework.stereotype.Component
+
+@Aspect
+@Component
+class EmailCertificateAspect(
+    private val queryEmailAuthPort: QueryEmailAuthPort,
+    private val commandEmailAuthPort: CommandEmailAuthPort
+) {
+    @Pointcut("execution(* com.dcd.server.core.domain.auth.usecase.SignUpUseCase.execute(..)) " +  "&& args(signUpRequestDto)")
+    fun signupUseCasePointcut(signUpRequestDto: SignUpRequestDto) {
+    }
+
+    @Before("signupUseCasePointcut(signUpRequestDto)")
+    private fun checkEmailCertificate(signUpRequestDto: SignUpRequestDto) {
+        val emailAuthList = queryEmailAuthPort.findByEmail(signUpRequestDto.email)
+            .filter { it.certificate }
+        if (emailAuthList.isEmpty())
+            throw NotCertificateEmailException()
+        commandEmailAuthPort.deleteByCode(emailAuthList[0].code)
+    }
+}

--- a/src/main/kotlin/com/dcd/server/core/common/aop/exception/NotCertificateEmailException.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/aop/exception/NotCertificateEmailException.kt
@@ -1,0 +1,7 @@
+package com.dcd.server.core.common.aop.exception
+
+import com.dcd.server.core.common.error.BasicException
+import com.dcd.server.core.common.error.ErrorCode
+
+class NotCertificateEmailException : BasicException(ErrorCode.NOT_CERTIFICATE_MAIL) {
+}

--- a/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
@@ -16,6 +16,7 @@ enum class ErrorCode(
     FORBIDDEN("금지된 요청", 403),
     NOT_VALID_TOKEN("토큰이 유효하지 않음", 403),
     NOT_VALID_CODE("코드가 유효하지 않음", 403),
+    NOT_CERTIFICATE_MAIL("메일인증후 진행해주세요", 403),
 
     NOT_FOUND("해당 리소스를 찾을 수 없음", 404),
 

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/dto/request/CertificateMailRequestDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/dto/request/CertificateMailRequestDto.kt
@@ -1,0 +1,6 @@
+package com.dcd.server.core.domain.auth.dto.request
+
+data class CertificateMailRequestDto (
+    val email: String,
+    val code: String
+)

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/model/EmailAuth.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/model/EmailAuth.kt
@@ -5,4 +5,5 @@ import java.util.*
 data class EmailAuth(
     val email: String,
     val code: String = UUID.randomUUID().toString().split("-")[0],
+    val certificate: Boolean = false
 )

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/service/VerifyEmailAuthService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/service/VerifyEmailAuthService.kt
@@ -1,4 +1,5 @@
 package com.dcd.server.core.domain.auth.service
 
 interface VerifyEmailAuthService {
+    fun verifyCode(email: String, code: String)
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/service/impl/VerifyEmailAuthServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/service/impl/VerifyEmailAuthServiceImpl.kt
@@ -12,12 +12,12 @@ class VerifyEmailAuthServiceImpl(
     private val queryEmailAuthPort: QueryEmailAuthPort,
     private val commandEmailAuthPort: CommandEmailAuthPort
 ) : VerifyEmailAuthService {
-    fun verifyCode(email: String, code: String) {
+    override fun verifyCode(email: String, code: String) {
         if (!queryEmailAuthPort.existsByCodeAndEmail(email, code))
             if (queryEmailAuthPort.existsByEmail(email))
                 throw InvalidAuthCodeException()
-            else
-                throw ExpiredCodeException() // 해당 코드가 만료됨
-        commandEmailAuthPort.deleteByCode(code)
+        val emailAuth = (queryEmailAuthPort.findByCode(code)
+            ?: throw ExpiredCodeException())
+        commandEmailAuthPort.save(emailAuth.copy(certificate = true))
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/AuthenticateMailUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/AuthenticateMailUseCase.kt
@@ -1,0 +1,14 @@
+package com.dcd.server.core.domain.auth.usecase
+
+import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.domain.auth.dto.request.CertificateMailRequestDto
+import com.dcd.server.core.domain.auth.service.VerifyEmailAuthService
+
+@UseCase
+class AuthenticateMailUseCase(
+    private val verifyEmailAuthService: VerifyEmailAuthService
+) {
+    fun execute(certificateMailRequestDto: CertificateMailRequestDto) {
+        verifyEmailAuthService.verifyCode(certificateMailRequestDto.email, certificateMailRequestDto.code)
+    }
+}

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
@@ -42,6 +42,7 @@ class SecurityConfig(
 
                 //auth
                 .requestMatchers(HttpMethod.POST, "/auth/email").permitAll()
+                .requestMatchers(HttpMethod.POST, "/auth/email/certificate").permitAll()
                 .requestMatchers(HttpMethod.POST, "/auth/signup").permitAll()
 
                 //when url not set

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/error/handler/BasicExceptionHandler.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/error/handler/BasicExceptionHandler.kt
@@ -5,6 +5,9 @@ import com.dcd.server.core.common.error.ErrorCode
 import com.dcd.server.infrastructure.global.error.response.ErrorResponse
 import jakarta.servlet.http.HttpServletRequest
 import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatusCode
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -14,22 +17,28 @@ class BasicExceptionHandler {
     private val log = LoggerFactory.getLogger(this::class.simpleName)
 
     @ExceptionHandler(BasicException::class)
-    fun handleBasicException(request: HttpServletRequest, ex: BasicException): ErrorResponse {
+    fun handleBasicException(request: HttpServletRequest, ex: BasicException): ResponseEntity<ErrorResponse> {
         log.error(request.method)
         log.error(request.requestURI)
         val errorCode = ex.errorCode
         log.error(errorCode.msg)
         log.error("${errorCode.code}")
-        return ErrorResponse(errorCode)
+        return ResponseEntity(
+            ErrorResponse(errorCode),
+            HttpStatus.valueOf(errorCode.code)
+        )
     }
 
     @ExceptionHandler(MethodArgumentNotValidException::class)
-    fun handleMethodArgumentNotValidException(request: HttpServletRequest, ex: MethodArgumentNotValidException): ErrorResponse {
+    fun handleMethodArgumentNotValidException(request: HttpServletRequest, ex: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> {
         log.error(request.method)
         log.error(request.requestURI)
         val errorCode = ErrorCode.BAD_REQUEST
         log.error(errorCode.msg)
         log.error("${errorCode.code}")
-        return ErrorResponse(errorCode)
+        return ResponseEntity(
+            ErrorResponse(errorCode),
+            HttpStatusCode.valueOf(errorCode.code)
+        )
     }
 }

--- a/src/main/kotlin/com/dcd/server/persistence/auth/adapter/EmailAuthAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/auth/adapter/EmailAuthAdapter.kt
@@ -6,11 +6,13 @@ import com.dcd.server.persistence.auth.entity.EmailAuthEntity
 fun EmailAuth.toEntity(): EmailAuthEntity =
     EmailAuthEntity(
         email = this.email,
-        code = this.code
+        code = this.code,
+        certificate = this.certificate
     )
 
 fun EmailAuthEntity.toDomain(): EmailAuth =
     EmailAuth(
         email = this.email,
-        code = this.code
+        code = this.code,
+        certificate = this.certificate
     )

--- a/src/main/kotlin/com/dcd/server/persistence/auth/entity/EmailAuthEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/auth/entity/EmailAuthEntity.kt
@@ -10,5 +10,6 @@ class EmailAuthEntity(
     val email: String,
     @Id
     @Indexed
-    val code: String
+    val code: String,
+    val certificate: Boolean
 )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/auth/AuthWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/auth/AuthWebAdapter.kt
@@ -1,8 +1,10 @@
 package com.dcd.server.presentation.domain.auth
 
 import com.dcd.server.core.domain.auth.usecase.AuthMailSendUseCase
+import com.dcd.server.core.domain.auth.usecase.AuthenticateMailUseCase
 import com.dcd.server.core.domain.auth.usecase.SignUpUseCase
 import com.dcd.server.presentation.domain.auth.data.exetension.toDto
+import com.dcd.server.presentation.domain.auth.data.request.CertificateMailRequest
 import com.dcd.server.presentation.domain.auth.data.request.EmailSendRequest
 import com.dcd.server.presentation.domain.auth.data.request.SignUpRequest
 import org.springframework.http.HttpStatus
@@ -17,7 +19,8 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/auth")
 class AuthWebAdapter(
     private val authMailSendUseCase: AuthMailSendUseCase,
-    private val signUpUseCase: SignUpUseCase
+    private val signUpUseCase: SignUpUseCase,
+    private val authenticateMailUseCase: AuthenticateMailUseCase
 ) {
     @PostMapping("/email")
     fun sendAuthEmail(
@@ -28,6 +31,14 @@ class AuthWebAdapter(
         authMailSendUseCase.execute(emailSendRequest.toDto())
             .run { ResponseEntity.ok().build() }
 
+    @PostMapping("/email/certificate")
+    fun certificateEmail(
+        @Validated
+        @RequestBody
+        certificateMailRequest: CertificateMailRequest
+    ): ResponseEntity<Void> =
+        authenticateMailUseCase.execute(certificateMailRequest.toDto())
+            .run { ResponseEntity.ok().build() }
 
     @PostMapping("/signup")
     fun signupUser(

--- a/src/main/kotlin/com/dcd/server/presentation/domain/auth/data/exetension/EmailAuthRequestExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/auth/data/exetension/EmailAuthRequestExtension.kt
@@ -1,9 +1,17 @@
 package com.dcd.server.presentation.domain.auth.data.exetension
 
+import com.dcd.server.core.domain.auth.dto.request.CertificateMailRequestDto
 import com.dcd.server.core.domain.auth.dto.request.EmailSendRequestDto
+import com.dcd.server.presentation.domain.auth.data.request.CertificateMailRequest
 import com.dcd.server.presentation.domain.auth.data.request.EmailSendRequest
 
 fun EmailSendRequest.toDto(): EmailSendRequestDto =
     EmailSendRequestDto(
         email = this.email
+    )
+
+fun CertificateMailRequest.toDto(): CertificateMailRequestDto =
+    CertificateMailRequestDto(
+        email = this.email,
+        code = this.code
     )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/auth/data/request/CertificateMailRequest.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/auth/data/request/CertificateMailRequest.kt
@@ -1,0 +1,12 @@
+package com.dcd.server.presentation.domain.auth.data.request
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+
+data class CertificateMailRequest(
+    @field:Email
+    @field:NotBlank
+    val email: String,
+    @field:NotBlank
+    val code: String
+)

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/service/VerifyEmailAuthServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/service/VerifyEmailAuthServiceImplTest.kt
@@ -2,6 +2,7 @@ package com.dcd.server.core.domain.auth.service
 
 import com.dcd.server.core.domain.auth.exception.ExpiredCodeException
 import com.dcd.server.core.domain.auth.exception.InvalidAuthCodeException
+import com.dcd.server.core.domain.auth.model.EmailAuth
 import com.dcd.server.core.domain.auth.service.impl.VerifyEmailAuthServiceImpl
 import com.dcd.server.core.domain.auth.spi.CommandEmailAuthPort
 import com.dcd.server.core.domain.auth.spi.QueryEmailAuthPort
@@ -9,6 +10,8 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
+import kotlin.math.E
 
 class VerifyEmailAuthServiceImplTest : BehaviorSpec({
     val queryEmailAuthPort = mockk<QueryEmailAuthPort>()
@@ -21,6 +24,7 @@ class VerifyEmailAuthServiceImplTest : BehaviorSpec({
         `when`("verifyCode메서드를 실행할때") {
             every { queryEmailAuthPort.existsByCodeAndEmail(testEmail, testCode) } returns false
             every { queryEmailAuthPort.existsByEmail(testEmail) } returns false
+            every { queryEmailAuthPort.findByCode(testCode) } returns null
             then("코드가 만료되었다면 ExpiredEmailAuthCodeException이 throw되야함") {
                 shouldThrow<ExpiredCodeException> {
                     serviceImpl.verifyCode(testEmail, testCode)
@@ -32,6 +36,14 @@ class VerifyEmailAuthServiceImplTest : BehaviorSpec({
                 shouldThrow<InvalidAuthCodeException> {
                     serviceImpl.verifyCode(testEmail, testCode)
                 }
+            }
+
+            every { queryEmailAuthPort.existsByCodeAndEmail(testEmail, testCode) } returns true
+            every { queryEmailAuthPort.findByCode(testCode) } returns EmailAuth(testEmail, testCode, false)
+            every { commandEmailAuthPort.save(any()) } answers { callOriginal() }
+            serviceImpl.verifyCode(testEmail, testCode)
+            then("코드도 옳바르면 업데이트 되야함") {
+                verify { commandEmailAuthPort.save(any()) }
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/AuthenticateMailUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/AuthenticateMailUseCaseTest.kt
@@ -1,0 +1,27 @@
+package com.dcd.server.core.domain.auth.usecase
+
+import com.dcd.server.core.domain.auth.dto.request.CertificateMailRequestDto
+import com.dcd.server.core.domain.auth.service.VerifyEmailAuthService
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+class AuthenticateMailUseCaseTest : BehaviorSpec({
+    val verifyEmailAuthService = mockk<VerifyEmailAuthService>()
+    val useCase = AuthenticateMailUseCase(verifyEmailAuthService)
+
+    given("CertificateMailRequestDto가 주어지고") {
+        val testEmail = "testEmail"
+        val testCode = "testCode"
+        val request = CertificateMailRequestDto(testEmail, testCode)
+
+        `when`("실행할때") {
+            every { verifyEmailAuthService.verifyCode(request.email, request.code) } returns Unit
+            useCase.execute(request)
+            then("verifyEmailAuthService의 verifyCode가 실행되어야함") {
+                verify { verifyEmailAuthService.verifyCode(testEmail, testCode) }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/dcd/server/presentation/domain/auth/AuthWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/auth/AuthWebAdapterTest.kt
@@ -1,7 +1,9 @@
 package com.dcd.server.presentation.domain.auth
 
 import com.dcd.server.core.domain.auth.usecase.AuthMailSendUseCase
+import com.dcd.server.core.domain.auth.usecase.AuthenticateMailUseCase
 import com.dcd.server.core.domain.auth.usecase.SignUpUseCase
+import com.dcd.server.presentation.domain.auth.data.request.CertificateMailRequest
 import com.dcd.server.presentation.domain.auth.data.request.EmailSendRequest
 import com.dcd.server.presentation.domain.auth.data.request.SignUpRequest
 import io.kotest.core.spec.style.BehaviorSpec
@@ -15,7 +17,8 @@ import org.springframework.http.ResponseEntity
 class AuthWebAdapterTest : BehaviorSpec({
     val authMailSendUseCase = mockk<AuthMailSendUseCase>()
     val signUpUseCase = mockk<SignUpUseCase>()
-    val authWebAdapter = AuthWebAdapter(authMailSendUseCase, signUpUseCase)
+    val authenticateMailUseCase = mockk<AuthenticateMailUseCase>()
+    val authWebAdapter = AuthWebAdapter(authMailSendUseCase, signUpUseCase, authenticateMailUseCase)
 
     given("EmailSendRequest가 주어지고") {
         val testEmail = "testEmail"
@@ -42,6 +45,20 @@ class AuthWebAdapterTest : BehaviorSpec({
             then("문제가 없다면 usecase가 실행되어야함") {
                 verify { signUpUseCase.execute(any()) }
                 result shouldBe ResponseEntity(HttpStatus.CREATED)
+            }
+        }
+    }
+
+    given("CertificateMailRequest가 주어지고") {
+        val testEmail = "testEmail"
+        val testCode = "testCode"
+        val request = CertificateMailRequest(testEmail, testCode)
+        `when`("certificateMail 메서드를 실행할때") {
+            every { authenticateMailUseCase.execute(any()) } returns Unit
+            val result = authWebAdapter.certificateEmail(request)
+            then("문제가 없다면 usecase가 실행되어야함") {
+                verify { authenticateMailUseCase.execute(any()) }
+                result shouldBe ResponseEntity.ok().build()
             }
         }
     }


### PR DESCRIPTION
💡 개요
* 이메일 인증 API 추가

📃 작업내용
* 이메일 인증 서비스 리펙토링
* 이메일 인증 유즈케이스 추가
* 이메일 인증 확인을 위한 aspect 추가

🔀 변경사항
* verfiyEmailAuthService의 로직을 변경

🙋‍♂️ 질문사항

🍴 사용방법

🎸 기타
* aspect 적용 범위를 어노테이션으로 걸어서 매번 포인트컷을 추가하지 않아도 되게끔 추후에 리펙토링 하면 좋을듯