### PR TITLE
🔀 :: 132 - [/auth/password] 엔드포인트 접근 권한 수정

### DIFF
--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
@@ -47,7 +47,7 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.POST, "/auth").permitAll()
                 it.requestMatchers(HttpMethod.PATCH, "/auth").permitAll()
                 it.requestMatchers(HttpMethod.DELETE, "/auth").authenticated()
-                it.requestMatchers(HttpMethod.PATCH, "/auth/password").authenticated()
+                it.requestMatchers(HttpMethod.PATCH, "/auth/password").permitAll()
 
                 //application
                 it.requestMatchers(HttpMethod.POST, "/application/{workspaceId}").authenticated()


### PR DESCRIPTION
## 🔖 개요
* [PATCH] /auth/password 엔드포인트의 접근 권한을 permitAll로 수정

## 📜 작업내용
*[PATCH] /auth/password 엔드포인트의 접근 권한을 permitAll로 수정