### PR TITLE
🔀 :: 136 - 애플리케이션 실행 커맨드 수정

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DockerRunServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DockerRunServiceImpl.kt
@@ -42,13 +42,10 @@ class DockerRunServiceImpl(
             }
 
             ApplicationType.MYSQL -> {
-                println("application.port = ${application.port}")
-                println("application.id = ${application.id}")
                 var externalPort = application.port
                 while (existsPortService.existsPort(externalPort)) {
                     externalPort += 1
                 }
-                println("externalPort = ${externalPort}")
                 commandPort.executeShellCommand(
                     "docker run --network ${application.workspace.title.replace(' ', '_')} " +
                             "-e MYSQL_ROOT_PASSWORD=${application.env["rootPassword"] ?: throw ApplicationEnvNotFoundException()} " +

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DockerRunServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DockerRunServiceImpl.kt
@@ -36,8 +36,8 @@ class DockerRunServiceImpl(
                 commandPort.executeShellCommand(
                     "cd ${application.name} " +
                             "&& docker run --network ${application.workspace.title.replace(' ', '_')} " +
-                            "--name ${application.name.lowercase()} -d ${application.name.lowercase()} " +
-                            "-p ${externalPort}:${application.port}"
+                            "--name ${application.name.lowercase()} -d " +
+                            "-p ${externalPort}:${application.port} ${application.name.lowercase()}"
                 )
             }
 

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/DockerRunServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/DockerRunServiceImplTest.kt
@@ -40,7 +40,7 @@ class DockerRunServiceImplTest : BehaviorSpec({
             service.runApplication(appId)
             then("commandPort가 실행되어야함") {
                 val externalPort = application.port
-                verify { commandPort.executeShellCommand("cd ${application.name} && docker run --network ${application.workspace.title.replace(' ', '_')} --name ${application.name.lowercase()} -d ${application.name.lowercase()} -p ${externalPort}:${application.port}") }
+                verify { commandPort.executeShellCommand("cd ${application.name} && docker run --network ${application.workspace.title.replace(' ', '_')} --name ${application.name.lowercase()} -d -p ${externalPort}:${application.port} ${application.name.lowercase()}") }
             }
         }
     }
@@ -60,7 +60,7 @@ class DockerRunServiceImplTest : BehaviorSpec({
 
             then("commandPort가 실행되어야함") {
                 val externalPort = application.port
-                verify { commandPort.executeShellCommand("cd ${application.name} && docker run --network ${application.workspace.title.replace(' ', '_')} --name ${application.name.lowercase()} -d ${application.name.lowercase()} -p ${externalPort}:${application.port}") }
+                verify { commandPort.executeShellCommand("cd ${application.name} && docker run --network ${application.workspace.title.replace(' ', '_')} --name ${application.name.lowercase()} -d -p ${externalPort}:${application.port} ${application.name.lowercase()}") }
             }
         }
     }


### PR DESCRIPTION
## 🔖 개요
* 스프링 애플리케이션 실행 커맨드에서 포트 바운드가 되지 않는 현상 수정

## 📜 작업내용
* spring 애플리케이션 실행 커맨드에서 포트 바운드가 적용되도록 수정
* 테스트할때 작성했던 print문 제거