### PR TITLE
🔀 :: 111 - 워크스페이스 수정 API 테스트 코드

### DIFF
--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/UpdateWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/UpdateWorkspaceUseCaseTest.kt
@@ -11,7 +11,9 @@ import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.every
+import io.mockk.impl.annotations.SpyK
 import io.mockk.mockk
+import io.mockk.spyk
 import io.mockk.verify
 import java.util.*
 
@@ -28,11 +30,13 @@ class UpdateWorkspaceUseCaseTest : BehaviorSpec({
         `when`("해당 아이디를 가진 워크스페이스가 있을때") {
             val user =
                 User(email = "email", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
-            val workspace = Workspace(
-                id = workspaceId,
-                title = "workspace",
-                description = "test workspace",
-                owner = user
+            val workspace = spyk(
+                Workspace(
+                    id = workspaceId,
+                    title = "workspace",
+                    description = "test workspace",
+                    owner = user
+                )
             )
 
             every { queryWorkspacePort.findById(workspaceId) } returns workspace
@@ -40,6 +44,7 @@ class UpdateWorkspaceUseCaseTest : BehaviorSpec({
 
             updateWorkspaceUseCase.execute(workspaceId, reqDto)
             then("commandWorkspacePort의 save 메서드가 실행되어야함") {
+                verify { workspace.copy(title = reqDto.title, description = reqDto.description) }
                 verify { commandWorkspacePort.save(any() as Workspace) }
             }
         }

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/UpdateWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/UpdateWorkspaceUseCaseTest.kt
@@ -1,0 +1,44 @@
+package com.dcd.server.core.domain.workspace.usecase
+
+import com.dcd.server.core.domain.auth.model.Role
+import com.dcd.server.core.domain.user.model.User
+import com.dcd.server.core.domain.user.service.GetCurrentUserService
+import com.dcd.server.core.domain.workspace.dto.request.UpdateWorkspaceReqDto
+import com.dcd.server.core.domain.workspace.model.Workspace
+import com.dcd.server.core.domain.workspace.spi.CommandWorkspacePort
+import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.*
+
+class UpdateWorkspaceUseCaseTest : BehaviorSpec({
+    val commandWorkspacePort = mockk<CommandWorkspacePort>(relaxUnitFun = true)
+    val queryWorkspacePort = mockk<QueryWorkspacePort>(relaxUnitFun = true)
+    val getCurrentUserService = mockk<GetCurrentUserService>(relaxUnitFun = true)
+    val updateWorkspaceUseCase = UpdateWorkspaceUseCase(commandWorkspacePort, queryWorkspacePort, getCurrentUserService)
+
+    given("워크스페이스 아이디가 주어지고") {
+        val workspaceId = UUID.randomUUID().toString()
+
+        `when`("해당 아이디를 가진 워크스페이스가 있을때") {
+            val user =
+                User(email = "email", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
+            val workspace = Workspace(
+                id = workspaceId,
+                title = "workspace",
+                description = "test workspace",
+                owner = user
+            )
+
+            every { queryWorkspacePort.findById(workspaceId) } returns workspace
+            every { getCurrentUserService.getCurrentUser() } returns user
+
+            updateWorkspaceUseCase.execute(workspaceId, UpdateWorkspaceReqDto(title = "test title", description = "test description"))
+            then("commandWorkspacePort의 save 메서드가 실행되어야함") {
+                verify { commandWorkspacePort.save(any() as Workspace) }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/dcd/server/presentation/domain/workspace/WorkspaceWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/workspace/WorkspaceWebAdapterTest.kt
@@ -2,11 +2,13 @@ package com.dcd.server.presentation.domain.workspace
 
 import com.dcd.server.core.domain.user.dto.response.UserResDto
 import com.dcd.server.core.domain.workspace.dto.request.CreateWorkspaceReqDto
+import com.dcd.server.core.domain.workspace.dto.request.UpdateWorkspaceReqDto
 import com.dcd.server.core.domain.workspace.dto.response.WorkspaceListResDto
 import com.dcd.server.core.domain.workspace.dto.response.WorkspaceResDto
 import com.dcd.server.core.domain.workspace.usecase.*
 import com.dcd.server.presentation.domain.workspace.data.exetension.toResponse
 import com.dcd.server.presentation.domain.workspace.data.request.CreateWorkspaceRequest
+import com.dcd.server.presentation.domain.workspace.data.request.UpdateWorkspaceRequest
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -71,10 +73,26 @@ class WorkspaceWebAdapterTest : BehaviorSpec({
 
     given("workspaceId가 주어지고") {
         val workspaceId = UUID.randomUUID().toString()
-        val result = workspaceWebAdapter.deleteWorkspace(workspaceId)
-        then("200 코드가 반환되고 deleteWorkspaceUseCase를 실행해야함") {
-            result.statusCode shouldBe HttpStatus.OK
-            verify { deleteWorkspaceUseCase.execute(workspaceId) }
+
+        `when`("deleteWorkspace 메서드를 실행했을때") {
+            val result = workspaceWebAdapter.deleteWorkspace(workspaceId)
+
+            then("200 코드가 반환되고 deleteWorkspaceUseCase를 실행해야함") {
+                result.statusCode shouldBe HttpStatus.OK
+                verify { deleteWorkspaceUseCase.execute(workspaceId) }
+            }
+        }
+
+        `when`("updateWorkspace 메서드를 실행했을때") {
+            val updatedRequest =
+                UpdateWorkspaceRequest(title = "updated title", description = "test description")
+
+            val result = workspaceWebAdapter.updateWorkspace(workspaceId, updatedRequest)
+
+            then("200 코드가 반환되고, updateWorkspaceUseCase를 실행해야함") {
+                result.statusCode shouldBe HttpStatus.OK
+                verify { updateWorkspaceUseCase.execute(workspaceId, any() as UpdateWorkspaceReqDto) }
+            }
         }
     }
 })


### PR DESCRIPTION
## 🔖 개요
* 워크스페이스 수정 API 테스트 코드 작성

## 📜 작업내용
* UpdateWorkspaceUseCase 테스트 추가
  * 주어진 id를 가진 workspace가 있을때
  * 주어진 id를 가진 workspace가 없을때
  * workspace의 주인과 현재 로그인된 유저가 다를때
* WorkspaceWebAdapter에 updateWorkspace 메서드 테스트 추가