### PR TITLE
🔀 :: 99 - 애플리케이션 env 리펙토링

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/request/RunApplicationReqDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/request/RunApplicationReqDto.kt
@@ -2,6 +2,5 @@ package com.dcd.server.core.domain.application.dto.request
 
 
 class RunApplicationReqDto(
-    val langVersion: Int,
-    val env: Map<String, String>
+    val langVersion: Int
 )

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/DockerRunService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/DockerRunService.kt
@@ -4,7 +4,7 @@ import com.dcd.server.core.domain.application.model.Application
 
 interface DockerRunService {
     fun runApplication(id: String)
+
     fun runApplication(application: Application)
 
-    fun runApplication(application: Application, env: Map<String, String>)
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DockerRunServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DockerRunServiceImpl.kt
@@ -26,20 +26,12 @@ class DockerRunServiceImpl(
     }
 
     override fun runApplication(application: Application) {
-        var externalPort = application.port
-        while (existsPortService.existsPort(externalPort)) {
-            externalPort += 1
-        }
-        commandPort.executeShellCommand("cd ${application.name} && docker run --network ${application.workspace.title.replace(' ', '_')} --name ${application.name.lowercase()} -d ${application.name.lowercase()} -p ${externalPort}:${application.port}")
-    }
-
-    override fun runApplication(application: Application, env: Map<String, String>) {
         val envString = StringBuilder()
         var externalPort = application.port
         while (existsPortService.existsPort(externalPort)) {
             externalPort += 1
         }
-        env.forEach {
+        application.env.forEach {
             envString.append("-e ${it.key}=${it.value}")
         }
         commandPort.executeShellCommand("cd ${application.name} && docker run $envString --network ${application.workspace.title.replace(' ', '_')} --name ${application.name.lowercase()} -d ${application.name.lowercase()} -p ${externalPort}:${application.port}")

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/ApplicationRunUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/ApplicationRunUseCase.kt
@@ -29,7 +29,7 @@ class ApplicationRunUseCase(
                 val version = runApplicationReqDto.langVersion
                 createDockerFileService.createFileToApplication(application, version)
                 buildDockerImageService.buildImageByApplication(application)
-                dockerRunService.runApplication(application, runApplicationReqDto.env)
+                dockerRunService.runApplication(application)
             }
         }
     }

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/CreateApplicationDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/CreateApplicationDataExtension.kt
@@ -17,6 +17,5 @@ fun CreateApplicationRequest.toDto(): CreateApplicationReqDto =
 
 fun RunApplicationRequest.toDto(): RunApplicationReqDto =
     RunApplicationReqDto(
-        langVersion = this.langVersion,
-        env = this.env
+        langVersion = this.langVersion
     )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/request/RunApplicationRequest.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/request/RunApplicationRequest.kt
@@ -1,6 +1,5 @@
 package com.dcd.server.presentation.domain.application.data.request
 
 open class RunApplicationRequest(
-    val langVersion: Int,
-    val env: Map<String, String>
+    val langVersion: Int
 )

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -46,7 +46,7 @@ class ApplicationWebAdapterTest : BehaviorSpec({
 
     given("RunApplicationRequest가 주어지고") {
         val id = "testApplicationId"
-        val request = RunApplicationRequest(langVersion = 11, env = mapOf())
+        val request = RunApplicationRequest(langVersion = 11)
         `when`("runApplication 메서드를 실행할때") {
             every { springApplicationRunUseCase.execute(id, any()) } returns Unit
             val result = applicationWebAdapter.runApplication(id, request)


### PR DESCRIPTION
💡 개요
* 애플리케이션 env 리펙토링
  * RunApplicationRequest에 있는 env 필드를 제거

📃 작업내용
* RunApplicationRequest, RunApplicationReqDto에 있는 env필드 제거
* DockerRunService에서 env를 파라미터로 받는 메서드 삭제

🔀 변경사항
* ApplicationWebAdapterTest 수정

🎸 기타
* ApplicationRunUseCase 테스트 코드가 없음