### PR TITLE
🔀 :: 93 - 워크스페이스 삭제 API 테스트 코드

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteWorkspaceUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteWorkspaceUseCase.kt
@@ -3,6 +3,7 @@ package com.dcd.server.core.domain.workspace.usecase
 import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.domain.user.service.GetCurrentUserService
 import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
+import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameException
 import com.dcd.server.core.domain.workspace.spi.CommandWorkspacePort
 import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
 
@@ -17,7 +18,7 @@ class DeleteWorkspaceUseCase(
             ?: throw WorkspaceNotFoundException())
         val currentUser = getCurrentUserService.getCurrentUser()
         if (currentUser.equals(workspace.owner).not())
-            throw RuntimeException()
+            throw WorkspaceOwnerNotSameException()
         commandWorkspacePort.delete(workspace)
     }
 }

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteWorkspaceUseCaseTest.kt
@@ -1,0 +1,47 @@
+package com.dcd.server.core.domain.workspace.usecase
+
+import com.dcd.server.core.domain.auth.model.Role
+import com.dcd.server.core.domain.user.model.User
+import com.dcd.server.core.domain.user.service.GetCurrentUserService
+import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
+import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameException
+import com.dcd.server.core.domain.workspace.model.Workspace
+import com.dcd.server.core.domain.workspace.spi.CommandWorkspacePort
+import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.*
+
+class DeleteWorkspaceUseCaseTest : BehaviorSpec({
+    val commandWorkspacePort = mockk<CommandWorkspacePort>(relaxUnitFun = true)
+    val queryWorkspacePort = mockk<QueryWorkspacePort>()
+    val getCurrentUserService = mockk<GetCurrentUserService>()
+    val deleteWorkspaceUseCase = DeleteWorkspaceUseCase(commandWorkspacePort, queryWorkspacePort, getCurrentUserService)
+
+    given("workspaceId가 주어지고") {
+        val workspaceId = UUID.randomUUID().toString()
+
+        `when`("해당 id를 가진 workspace가 있을때") {
+            val user =
+                User(email = "email", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
+            val workspace = Workspace(
+                id = workspaceId,
+                title = "workspace",
+                description = "test workspace",
+                owner = user
+            )
+
+            every { getCurrentUserService.getCurrentUser() } returns user
+            every { queryWorkspacePort.findById(workspaceId) } returns workspace
+
+            deleteWorkspaceUseCase.execute(workspaceId)
+            then("delete 메서드를 호출해야함") {
+                verify { commandWorkspacePort.delete(workspace) }
+            }
+        }
+
+    }
+})

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteWorkspaceUseCaseTest.kt
@@ -43,5 +43,15 @@ class DeleteWorkspaceUseCaseTest : BehaviorSpec({
             }
         }
 
+        `when`("해당 id를 가진 workspace가 없을때") {
+            every { queryWorkspacePort.findById(workspaceId) } returns null
+
+            then("WorkspaceNotFoundException이 발생해야함") {
+                shouldThrow<WorkspaceNotFoundException> {
+                    deleteWorkspaceUseCase.execute(workspaceId)
+                }
+            }
+        }
+
     }
 })

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteWorkspaceUseCaseTest.kt
@@ -53,5 +53,29 @@ class DeleteWorkspaceUseCaseTest : BehaviorSpec({
             }
         }
 
+        `when`("요청한 유저가 workspace의 주인이 아닐때") {
+            val owner =
+                User(email = "owner", password = "password", name = "owner", roles = mutableListOf(Role.ROLE_USER))
+            val workspace = Workspace(
+                id = workspaceId,
+                title = "workspace",
+                description = "test workspace",
+                owner = owner
+            )
+            val user =
+                User(email = "user", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
+
+
+            every { getCurrentUserService.getCurrentUser() } returns user
+            every { queryWorkspacePort.findById(workspaceId) } returns workspace
+
+
+            then("에러가 발생해야함") {
+                shouldThrow<WorkspaceOwnerNotSameException> {
+                    deleteWorkspaceUseCase.execute(workspaceId)
+                }
+            }
+        }
+
     }
 })

--- a/src/test/kotlin/com/dcd/server/presentation/domain/workspace/WorkspaceWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/workspace/WorkspaceWebAdapterTest.kt
@@ -22,7 +22,7 @@ class WorkspaceWebAdapterTest : BehaviorSpec({
     val createWorkspaceUseCase = mockk<CreateWorkspaceUseCase>(relaxUnitFun = true)
     val getAllWorkspaceUseCase = mockk<GetAllWorkspaceUseCase>()
     val getWorkspaceUseCase = mockk<GetWorkspaceUseCase>()
-    val deleteWorkspaceUseCase = mockk<DeleteWorkspaceUseCase>()
+    val deleteWorkspaceUseCase = mockk<DeleteWorkspaceUseCase>(relaxUnitFun = true)
     val workspaceWebAdapter = WorkspaceWebAdapter(createWorkspaceUseCase, getAllWorkspaceUseCase, getWorkspaceUseCase, deleteWorkspaceUseCase)
 
     given("CreateWorkspaceRequest가 주어지고") {
@@ -68,6 +68,15 @@ class WorkspaceWebAdapterTest : BehaviorSpec({
                 result.statusCode shouldBe HttpStatus.OK
                 result.body!! shouldBe workspaceResDto.toResponse()
             }
+        }
+    }
+
+    given("workspaceId가 주어지고") {
+        val workspaceId = UUID.randomUUID().toString()
+        val result = workspaceWebAdapter.deleteWorkspace(workspaceId)
+        then("200 코드가 반환되고 deleteWorkspaceUseCase를 실행해야함") {
+            result.statusCode shouldBe HttpStatus.OK
+            verify { deleteWorkspaceUseCase.execute(workspaceId) }
         }
     }
 })


### PR DESCRIPTION
💡 개요
* 워크스페이스 삭제 API에 관한 테스트 코드 작성

📃 작업내용
* usecase 테스트 코드
  * 해당 id를 가진 워크스페이스가 있을때
  * 해당 id를 가진 워크스페이스가 없을때
  * owner가 일치하지 않을때
* WebAdapter 테스트 코드

🔀 변경사항
* workspace의 owner를 검사하는 부분에 WorkspaceOwnerNotSameException 적용