### PR TITLE
🔀 :: 128 - 로그인되지 않았을때 패스워드 변경 API

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/auth/dto/request/NonAuthChangePasswordReqDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/dto/request/NonAuthChangePasswordReqDto.kt
@@ -1,0 +1,6 @@
+package com.dcd.server.core.domain.auth.dto.request
+
+data class NonAuthChangePasswordReqDto(
+    val email: String,
+    val newPassword: String
+)

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/NonAuthChangePasswordUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/NonAuthChangePasswordUseCase.kt
@@ -1,0 +1,23 @@
+package com.dcd.server.core.domain.auth.usecase
+
+import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.domain.auth.dto.request.NonAuthChangePasswordReqDto
+import com.dcd.server.core.domain.user.service.GetCurrentUserService
+import com.dcd.server.core.domain.user.spi.CommandUserPort
+import org.springframework.security.crypto.password.PasswordEncoder
+
+@UseCase
+class NonAuthChangePasswordUseCase(
+    private val getCurrentUserService: GetCurrentUserService,
+    private val commandUserPort: CommandUserPort,
+    private val passwordEncoder: PasswordEncoder
+) {
+    fun execute(nonAuthChangePasswordReqDto: NonAuthChangePasswordReqDto) {
+        val user = getCurrentUserService.getCurrentUser()
+
+        val encodedPassword = passwordEncoder.encode(nonAuthChangePasswordReqDto.newPassword)
+        val updatedUser = user.copy(password = encodedPassword)
+
+        commandUserPort.save(updatedUser)
+    }
+}

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
@@ -47,6 +47,7 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.POST, "/auth").permitAll()
                 it.requestMatchers(HttpMethod.PATCH, "/auth").permitAll()
                 it.requestMatchers(HttpMethod.DELETE, "/auth").authenticated()
+                it.requestMatchers(HttpMethod.PATCH, "/auth/password").authenticated()
 
                 //application
                 it.requestMatchers(HttpMethod.POST, "/application/{workspaceId}").authenticated()

--- a/src/main/kotlin/com/dcd/server/presentation/domain/auth/AuthWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/auth/AuthWebAdapter.kt
@@ -4,10 +4,7 @@ import com.dcd.server.core.domain.auth.usecase.*
 import com.dcd.server.presentation.domain.auth.data.exetension.toDto
 import com.dcd.server.presentation.domain.auth.data.exetension.toReissueResponse
 import com.dcd.server.presentation.domain.auth.data.exetension.toResponse
-import com.dcd.server.presentation.domain.auth.data.request.CertificateMailRequest
-import com.dcd.server.presentation.domain.auth.data.request.EmailSendRequest
-import com.dcd.server.presentation.domain.auth.data.request.SignInRequest
-import com.dcd.server.presentation.domain.auth.data.request.SignUpRequest
+import com.dcd.server.presentation.domain.auth.data.request.*
 import com.dcd.server.presentation.domain.auth.data.response.ReissueTokenResponse
 import com.dcd.server.presentation.domain.auth.data.response.SignInResponse
 import org.springframework.http.HttpStatus
