### PR TITLE
🔀 :: 130 - 패스워드 변경 API 테스트 코드

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/NonAuthChangePasswordUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/NonAuthChangePasswordUseCase.kt
@@ -2,18 +2,20 @@ package com.dcd.server.core.domain.auth.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.domain.auth.dto.request.NonAuthChangePasswordReqDto
-import com.dcd.server.core.domain.user.service.GetCurrentUserService
+import com.dcd.server.core.domain.auth.exception.UserNotFoundException
 import com.dcd.server.core.domain.user.spi.CommandUserPort
+import com.dcd.server.core.domain.user.spi.QueryUserPort
 import org.springframework.security.crypto.password.PasswordEncoder
 
 @UseCase
 class NonAuthChangePasswordUseCase(
-    private val getCurrentUserService: GetCurrentUserService,
+    private val queryUserPort: QueryUserPort,
     private val commandUserPort: CommandUserPort,
     private val passwordEncoder: PasswordEncoder
 ) {
     fun execute(nonAuthChangePasswordReqDto: NonAuthChangePasswordReqDto) {
-        val user = getCurrentUserService.getCurrentUser()
+        val user = queryUserPort.findByEmail(nonAuthChangePasswordReqDto.email)
+            ?: throw UserNotFoundException()
 
         val encodedPassword = passwordEncoder.encode(nonAuthChangePasswordReqDto.newPassword)
         val updatedUser = user.copy(password = encodedPassword)

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/NonAuthChangePasswordUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/NonAuthChangePasswordUseCaseTest.kt
@@ -1,0 +1,48 @@
+package com.dcd.server.core.domain.auth.usecase
+
+import com.dcd.server.core.domain.auth.dto.request.NonAuthChangePasswordReqDto
+import com.dcd.server.core.domain.auth.exception.UserNotFoundException
+import com.dcd.server.core.domain.auth.model.Role
+import com.dcd.server.core.domain.user.model.User
+import com.dcd.server.core.domain.user.spi.CommandUserPort
+import com.dcd.server.core.domain.user.spi.QueryUserPort
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.security.crypto.password.PasswordEncoder
+
+class NonAuthChangePasswordUseCaseTest : BehaviorSpec({
+    val queryUserPort = mockk<QueryUserPort>()
+    val commandUserPort = mockk<CommandUserPort>(relaxUnitFun = true)
+    val passwordEncoder = mockk<PasswordEncoder>()
+    val nonAuthChangePasswordUseCase = NonAuthChangePasswordUseCase(queryUserPort, commandUserPort, passwordEncoder)
+
+    given("유저와 NonAuthChangePasswordReqDto가 주어지고") {
+        val user =
+            User(email = "email", password = "existingPassword", name = "testName", roles = mutableListOf(Role.ROLE_USER))
+        val nonAuthChangePasswordReqDto = NonAuthChangePasswordReqDto(email = "email", newPassword = "newPassword")
+
+        `when`("유스케이스를 실행할때") {
+            every { queryUserPort.findByEmail(nonAuthChangePasswordReqDto.email) } returns user
+            every { passwordEncoder.encode(nonAuthChangePasswordReqDto.newPassword) } returns nonAuthChangePasswordReqDto.newPassword
+
+            nonAuthChangePasswordUseCase.execute(nonAuthChangePasswordReqDto)
+
+            then("NonAuthChangePasswordReqDto의 새 패스워드를 가진 유저를 저장해야함") {
+                verify { commandUserPort.save(user.copy(password = nonAuthChangePasswordReqDto.newPassword)) }
+            }
+        }
+
+        `when`("해당 이메일을 가진 유저가 존재하지 않을때") {
+            every { queryUserPort.findByEmail(nonAuthChangePasswordReqDto.email) } returns null
+
+            then("UserNotFoundException이 발생해야함") {
+                shouldThrow<UserNotFoundException> {
+                    nonAuthChangePasswordUseCase.execute(nonAuthChangePasswordReqDto)
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangePasswordUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangePasswordUseCaseTest.kt
@@ -1,0 +1,54 @@
+package com.dcd.server.core.domain.user.usecase
+
+import com.dcd.server.core.common.service.exception.PasswordNotCorrectException
+import com.dcd.server.core.domain.auth.model.Role
+import com.dcd.server.core.domain.user.dto.request.PasswordChangeReqDto
+import com.dcd.server.core.domain.user.model.User
+import com.dcd.server.core.domain.user.service.GetCurrentUserService
+import com.dcd.server.core.domain.user.spi.CommandUserPort
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.security.crypto.password.PasswordEncoder
+
+class ChangePasswordUseCaseTest : BehaviorSpec({
+    val getCurrentUserService = mockk<GetCurrentUserService>()
+    val commandUserPort = mockk<CommandUserPort>(relaxUnitFun = true)
+    val passwordEncoder = mockk<PasswordEncoder>()
+    val changePasswordUseCase = ChangePasswordUseCase(getCurrentUserService, commandUserPort, passwordEncoder)
+
+    given("User, PasswordChangeReqDto가 주어지고") {
+        val user =
+            User(email = "email", password = "existingPassword", name = "testName", roles = mutableListOf(Role.ROLE_USER))
+        val passwordChangeReqDto = PasswordChangeReqDto(
+            existingPassword = "existingPassword",
+            newPassword = "newPassword"
+        )
+
+        `when`("usecase를 실행할때") {
+            every { getCurrentUserService.getCurrentUser() } returns user
+            every { passwordEncoder.matches(passwordChangeReqDto.existingPassword, user.password) } returns true
+            every { passwordEncoder.encode(passwordChangeReqDto.newPassword) } returns passwordChangeReqDto.newPassword
+
+            changePasswordUseCase.execute(passwordChangeReqDto)
+            then("passwordChangeReqDto의 새 패스워드를 가진 유저를 저장해야함") {
+                verify {
+                    commandUserPort.save(user.copy(password = passwordChangeReqDto.newPassword))
+                }
+            }
+        }
+
+        `when`("password가 일치하지 않을때") {
+            every { getCurrentUserService.getCurrentUser() } returns user
+            every { passwordEncoder.matches(passwordChangeReqDto.existingPassword, user.password) } returns false
+
+            then("PasswordNotCorrectException이 발생해야함") {
+                shouldThrow<PasswordNotCorrectException> {
+                    changePasswordUseCase.execute(passwordChangeReqDto)
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/dcd/server/core/domain/user/usecase/GetUserProfileUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/user/usecase/GetUserProfileUseCaseTest.kt
@@ -1,4 +1,4 @@
-package com.dcd.server.core.domain.user
+package com.dcd.server.core.domain.user.usecase
 
 import com.dcd.server.core.domain.application.dto.extenstion.toProfileDto
 import com.dcd.server.core.domain.application.model.Application

--- a/src/test/kotlin/com/dcd/server/presentation/domain/auth/AuthWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/auth/AuthWebAdapterTest.kt
@@ -2,12 +2,11 @@ package com.dcd.server.presentation.domain.auth
 
 import com.dcd.server.core.domain.auth.dto.response.TokenResDto
 import com.dcd.server.core.domain.auth.usecase.*
+import com.dcd.server.presentation.domain.auth.data.exetension.toDto
 import com.dcd.server.presentation.domain.auth.data.exetension.toReissueResponse
 import com.dcd.server.presentation.domain.auth.data.exetension.toResponse
-import com.dcd.server.presentation.domain.auth.data.request.CertificateMailRequest
-import com.dcd.server.presentation.domain.auth.data.request.EmailSendRequest
-import com.dcd.server.presentation.domain.auth.data.request.SignInRequest
-import com.dcd.server.presentation.domain.auth.data.request.SignUpRequest
+import com.dcd.server.presentation.domain.auth.data.request.*
+import com.dcd.server.presentation.domain.user.data.request.PasswordChangeRequest
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -24,7 +23,7 @@ class AuthWebAdapterTest : BehaviorSpec({
     val signInUseCase = mockk<SignInUseCase>()
     val reissueTokenUseCase = mockk<ReissueTokenUseCase>()
     val signOutUseCase = mockk<SignOutUseCase>()
-    val nonAuthChangePasswordUseCase = mockk<NonAuthChangePasswordUseCase>()
+    val nonAuthChangePasswordUseCase = mockk<NonAuthChangePasswordUseCase>(relaxUnitFun = true)
     val authWebAdapter = AuthWebAdapter(
         authMailSendUseCase,
         signUpUseCase,
@@ -103,6 +102,18 @@ class AuthWebAdapterTest : BehaviorSpec({
             then("상태코드는 200이여야되고 ReissuTokenResponse가 바디에 들어있어야함") {
                 result.statusCode shouldBe HttpStatus.OK
                 result.body shouldBe responseDto.toReissueResponse()
+            }
+        }
+    }
+
+    given("PasswordChangeRequest가 주어지고") {
+        val nonAuthChangePasswordRequest = NonAuthChangePasswordRequest(email = "email", newPassword = "newPassword")
+
+        `when`("changePassword 메서드를 실행할때") {
+            val result = authWebAdapter.changePassword(nonAuthChangePasswordRequest)
+
+            then("상태코드는 200이여야함") {
+                result.statusCode shouldBe HttpStatus.OK
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/presentation/domain/user/UserWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/user/UserWebAdapterTest.kt
@@ -7,6 +7,7 @@ import com.dcd.server.core.domain.user.model.User
 import com.dcd.server.core.domain.user.usecase.ChangePasswordUseCase
 import com.dcd.server.core.domain.user.usecase.GetUserProfileUseCase
 import com.dcd.server.presentation.domain.user.data.exetension.toResponse
+import com.dcd.server.presentation.domain.user.data.request.PasswordChangeRequest
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -15,7 +16,7 @@ import org.springframework.http.HttpStatus
 
 class UserWebAdapterTest : BehaviorSpec({
     val getUserProfileUseCase = mockk<GetUserProfileUseCase>()
-    val changePasswordUseCase = mockk<ChangePasswordUseCase>()
+    val changePasswordUseCase = mockk<ChangePasswordUseCase>(relaxUnitFun = true)
 
     val userWebAdapter = UserWebAdapter(getUserProfileUseCase, changePasswordUseCase)
 
@@ -34,6 +35,20 @@ class UserWebAdapterTest : BehaviorSpec({
             }
             then("body값은 userProfileResDto를 담고있어야함") {
                 response.body!! shouldBe userProfileResDto.toResponse()
+            }
+        }
+    }
+
+    given("PasswordChangeRequest가 주어지고") {
+        val passwordChangeRequest =
+            PasswordChangeRequest(existingPassword = "existingPassword", newPassword = "newPassword")
+
+        `when`("changePassword 메서드를 실행할떼") {
+
+            val response = userWebAdapter.changePassword(passwordChangeRequest)
+
+            then("응답 코드는 200이여야함") {
+                response.statusCode shouldBe HttpStatus.OK
             }
         }
     }


### PR DESCRIPTION
## 🔖 개요
* 패스워드 변경 API에 관련된 테스트 코드 작성

## 📜 작업내용
* ChangePasswordUseCase 테스트 코드 추가
* UserWebAdapter에 패스워드 변경 메서드 테스트 추가
* NonAuthChangePasswordUseCase 테스트 코드 추가
* AuthWebAdapter에 패스워드 변경 메서드 테스트 추가

## 🔀 변경사항
* 로그인 되어있지 않은 패스워드 변경 유스케이스에서 로그인된 유저를 가져오는 부분 수정
* GetUserProfileUseCaseTest를 usecase 패키지 내부로 이동