### PR TITLE
🔀 :: 95 - 워크스페이스의 주인이 아닐때 애플리케이션을 수정하거나 생성할 수 없어야함

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/AddApplicationEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/AddApplicationEnvUseCase.kt
@@ -5,15 +5,20 @@ import com.dcd.server.core.domain.application.dto.request.AddApplicationEnvReqDt
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import com.dcd.server.core.domain.user.service.GetCurrentUserService
+import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 
 @UseCase
 class AddApplicationEnvUseCase(
     private val queryApplicationPort: QueryApplicationPort,
     private val commandApplicationPort: CommandApplicationPort,
+    private val getCurrentUserService: GetCurrentUserService,
+    private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService
 ) {
     fun execute(id: String, addApplicationEnvReqDto: AddApplicationEnvReqDto) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
+        validateWorkspaceOwnerService.validateOwner(getCurrentUserService.getCurrentUser(), application.workspace)
         val envMutable = application.env.toMutableMap()
         addApplicationEnvReqDto.envList.forEach {
             envMutable[it.key] = it.value

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/AddApplicationEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/AddApplicationEnvUseCase.kt
@@ -5,20 +5,18 @@ import com.dcd.server.core.domain.application.dto.request.AddApplicationEnvReqDt
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
-import com.dcd.server.core.domain.user.service.GetCurrentUserService
 import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 
 @UseCase
 class AddApplicationEnvUseCase(
     private val queryApplicationPort: QueryApplicationPort,
     private val commandApplicationPort: CommandApplicationPort,
-    private val getCurrentUserService: GetCurrentUserService,
     private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService
 ) {
     fun execute(id: String, addApplicationEnvReqDto: AddApplicationEnvReqDto) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
-        validateWorkspaceOwnerService.validateOwner(getCurrentUserService.getCurrentUser(), application.workspace)
+        validateWorkspaceOwnerService.validateOwner(application.workspace)
         val envMutable = application.env.toMutableMap()
         addApplicationEnvReqDto.envList.forEach {
             envMutable[it.key] = it.value

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/ApplicationRunUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/ApplicationRunUseCase.kt
@@ -1,14 +1,11 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.ReadOnlyUseCase
-import com.dcd.server.core.common.spi.CompareUserPort
 import com.dcd.server.core.domain.application.dto.request.RunApplicationReqDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.*
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
-import com.dcd.server.core.domain.user.service.GetCurrentUserService
-import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameException
 import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 
 @ReadOnlyUseCase
@@ -18,14 +15,13 @@ class ApplicationRunUseCase(
     private val createDockerFileService: CreateDockerFileService,
     private val buildDockerImageService: BuildDockerImageService,
     private val dockerRunService: DockerRunService,
-    private val currentUserService: GetCurrentUserService,
     private val queryApplicationPort: QueryApplicationPort,
     private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService
 ) {
     fun execute(id: String, runApplicationReqDto: RunApplicationReqDto) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
-        validateWorkspaceOwnerService.validateOwner(currentUserService.getCurrentUser(), application.workspace)
+        validateWorkspaceOwnerService.validateOwner(application.workspace)
         cloneApplicationByUrlService.cloneByApplication(application)
         when(application.applicationType){
             ApplicationType.SPRING_BOOT -> {

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCase.kt
@@ -1,25 +1,26 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
-import com.dcd.server.core.common.service.SecurityService
 import com.dcd.server.core.domain.application.dto.extenstion.toEntity
 import com.dcd.server.core.domain.application.dto.request.CreateApplicationReqDto
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
-import com.dcd.server.core.domain.auth.exception.UserNotFoundException
-import com.dcd.server.core.domain.user.spi.QueryUserPort
+import com.dcd.server.core.domain.user.service.GetCurrentUserService
 import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
+import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
 
 @UseCase
 class CreateApplicationUseCase(
     private val commandApplicationPort: CommandApplicationPort,
-    private val securityService: SecurityService,
+    private val getCurrentUserService: GetCurrentUserService,
     private val queryWorkspacePort: QueryWorkspacePort,
-    private val queryUserPort: QueryUserPort
+    private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService
 ) {
     fun execute(workspaceId: String, createApplicationReqDto: CreateApplicationReqDto) {
         val workspace = queryWorkspacePort.findById(workspaceId)
             ?: throw WorkspaceNotFoundException()
+        val currentUser = getCurrentUserService.getCurrentUser()
+        validateWorkspaceOwnerService.validateOwner(currentUser, workspace)
         val application = createApplicationReqDto.toEntity(workspace)
         commandApplicationPort.save(application)
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCase.kt
@@ -4,7 +4,6 @@ import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.domain.application.dto.extenstion.toEntity
 import com.dcd.server.core.domain.application.dto.request.CreateApplicationReqDto
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
-import com.dcd.server.core.domain.user.service.GetCurrentUserService
 import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
 import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
@@ -12,15 +11,13 @@ import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
 @UseCase
 class CreateApplicationUseCase(
     private val commandApplicationPort: CommandApplicationPort,
-    private val getCurrentUserService: GetCurrentUserService,
     private val queryWorkspacePort: QueryWorkspacePort,
     private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService
 ) {
     fun execute(workspaceId: String, createApplicationReqDto: CreateApplicationReqDto) {
         val workspace = queryWorkspacePort.findById(workspaceId)
             ?: throw WorkspaceNotFoundException()
-        val currentUser = getCurrentUserService.getCurrentUser()
-        validateWorkspaceOwnerService.validateOwner(currentUser, workspace)
+        validateWorkspaceOwnerService.validateOwner(workspace)
         val application = createApplicationReqDto.toEntity(workspace)
         commandApplicationPort.save(application)
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationEnvUseCase.kt
@@ -5,20 +5,18 @@ import com.dcd.server.core.domain.application.exception.ApplicationEnvNotFoundEx
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
-import com.dcd.server.core.domain.user.service.GetCurrentUserService
 import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 
 @UseCase
 class DeleteApplicationEnvUseCase(
     private val queryApplicationPort: QueryApplicationPort,
     private val commandApplicationPort: CommandApplicationPort,
-    private val getCurrentUserService: GetCurrentUserService,
     private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService
 ) {
     fun execute(id: String, key: String) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
-        validateWorkspaceOwnerService.validateOwner(getCurrentUserService.getCurrentUser(), application.workspace)
+        validateWorkspaceOwnerService.validateOwner(application.workspace)
         val updatedEnv = application.env.toMutableMap()
         updatedEnv.remove(key)
             ?: throw ApplicationEnvNotFoundException()

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationEnvUseCase.kt
@@ -5,15 +5,20 @@ import com.dcd.server.core.domain.application.exception.ApplicationEnvNotFoundEx
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import com.dcd.server.core.domain.user.service.GetCurrentUserService
+import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 
 @UseCase
 class DeleteApplicationEnvUseCase(
     private val queryApplicationPort: QueryApplicationPort,
-    private val commandApplicationPort: CommandApplicationPort
+    private val commandApplicationPort: CommandApplicationPort,
+    private val getCurrentUserService: GetCurrentUserService,
+    private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService
 ) {
     fun execute(id: String, key: String) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
+        validateWorkspaceOwnerService.validateOwner(getCurrentUserService.getCurrentUser(), application.workspace)
         val updatedEnv = application.env.toMutableMap()
         updatedEnv.remove(key)
             ?: throw ApplicationEnvNotFoundException()

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationUseCase.kt
@@ -5,19 +5,20 @@ import com.dcd.server.core.domain.application.exception.ApplicationNotFoundExcep
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.user.service.GetCurrentUserService
+import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 
 @UseCase
 class DeleteApplicationUseCase(
     private val getCurrentUserService: GetCurrentUserService,
     private val commandApplicationPort: CommandApplicationPort,
-    private val queryApplicationPort: QueryApplicationPort
+    private val queryApplicationPort: QueryApplicationPort,
+    private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService
 ) {
     fun execute(id: String) {
         val user = getCurrentUserService.getCurrentUser()
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
-        if (!application.workspace.owner.equals(user))
-            throw RuntimeException()
+        validateWorkspaceOwnerService.validateOwner(user, application.workspace)
         commandApplicationPort.delete(application)
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCase.kt
@@ -1,7 +1,6 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.ReadOnlyUseCase
-import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.domain.application.dto.extenstion.toDto
 import com.dcd.server.core.domain.application.dto.response.ApplicationListResponseDto
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCase.kt
@@ -1,7 +1,6 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.ReadOnlyUseCase
-import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.domain.application.dto.extenstion.toDto
 import com.dcd.server.core.domain.application.dto.response.ApplicationResponseDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCase.kt
@@ -5,16 +5,21 @@ import com.dcd.server.core.domain.application.exception.ApplicationNotFoundExcep
 import com.dcd.server.core.domain.application.service.DeleteApplicationDirectoryService
 import com.dcd.server.core.domain.application.service.DeleteContainerService
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import com.dcd.server.core.domain.user.service.GetCurrentUserService
+import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 
 @ReadOnlyUseCase
 class StopApplicationUseCase(
     private val queryApplicationPort: QueryApplicationPort,
     private val deleteContainerService: DeleteContainerService,
-    private val deleteApplicationDirectoryService: DeleteApplicationDirectoryService
+    private val deleteApplicationDirectoryService: DeleteApplicationDirectoryService,
+    private val getCurrentUserService: GetCurrentUserService,
+    private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService
 ) {
     fun execute(id: String) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
+        validateWorkspaceOwnerService.validateOwner(getCurrentUserService.getCurrentUser(), application.workspace)
         deleteContainerService.deleteContainer(application)
         deleteApplicationDirectoryService.deleteApplicationDirectory(application)
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCase.kt
@@ -13,13 +13,12 @@ class StopApplicationUseCase(
     private val queryApplicationPort: QueryApplicationPort,
     private val deleteContainerService: DeleteContainerService,
     private val deleteApplicationDirectoryService: DeleteApplicationDirectoryService,
-    private val getCurrentUserService: GetCurrentUserService,
     private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService
 ) {
     fun execute(id: String) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
-        validateWorkspaceOwnerService.validateOwner(getCurrentUserService.getCurrentUser(), application.workspace)
+        validateWorkspaceOwnerService.validateOwner(application.workspace)
         deleteContainerService.deleteContainer(application)
         deleteApplicationDirectoryService.deleteApplicationDirectory(application)
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/service/ValidateWorkspaceOwnerService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/service/ValidateWorkspaceOwnerService.kt
@@ -5,4 +5,6 @@ import com.dcd.server.core.domain.workspace.model.Workspace
 
 interface ValidateWorkspaceOwnerService {
     fun validateOwner(user: User, workspace: Workspace)
+
+    fun validateOwner(workspace: Workspace)
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/service/ValidateWorkspaceOwnerService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/service/ValidateWorkspaceOwnerService.kt
@@ -1,0 +1,8 @@
+package com.dcd.server.core.domain.workspace.service
+
+import com.dcd.server.core.domain.user.model.User
+import com.dcd.server.core.domain.workspace.model.Workspace
+
+interface ValidateWorkspaceOwnerService {
+    fun validateOwner(user: User, workspace: Workspace)
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/service/impl/ValidateWorkspaceOwnerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/service/impl/ValidateWorkspaceOwnerServiceImpl.kt
@@ -1,0 +1,15 @@
+package com.dcd.server.core.domain.workspace.service.impl
+
+import com.dcd.server.core.domain.user.model.User
+import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameException
+import com.dcd.server.core.domain.workspace.model.Workspace
+import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
+import org.springframework.stereotype.Service
+
+@Service
+class ValidateWorkspaceOwnerServiceImpl : ValidateWorkspaceOwnerService{
+    override fun validateOwner(user: User, workspace: Workspace) {
+        if (user.equals(workspace.owner).not())
+            throw WorkspaceOwnerNotSameException()
+    }
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/service/impl/ValidateWorkspaceOwnerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/service/impl/ValidateWorkspaceOwnerServiceImpl.kt
@@ -1,14 +1,23 @@
 package com.dcd.server.core.domain.workspace.service.impl
 
 import com.dcd.server.core.domain.user.model.User
+import com.dcd.server.core.domain.user.service.GetCurrentUserService
 import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameException
 import com.dcd.server.core.domain.workspace.model.Workspace
 import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 import org.springframework.stereotype.Service
 
 @Service
-class ValidateWorkspaceOwnerServiceImpl : ValidateWorkspaceOwnerService{
+class ValidateWorkspaceOwnerServiceImpl(
+    private val getCurrentUserService: GetCurrentUserService
+) : ValidateWorkspaceOwnerService{
     override fun validateOwner(user: User, workspace: Workspace) {
+        if (user.equals(workspace.owner).not())
+            throw WorkspaceOwnerNotSameException()
+    }
+
+    override fun validateOwner(workspace: Workspace) {
+        val user = getCurrentUserService.getCurrentUser()
         if (user.equals(workspace.owner).not())
             throw WorkspaceOwnerNotSameException()
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteWorkspaceUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteWorkspaceUseCase.kt
@@ -4,6 +4,7 @@ import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.domain.user.service.GetCurrentUserService
 import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
 import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameException
+import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 import com.dcd.server.core.domain.workspace.spi.CommandWorkspacePort
 import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
 
@@ -11,14 +12,14 @@ import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
 class DeleteWorkspaceUseCase(
     private val commandWorkspacePort: CommandWorkspacePort,
     private val queryWorkspacePort: QueryWorkspacePort,
-    private val getCurrentUserService: GetCurrentUserService
+    private val getCurrentUserService: GetCurrentUserService,
+    private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService
 ) {
     fun execute(workspaceId: String) {
         val workspace = (queryWorkspacePort.findById(workspaceId)
             ?: throw WorkspaceNotFoundException())
         val currentUser = getCurrentUserService.getCurrentUser()
-        if (currentUser.equals(workspace.owner).not())
-            throw WorkspaceOwnerNotSameException()
+        validateWorkspaceOwnerService.validateOwner(currentUser, workspace)
         commandWorkspacePort.delete(workspace)
     }
 }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/AddApplicationEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/AddApplicationEnvUseCaseTest.kt
@@ -9,6 +9,7 @@ import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.auth.model.Role
 import com.dcd.server.core.domain.user.model.User
 import com.dcd.server.core.domain.workspace.model.Workspace
+import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.every
@@ -19,7 +20,8 @@ import java.util.*
 class AddApplicationEnvUseCaseTest : BehaviorSpec({
     val queryApplicationPort = mockk<QueryApplicationPort>()
     val commandApplicationPort = mockk<CommandApplicationPort>()
-    val addApplicationEnvUseCase = AddApplicationEnvUseCase(queryApplicationPort, commandApplicationPort)
+    val validateWorkspaceOwnerService = mockk<ValidateWorkspaceOwnerService>(relaxUnitFun = true)
+    val addApplicationEnvUseCase = AddApplicationEnvUseCase(queryApplicationPort, commandApplicationPort, validateWorkspaceOwnerService)
 
     given("request가 주어지고") {
         val request = AddApplicationEnvReqDto(

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
@@ -9,6 +9,7 @@ import com.dcd.server.core.domain.auth.model.Role
 import com.dcd.server.core.domain.user.model.User
 import com.dcd.server.core.domain.user.spi.QueryUserPort
 import com.dcd.server.core.domain.workspace.model.Workspace
+import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
@@ -22,7 +23,8 @@ class CreateApplicationUseCaseTest : BehaviorSpec({
     val queryUserPort = mockk<QueryUserPort>()
     val securityService = mockk<SecurityService>()
     val queryWorkspacePort = mockk<QueryWorkspacePort>()
-    val createApplicationUseCase = CreateApplicationUseCase(commandApplicationPort, securityService, queryWorkspacePort, queryUserPort)
+    val validateWorkspaceOwnerService = mockk<ValidateWorkspaceOwnerService>(relaxUnitFun = true)
+    val createApplicationUseCase = CreateApplicationUseCase(commandApplicationPort, queryWorkspacePort, validateWorkspaceOwnerService)
 
     given("CreateApplicationReqDto와 유저가 주어지고") {
         val request = CreateApplicationReqDto(

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationEnvUseCaseTest.kt
@@ -9,6 +9,7 @@ import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.auth.model.Role
 import com.dcd.server.core.domain.user.model.User
 import com.dcd.server.core.domain.workspace.model.Workspace
+import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.every
@@ -19,7 +20,8 @@ import java.util.*
 class DeleteApplicationEnvUseCaseTest : BehaviorSpec({
     val queryApplicationPort = mockk<QueryApplicationPort>()
     val commandApplicationPort = mockk<CommandApplicationPort>()
-    val deleteApplicationEnvUseCase = DeleteApplicationEnvUseCase(queryApplicationPort, commandApplicationPort)
+    val validateWorkspaceOwnerService = mockk<ValidateWorkspaceOwnerService>(relaxUnitFun = true)
+    val deleteApplicationEnvUseCase = DeleteApplicationEnvUseCase(queryApplicationPort, commandApplicationPort, validateWorkspaceOwnerService)
 
     given("애플리케이션 Id와 삭제할 key가 주어지고") {
         val applicationId = "testId"

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationUseCaseTest.kt
@@ -9,6 +9,7 @@ import com.dcd.server.core.domain.auth.model.Role
 import com.dcd.server.core.domain.user.model.User
 import com.dcd.server.core.domain.user.service.GetCurrentUserService
 import com.dcd.server.core.domain.workspace.model.Workspace
+import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.every
@@ -21,8 +22,9 @@ class DeleteApplicationUseCaseTest : BehaviorSpec({
     val getCurrentUserService = mockk<GetCurrentUserService>()
     val commandApplicationPort = mockk<CommandApplicationPort>()
     val queryApplicationPort = mockk<QueryApplicationPort>()
+    val validateWorkspaceOwnerService = mockk<ValidateWorkspaceOwnerService>(relaxUnitFun = true)
     val deleteApplicationUseCase =
-        DeleteApplicationUseCase(getCurrentUserService, commandApplicationPort, queryApplicationPort)
+        DeleteApplicationUseCase(getCurrentUserService, commandApplicationPort, queryApplicationPort, validateWorkspaceOwnerService)
     given("애플리케이션 id가 주어지고") {
         val applicationId = "testId"
         val user =

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
@@ -9,6 +9,7 @@ import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.auth.model.Role
 import com.dcd.server.core.domain.user.model.User
 import com.dcd.server.core.domain.workspace.model.Workspace
+import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.every
@@ -20,8 +21,9 @@ class StopApplicationUseCaseTest : BehaviorSpec({
     val queryApplicationPort = mockk<QueryApplicationPort>()
     val deleteContainerService = mockk<DeleteContainerService>()
     val deleteApplicationDirectoryService = mockk<DeleteApplicationDirectoryService>()
+    val validateWorkspaceOwnerService = mockk<ValidateWorkspaceOwnerService>(relaxUnitFun = true)
     val stopApplicationUseCase =
-        StopApplicationUseCase(queryApplicationPort, deleteContainerService, deleteApplicationDirectoryService)
+        StopApplicationUseCase(queryApplicationPort, deleteContainerService, deleteApplicationDirectoryService, validateWorkspaceOwnerService)
 
     given("애플리케이션 Id가 주어지고") {
         val applicationId = "testApplicationId"

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/service/ValidateWorkspaceOwnerServiceTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/service/ValidateWorkspaceOwnerServiceTest.kt
@@ -1,0 +1,44 @@
+package com.dcd.server.core.domain.workspace.service
+
+import com.dcd.server.core.domain.auth.model.Role
+import com.dcd.server.core.domain.user.model.User
+import com.dcd.server.core.domain.user.service.GetCurrentUserService
+import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameException
+import com.dcd.server.core.domain.workspace.model.Workspace
+import com.dcd.server.core.domain.workspace.service.impl.ValidateWorkspaceOwnerServiceImpl
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import java.util.*
+
+class ValidateWorkspaceOwnerServiceTest : BehaviorSpec({
+    val getCurrentUserService = mockk<GetCurrentUserService>()
+    val service = ValidateWorkspaceOwnerServiceImpl(getCurrentUserService)
+
+    given("user와 workspace가 주어지고") {
+        val user =
+            User(email = "email", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
+        val workspace = Workspace(
+            id = UUID.randomUUID().toString(),
+            title = "workspace",
+            description = "test workspace",
+            owner = user
+        )
+        `when`("현재 인증된 유저가 workspace의 주인일때") {
+            val result = service.validateOwner(user, workspace)
+            then("결과값은 Unit이여야됨") {
+                result shouldBe Unit
+            }
+        }
+        `when`("현재 인증된 유저가 workspace의 주인이 아닐때") {
+            val another =
+                User(email = "another", password = "password", name = "another user", roles = mutableListOf(Role.ROLE_USER))
+            then("WorkspaceOwnerNotSameException이 발생해야함") {
+                shouldThrow<WorkspaceOwnerNotSameException> {
+                    service.validateOwner(another, workspace)
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteWorkspaceUseCaseTest.kt
@@ -6,6 +6,7 @@ import com.dcd.server.core.domain.user.service.GetCurrentUserService
 import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
 import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameException
 import com.dcd.server.core.domain.workspace.model.Workspace
+import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 import com.dcd.server.core.domain.workspace.spi.CommandWorkspacePort
 import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
 import io.kotest.assertions.throwables.shouldThrow
@@ -19,7 +20,8 @@ class DeleteWorkspaceUseCaseTest : BehaviorSpec({
     val commandWorkspacePort = mockk<CommandWorkspacePort>(relaxUnitFun = true)
     val queryWorkspacePort = mockk<QueryWorkspacePort>()
     val getCurrentUserService = mockk<GetCurrentUserService>()
-    val deleteWorkspaceUseCase = DeleteWorkspaceUseCase(commandWorkspacePort, queryWorkspacePort, getCurrentUserService)
+    val validateWorkspaceOwnerService = mockk<ValidateWorkspaceOwnerService>(relaxUnitFun = true)
+    val deleteWorkspaceUseCase = DeleteWorkspaceUseCase(commandWorkspacePort, queryWorkspacePort, getCurrentUserService, validateWorkspaceOwnerService)
 
     given("workspaceId가 주어지고") {
         val workspaceId = UUID.randomUUID().toString()
@@ -48,30 +50,6 @@ class DeleteWorkspaceUseCaseTest : BehaviorSpec({
 
             then("WorkspaceNotFoundException이 발생해야함") {
                 shouldThrow<WorkspaceNotFoundException> {
-                    deleteWorkspaceUseCase.execute(workspaceId)
-                }
-            }
-        }
-
-        `when`("요청한 유저가 workspace의 주인이 아닐때") {
-            val owner =
-                User(email = "owner", password = "password", name = "owner", roles = mutableListOf(Role.ROLE_USER))
-            val workspace = Workspace(
-                id = workspaceId,
-                title = "workspace",
-                description = "test workspace",
-                owner = owner
-            )
-            val user =
-                User(email = "user", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
-
-
-            every { getCurrentUserService.getCurrentUser() } returns user
-            every { queryWorkspacePort.findById(workspaceId) } returns workspace
-
-
-            then("에러가 발생해야함") {
-                shouldThrow<WorkspaceOwnerNotSameException> {
                     deleteWorkspaceUseCase.execute(workspaceId)
                 }
             }


### PR DESCRIPTION
💡 개요
* 워크스페이스의 주인이 아닐때 애플리케이션을 수정하거나 생성할 수 없어야함

📃 작업내용
* ValidateWorkspaceOwnerService 추가
* Application 모듈의 UseCase에서 ValidateWorkspaceOwnerService를 사용하도록 변경
* ValidateWorkspaceOwnerService에 user를 파라미터로 받지 않는 메서드 추가
* ValidateWorkspaceOwnerService 테스트 코드 작성

🔀 변경사항
* DeleteWorkspaceUseCase에서 ValidateWorkspaceOwnerService를 사용하도록 변경
* application 모듈의 UseCase 테스트 코드 수정