### PR TITLE
🔀 :: 145 - 애플리케이션 수정 API 테스트 코드

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCase.kt
@@ -6,6 +6,7 @@ import com.dcd.server.core.domain.application.exception.ApplicationNotFoundExcep
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.user.service.GetCurrentUserService
+import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameException
 
 @UseCase
 class UpdateApplicationUseCase(
@@ -19,7 +20,7 @@ class UpdateApplicationUseCase(
         val owner = application.workspace.owner
 
         if (owner.equals(getCurrentUserService.getCurrentUser()).not())
-            throw RuntimeException()
+            throw WorkspaceOwnerNotSameException()
 
         val updatedApplication =
             application.copy(name = updateApplicationReqDto.name, description = updateApplicationReqDto.description)

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCaseTest.kt
@@ -59,5 +59,15 @@ class UpdateApplicationUseCaseTest : BehaviorSpec({
                 verify { commandApplicationPort.save(updatedApplication) }
             }
         }
+
+        `when`("로그인된 유저가 workspace 주인이 아닐때") {
+            every { getCurrentUserService.getCurrentUser() } returns user.copy(id = "another", name = "another", email = "another")
+
+            then("WorkspaceOwnerNotSameException이 발생해야함") {
+                shouldThrow<WorkspaceOwnerNotSameException> {
+                    updateApplicationUseCase.execute(applicationId, updateReqDto)
+                }
+            }
+        }
     }
 })

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCaseTest.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.domain.application.dto.request.UpdateApplicationReqDto
+import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
@@ -65,6 +66,19 @@ class UpdateApplicationUseCaseTest : BehaviorSpec({
 
             then("WorkspaceOwnerNotSameException이 발생해야함") {
                 shouldThrow<WorkspaceOwnerNotSameException> {
+                    updateApplicationUseCase.execute(applicationId, updateReqDto)
+                }
+            }
+        }
+    }
+
+    given("애플리케이션이 주어지지 않고") {
+
+        `when`("usecase를 실행할때") {
+            every { queryApplicationPort.findById(applicationId) } returns null
+
+            then("ApplicationNotFoundException이 발생해야함") {
+                shouldThrow<ApplicationNotFoundException> {
                     updateApplicationUseCase.execute(applicationId, updateReqDto)
                 }
             }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCaseTest.kt
@@ -1,0 +1,63 @@
+package com.dcd.server.core.domain.application.usecase
+
+import com.dcd.server.core.domain.application.dto.request.UpdateApplicationReqDto
+import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.enums.ApplicationType
+import com.dcd.server.core.domain.application.spi.CommandApplicationPort
+import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import com.dcd.server.core.domain.auth.model.Role
+import com.dcd.server.core.domain.user.model.User
+import com.dcd.server.core.domain.user.service.GetCurrentUserService
+import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameException
+import com.dcd.server.core.domain.workspace.model.Workspace
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.*
+
+class UpdateApplicationUseCaseTest : BehaviorSpec({
+    val queryApplicationPort = mockk<QueryApplicationPort>()
+    val commandApplicationPort = mockk<CommandApplicationPort>(relaxUnitFun = true)
+    val getCurrentUserService = mockk<GetCurrentUserService>()
+
+    val updateApplicationUseCase =
+        UpdateApplicationUseCase(queryApplicationPort, commandApplicationPort, getCurrentUserService)
+
+    val user =
+        User(email = "email", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
+    val workspace = Workspace(
+        UUID.randomUUID().toString(),
+        title = "test workspace",
+        description = "test workspace description",
+        owner = user
+    )
+    val applicationId = "testId"
+    val updateReqDto = UpdateApplicationReqDto(name = "updated application", description = "dldl")
+
+    given("애플리케이션이 주어지고") {
+        val application = Application(
+            id = applicationId,
+            name = "test",
+            description = "test",
+            applicationType = ApplicationType.SPRING_BOOT,
+            env = mapOf(),
+            githubUrl = "testUrl",
+            workspace = workspace,
+            port = 8080
+        )
+
+        `when`("usecase를 실행할때") {
+            every { getCurrentUserService.getCurrentUser() } returns user
+            every { queryApplicationPort.findById(applicationId) } returns application
+
+            updateApplicationUseCase.execute(applicationId, updateReqDto)
+
+            then("ReqDto의 내용이 반영된 애플리케이션을 저장해야함") {
+                val updatedApplication = application.copy(name = updateReqDto.name, description = updateReqDto.description)
+                verify { commandApplicationPort.save(updatedApplication) }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -119,7 +119,7 @@ class ApplicationWebAdapterTest : BehaviorSpec({
         }
     }
 
-    given("애플리케이션 id와 삭젷할 키가 주어지고") {
+    given("애플리케이션 id와 삭제할 키가 주어지고") {
         val testId = "testId"
         val key = "testKey"
         `when`("deleteApplicationEnv메서드를 실행할때") {
@@ -140,10 +140,7 @@ class ApplicationWebAdapterTest : BehaviorSpec({
                 result.statusCode shouldBe HttpStatus.OK
             }
         }
-    }
 
-    given("애플리케이션 Id가 주어지고") {
-        val testId = "testId"
         `when`("deleteApplication 메서드를 실행할때") {
             every { deleteApplicationUseCase.execute(testId) } returns Unit
             val result = applicationWebAdapter.deleteApplication(testId)

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.presentation.domain.application
 
+import com.dcd.server.core.domain.application.dto.request.UpdateApplicationReqDto
 import com.dcd.server.core.domain.application.dto.response.ApplicationListResDto
 import com.dcd.server.core.domain.application.dto.response.ApplicationResDto
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
@@ -8,10 +9,12 @@ import com.dcd.server.presentation.domain.application.data.exetension.toResponse
 import com.dcd.server.presentation.domain.application.data.request.AddApplicationEnvRequest
 import com.dcd.server.presentation.domain.application.data.request.CreateApplicationRequest
 import com.dcd.server.presentation.domain.application.data.request.RunApplicationRequest
+import com.dcd.server.presentation.domain.application.data.request.UpdateApplicationRequest
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.springframework.http.HttpStatus
 
 class ApplicationWebAdapterTest : BehaviorSpec({
@@ -23,7 +26,7 @@ class ApplicationWebAdapterTest : BehaviorSpec({
     val deleteApplicationEnvUseCase = mockk<DeleteApplicationEnvUseCase>()
     val stopApplicationUseCase = mockk<StopApplicationUseCase>()
     val deleteApplicationUseCase = mockk<DeleteApplicationUseCase>()
-    val updateApplicationUseCase = mockk<UpdateApplicationUseCase>()
+    val updateApplicationUseCase = mockk<UpdateApplicationUseCase>(relaxUnitFun = true)
     val applicationWebAdapter = ApplicationWebAdapter(createApplicationUseCase, springApplicationRunUseCase, getAllApplicationUseCase, getOneApplicationUseCase, addApplicationEnvUseCase, deleteApplicationEnvUseCase, stopApplicationUseCase, deleteApplicationUseCase, updateApplicationUseCase)
 
     given("CreateApplicationRequest가 주어지고") {
@@ -146,6 +149,22 @@ class ApplicationWebAdapterTest : BehaviorSpec({
             val result = applicationWebAdapter.deleteApplication(testId)
             then("status는 200이여야함") {
                 result.statusCode shouldBe HttpStatus.OK
+            }
+        }
+    }
+
+    given("UpdateRequest가 주어지고") {
+        val testId ="testId"
+        val request = UpdateApplicationRequest(name = "update", description = null)
+
+        `when`("updateApplication 메서드를 실행할때") {
+            val result = applicationWebAdapter.updateApplication(testId, request)
+
+            then("status는 200이여야함") {
+                result.statusCode shouldBe HttpStatus.OK
+            }
+            then("updateApplicationUseCase를 실행해야함") {
+                verify { updateApplicationUseCase.execute(testId, any() as UpdateApplicationReqDto) }
             }
         }
     }


### PR DESCRIPTION
## 🔖 개요
* 애플리케이션 수정 API 테스트 코드 작성

## 📜 작업내용
* 정상적으로 UseCase가 실행되는 테스트 케이스
* 애플리케이션의 워크스페이스 주인이 현재 로그인된 유저가 아닌 테스트 케이스
* 해당 애플리케이션이 존재하지 않는 테스트 케이스
* ApplicationWebAdpater의 updateApplication 메서드 테스트 케이스

## 🔀 변경사항
* ApplicationWebAdapterTest의 테스트 케이스 네이밍에 오타있는 부분 수정