@@ -29,7 +26,8 @@ class AuthWebAdapter(
     private val authenticateMailUseCase: AuthenticateMailUseCase,
     private val signInUseCase: SignInUseCase,
     private val reissueTokenUseCase: ReissueTokenUseCase,
-    private val signOutUseCase: SignOutUseCase
+    private val signOutUseCase: SignOutUseCase,
+    private val nonAuthChangePasswordUseCase: NonAuthChangePasswordUseCase
 ) {
     @PostMapping("/email")
     fun sendAuthEmail(
@@ -75,5 +73,11 @@ class AuthWebAdapter(
     @DeleteMapping
     fun signOut(): ResponseEntity<Void>  =
         signOutUseCase.execute()
+            .run { ResponseEntity.ok().build() }
+
+    @PatchMapping("/password")
+    fun changePassword(@RequestBody nonAuthChangePasswordRequest: NonAuthChangePasswordRequest): ResponseEntity<Void> =
+        nonAuthChangePasswordUseCase
+            .execute(nonAuthChangePasswordRequest.toDto())
             .run { ResponseEntity.ok().build() }
 }

--- a/src/main/kotlin/com/dcd/server/presentation/domain/auth/data/exetension/AuthRequestDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/auth/data/exetension/AuthRequestDataExtension.kt
@@ -1,13 +1,7 @@
 package com.dcd.server.presentation.domain.auth.data.exetension
 
-import com.dcd.server.core.domain.auth.dto.request.CertificateMailReqDto
-import com.dcd.server.core.domain.auth.dto.request.EmailSendReqDto
-import com.dcd.server.core.domain.auth.dto.request.SignInReqDto
-import com.dcd.server.core.domain.auth.dto.request.SignUpReqDto
-import com.dcd.server.presentation.domain.auth.data.request.CertificateMailRequest
-import com.dcd.server.presentation.domain.auth.data.request.EmailSendRequest
-import com.dcd.server.presentation.domain.auth.data.request.SignInRequest
-import com.dcd.server.presentation.domain.auth.data.request.SignUpRequest
+import com.dcd.server.core.domain.auth.dto.request.*
+import com.dcd.server.presentation.domain.auth.data.request.*
 
 fun EmailSendRequest.toDto(): EmailSendReqDto =
     EmailSendReqDto(
@@ -31,4 +25,10 @@ fun SignUpRequest.toDto(): SignUpReqDto =
         email = this.email,
         password = this.password,
         name = this.name
+    )
+
+fun NonAuthChangePasswordRequest.toDto(): NonAuthChangePasswordReqDto =
+    NonAuthChangePasswordReqDto(
+        email = this.email,
+        newPassword = this.newPassword
     )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/auth/data/request/NonAuthChangePasswordRequest.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/auth/data/request/NonAuthChangePasswordRequest.kt
@@ -1,0 +1,6 @@
+package com.dcd.server.presentation.domain.auth.data.request
+
+data class NonAuthChangePasswordRequest(
+    val email: String,
+    val newPassword: String
+)

--- a/src/test/kotlin/com/dcd/server/presentation/domain/auth/AuthWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/auth/AuthWebAdapterTest.kt
@@ -24,13 +24,15 @@ class AuthWebAdapterTest : BehaviorSpec({
     val signInUseCase = mockk<SignInUseCase>()
     val reissueTokenUseCase = mockk<ReissueTokenUseCase>()
     val signOutUseCase = mockk<SignOutUseCase>()
+    val nonAuthChangePasswordUseCase = mockk<NonAuthChangePasswordUseCase>()
     val authWebAdapter = AuthWebAdapter(
         authMailSendUseCase,
         signUpUseCase,
         authenticateMailUseCase,
         signInUseCase,
         reissueTokenUseCase,
-        signOutUseCase
+        signOutUseCase,
+        nonAuthChangePasswordUseCase
     )
 
     given("EmailSendRequest가 주어지고") {


### PR DESCRIPTION
## 🔖 개요
* 로그인되어있지 않을때, 패스워드 변경 API 추가

## 📜 작업내용
* 패스워드 변경 요청 객체 추가
* 로그인되지 않은 유저가 패스워드를 변경할 수 있는 유스케이스 추가
* 로그인되지 않았을때 패스워드 변경 엔드포인트 추가
* 로그인되지 않았을때 패스워드 변경 엔드포인트에 권한 설정 추가
* AuthWebAdapterTest에 nonAuthChangePasswordUseCase 파라미터 추가

## 🔀 변경사항
* 기존에 패스워드 변경시에 이메일 검증 포인트컷을 로그인 되지않은 패스워드 변경 요청일때 적용되도록 변경
  * 로그인이 되어있을때 패스워드 변경 요청할때는 현재 패스워드가 현재 유저의 패스워드와 매칭되는지 검증으로 현재 유저가 요청하는지 검증할 수 있음