### PR TITLE
🔀 :: 147 - Application 엔티티에 version 필드 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/extenstion/ApplicationDtoExtension.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/extenstion/ApplicationDtoExtension.kt
@@ -14,7 +14,8 @@ fun CreateApplicationReqDto.toEntity(workspace: Workspace): Application =
         applicationType = this.applicationType,
         env = this.env,
         workspace = workspace,
-        port = this.port
+        port = this.port,
+        version = this.version
     )
 
 fun Application.toDto(): ApplicationResDto =

--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/request/CreateApplicationReqDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/request/CreateApplicationReqDto.kt
@@ -8,5 +8,6 @@ data class CreateApplicationReqDto(
     val githubUrl: String,
     val env: Map<String, String>,
     val applicationType: ApplicationType,
-    val port: Int
+    val port: Int,
+    val version: String
 )

--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/request/RunApplicationReqDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/request/RunApplicationReqDto.kt
@@ -1,6 +1,0 @@
-package com.dcd.server.core.domain.application.dto.request
-
-
-class RunApplicationReqDto(
-    val version: String
-)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/model/Application.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/model/Application.kt
@@ -12,6 +12,7 @@ data class Application(
     val applicationType: ApplicationType,
     val githubUrl: String,
     val env: Map<String, String>,
+    val version: String,
     val workspace: Workspace,
     val port: Int
 )

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/ApplicationRunUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/ApplicationRunUseCase.kt
@@ -1,7 +1,6 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.ReadOnlyUseCase
-import com.dcd.server.core.domain.application.dto.request.RunApplicationReqDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.*
@@ -18,7 +17,7 @@ class ApplicationRunUseCase(
     private val queryApplicationPort: QueryApplicationPort,
     private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService
 ) {
-    fun execute(id: String, runApplicationReqDto: RunApplicationReqDto) {
+    fun execute(id: String) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
         validateWorkspaceOwnerService.validateOwner(application.workspace)
@@ -28,18 +27,18 @@ class ApplicationRunUseCase(
             ApplicationType.SPRING_BOOT -> {
                 cloneApplicationByUrlService.cloneByApplication(application)
                 modifyGradleService.modifyGradleByApplication(application)
-                val version = runApplicationReqDto.version
+                val version = application.version
                 createDockerFileService.createFileToApplication(application, version)
                 buildDockerImageService.buildImageByApplication(application)
                 dockerRunService.runApplication(application)
             }
 
             ApplicationType.MYSQL -> {
-                dockerRunService.runApplication(application, runApplicationReqDto.version)
+                dockerRunService.runApplication(application, application.version)
             }
 
             ApplicationType.REDIS -> {
-                dockerRunService.runApplication(application, runApplicationReqDto.version)
+                dockerRunService.runApplication(application, application.version)
             }
         }
     }

--- a/src/main/kotlin/com/dcd/server/persistence/application/adapter/ApplicationAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/application/adapter/ApplicationAdapter.kt
@@ -16,7 +16,8 @@ fun Application.toEntity(): ApplicationJpaEntity =
         githubUrl = this.githubUrl,
         env = this.env,
         workspace = this.workspace.toEntity(),
-        port = this.port
+        port = this.port,
+        version = this.version
     )
 
 fun ApplicationJpaEntity.toDomain(): Application =
@@ -28,5 +29,6 @@ fun ApplicationJpaEntity.toDomain(): Application =
         githubUrl = this.githubUrl,
         env = this.env,
         workspace = this.workspace.toDomain(),
-        port = this.port
+        port = this.port,
+        version = this.version
     )

--- a/src/main/kotlin/com/dcd/server/persistence/application/entity/ApplicationJpaEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/application/entity/ApplicationJpaEntity.kt
@@ -24,4 +24,5 @@ class ApplicationJpaEntity(
     @JoinColumn(name = "workspace_id")
     val workspace: WorkspaceJpaEntity,
     val port: Int,
+    val version: String,
 )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
@@ -5,7 +5,6 @@ import com.dcd.server.presentation.domain.application.data.exetension.toDto
 import com.dcd.server.presentation.domain.application.data.exetension.toResponse
 import com.dcd.server.presentation.domain.application.data.request.AddApplicationEnvRequest
 import com.dcd.server.presentation.domain.application.data.request.CreateApplicationRequest
-import com.dcd.server.presentation.domain.application.data.request.RunApplicationRequest
 import com.dcd.server.presentation.domain.application.data.request.UpdateApplicationRequest
 import com.dcd.server.presentation.domain.application.data.response.ApplicationListResponse
 import com.dcd.server.presentation.domain.application.data.response.ApplicationResponse
@@ -33,8 +32,8 @@ class ApplicationWebAdapter(
             .run { ResponseEntity(HttpStatus.CREATED) }
 
     @PostMapping("/{id}/run")
-    fun runApplication(@PathVariable id: String, @RequestBody runApplicationRequest: RunApplicationRequest): ResponseEntity<Void> =
-        applicationRunUseCase.execute(id, runApplicationRequest.toDto())
+    fun runApplication(@PathVariable id: String): ResponseEntity<Void> =
+        applicationRunUseCase.execute(id)
             .run { ResponseEntity.ok().build() }
 
     @GetMapping

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationRequestDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationRequestDataExtension.kt
@@ -2,11 +2,9 @@ package com.dcd.server.presentation.domain.application.data.exetension
 
 import com.dcd.server.core.domain.application.dto.request.AddApplicationEnvReqDto
 import com.dcd.server.core.domain.application.dto.request.CreateApplicationReqDto
-import com.dcd.server.core.domain.application.dto.request.RunApplicationReqDto
 import com.dcd.server.core.domain.application.dto.request.UpdateApplicationReqDto
 import com.dcd.server.presentation.domain.application.data.request.AddApplicationEnvRequest
 import com.dcd.server.presentation.domain.application.data.request.CreateApplicationRequest
-import com.dcd.server.presentation.domain.application.data.request.RunApplicationRequest
 import com.dcd.server.presentation.domain.application.data.request.UpdateApplicationRequest
 
 fun AddApplicationEnvRequest.toDto(): AddApplicationEnvReqDto =
@@ -22,11 +20,6 @@ fun CreateApplicationRequest.toDto(): CreateApplicationReqDto =
         env = this.env,
         applicationType = this.applicationType,
         port = this.port
-    )
-
-fun RunApplicationRequest.toDto(): RunApplicationReqDto =
-    RunApplicationReqDto(
-        version = this.version
     )
 
 fun UpdateApplicationRequest.toDto(): UpdateApplicationReqDto =

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationRequestDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationRequestDataExtension.kt
@@ -19,7 +19,8 @@ fun CreateApplicationRequest.toDto(): CreateApplicationReqDto =
         githubUrl = this.githubUrl,
         env = this.env,
         applicationType = this.applicationType,
-        port = this.port
+        port = this.port,
+        version = this.version
     )
 
 fun UpdateApplicationRequest.toDto(): UpdateApplicationReqDto =

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/request/CreateApplicationRequest.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/request/CreateApplicationRequest.kt
@@ -11,5 +11,6 @@ data class CreateApplicationRequest(
     val githubUrl: String,
     val env: Map<String, String>,
     val applicationType: ApplicationType,
-    val port: Int
+    val port: Int,
+    val version: String
 )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/request/RunApplicationRequest.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/request/RunApplicationRequest.kt
@@ -1,5 +1,0 @@
-package com.dcd.server.presentation.domain.application.data.request
-
-open class RunApplicationRequest(
-    val version: String
-)

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/BuildDockerImageServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/BuildDockerImageServiceImplTest.kt
@@ -31,7 +31,7 @@ class BuildDockerImageServiceImplTest : BehaviorSpec({
                 description = "test workspace description",
                 owner = user
             )
-            val application = Application(appId, "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), workspace, port = 8080)
+            val application = Application(appId, "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), "17", workspace, port = 8080)
             every { queryApplicationPort.findById(appId) } returns application
 
             service.buildImageByApplicationId(appId)
@@ -49,7 +49,7 @@ class BuildDockerImageServiceImplTest : BehaviorSpec({
             description = "test workspace description",
             owner = user
         )
-        val application = Application(UUID.randomUUID().toString(), "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), workspace, port = 8080)
+        val application = Application(UUID.randomUUID().toString(), "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), "17", workspace, port = 8080)
 
         `when`("buildImageByApplication 메서드를 실행할때") {
             service.buildImageByApplication(application)

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/CloneApplicationByUrlServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/CloneApplicationByUrlServiceImplTest.kt
@@ -31,7 +31,7 @@ class CloneApplicationByUrlServiceImplTest : BehaviorSpec({
                 description = "test workspace description",
                 owner = user
             )
-            val application = Application(appId, "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), workspace, port = 8080)
+            val application = Application(appId, "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), "17", workspace, port = 8080)
             every { queryApplicationPort.findById(appId) } returns application
 
             service.cloneById(appId)
@@ -48,7 +48,7 @@ class CloneApplicationByUrlServiceImplTest : BehaviorSpec({
             description = "test workspace description",
             owner = user
         )
-        val application = Application(UUID.randomUUID().toString(), "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), workspace, port = 8080)
+        val application = Application(UUID.randomUUID().toString(), "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), "17", workspace, port = 8080)
 
         `when`("cloneByApplication 메서드를 실행할때") {
             service.cloneByApplication(application)

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/DeleteApplicationDirectoryServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/DeleteApplicationDirectoryServiceImplTest.kt
@@ -25,7 +25,7 @@ class DeleteApplicationDirectoryServiceImplTest : BehaviorSpec({
             description = "test workspace description",
             owner = user
         )
-        val application = Application(UUID.randomUUID().toString(), "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), workspace, port = 8080)
+        val application = Application(UUID.randomUUID().toString(), "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), "17", workspace, port = 8080)
 
         `when`("buildImageByApplication 메서드를 실행할때") {
             service.deleteApplicationDirectory(application)

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/DeleteContainerServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/DeleteContainerServiceImplTest.kt
@@ -25,7 +25,7 @@ class DeleteContainerServiceImplTest : BehaviorSpec({
             description = "test workspace description",
             owner = user
         )
-        val application = Application(UUID.randomUUID().toString(), "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), workspace, port = 8080)
+        val application = Application(UUID.randomUUID().toString(), "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), "17", workspace, port = 8080)
 
         `when`("buildImageByApplication 메서드를 실행할때") {
             service.deleteContainer(application)

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/DockerRunServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/DockerRunServiceImplTest.kt
@@ -34,7 +34,7 @@ class DockerRunServiceImplTest : BehaviorSpec({
         val appId = UUID.randomUUID().toString()
 
         `when`("executeShellCommand를 실행할때") {
-            val application = Application(appId, "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), workspace, port = 8080)
+            val application = Application(appId, "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), "17", workspace, port = 8080)
             every { queryApplicationPort.findById(appId) } returns application
             every { existsPortService.existsPort(application.port) } returns false
 
@@ -47,7 +47,7 @@ class DockerRunServiceImplTest : BehaviorSpec({
     }
 
     given("애플리케이션이 주이지고") {
-        val application = Application(UUID.randomUUID().toString(), "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), workspace, port = 8080)
+        val application = Application(UUID.randomUUID().toString(), "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), "17", workspace, port = 8080)
 
         `when`("executeShellCommand 메서드를 실행할때") {
             every { existsPortService.existsPort(application.port) } returns false
@@ -68,6 +68,7 @@ class DockerRunServiceImplTest : BehaviorSpec({
             ApplicationType.MYSQL,
             "testUrl",
             mapOf( Pair("rootPassword", "testMysqlPassword") ),
+            "17",
             workspace,
             port = 3306
         )
@@ -93,6 +94,7 @@ class DockerRunServiceImplTest : BehaviorSpec({
             ApplicationType.REDIS,
             "testUrl",
             mapOf(),
+            "17",
             workspace,
             port = 6379
         )

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/AddApplicationEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/AddApplicationEnvUseCaseTest.kt
@@ -42,6 +42,7 @@ class AddApplicationEnvUseCaseTest : BehaviorSpec({
             applicationType = ApplicationType.SPRING_BOOT,
             env = mapOf(),
             githubUrl = "testUrl",
+            version = "17",
             workspace = workspace,
             port = 8080
         )

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/ApplicationRunUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/ApplicationRunUseCaseTest.kt
@@ -1,6 +1,5 @@
 package com.dcd.server.core.domain.application.usecase
 
-import com.dcd.server.core.domain.application.dto.request.RunApplicationReqDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
@@ -52,17 +51,17 @@ class ApplicationRunUseCaseTest : BehaviorSpec({
             env = mapOf(),
             githubUrl = "testUrl",
             workspace = workspace,
-            port = 8080
+            port = 8080,
+            version = "17"
         )
-        val reqDto = RunApplicationReqDto("17")
         `when`("usecase를 실행할때") {
             every { queryApplicationPort.findById("testId") } returns application
-            applicationRunUseCase.execute("testId", reqDto)
+            applicationRunUseCase.execute("testId")
             then("애플리케이션 실행에 관한 service들이 실행되어야함") {
                 verify { cloneApplicationByUrlService.cloneByApplication(application) }
                 verify { validateWorkspaceOwnerService.validateOwner(workspace) }
                 verify { modifyGradleService.modifyGradleByApplication(application) }
-                verify { createDockerFileService.createFileToApplication(application, reqDto.version) }
+                verify { createDockerFileService.createFileToApplication(application, application.version) }
                 verify { buildDockerImageService.buildImageByApplication(application) }
                 verify { dockerRunService.runApplication(application) }
             }
@@ -72,7 +71,7 @@ class ApplicationRunUseCaseTest : BehaviorSpec({
             every { queryApplicationPort.findById("testId") } returns null
             then("ApplicationNotFoundException이 발생해야함") {
                 shouldThrow<ApplicationNotFoundException> {
-                    applicationRunUseCase.execute("testId", reqDto)
+                    applicationRunUseCase.execute("testId")
                 }
             }
         }
@@ -87,21 +86,21 @@ class ApplicationRunUseCaseTest : BehaviorSpec({
             env = mapOf(),
             githubUrl = "testUrl",
             workspace = workspace,
-            port = 3306
+            port = 3306,
+            version = "8"
         )
-        val reqDto = RunApplicationReqDto("8")
 
         `when`("usecase를 실행하면") {
             every { queryApplicationPort.findById(application.id) } returns application
 
-            applicationRunUseCase.execute(application.id, reqDto)
+            applicationRunUseCase.execute(application.id)
             then("dockerRunService만 실행되어야함") {
-                verify { dockerRunService.runApplication(application, reqDto.version) }
+                verify { dockerRunService.runApplication(application, application.version) }
                 shouldThrow<AssertionError> {
                     verify { cloneApplicationByUrlService.cloneByApplication(application) }
                     verify { validateWorkspaceOwnerService.validateOwner(workspace) }
                     verify { modifyGradleService.modifyGradleByApplication(application) }
-                    verify { createDockerFileService.createFileToApplication(application, reqDto.version) }
+                    verify { createDockerFileService.createFileToApplication(application, application.version) }
                     verify { buildDockerImageService.buildImageByApplication(application) }
                 }
             }
@@ -117,21 +116,21 @@ class ApplicationRunUseCaseTest : BehaviorSpec({
             env = mapOf(),
             githubUrl = "testUrl",
             workspace = workspace,
-            port = 6379
+            port = 6379,
+            version = "6"
         )
-        val reqDto = RunApplicationReqDto("6")
 
         `when`("usecase를 실행하면") {
             every { queryApplicationPort.findById(application.id) } returns application
 
-            applicationRunUseCase.execute(application.id, reqDto)
+            applicationRunUseCase.execute(application.id)
             then("dockerRunService만 실행되어야함") {
-                verify { dockerRunService.runApplication(application, reqDto.version) }
+                verify { dockerRunService.runApplication(application, application.version) }
                 shouldThrow<AssertionError> {
                     verify { cloneApplicationByUrlService.cloneByApplication(application) }
                     verify { validateWorkspaceOwnerService.validateOwner(workspace) }
                     verify { modifyGradleService.modifyGradleByApplication(application) }
-                    verify { createDockerFileService.createFileToApplication(application, reqDto.version) }
+                    verify { createDockerFileService.createFileToApplication(application, application.version) }
                     verify { buildDockerImageService.buildImageByApplication(application) }
                 }
             }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
@@ -33,6 +33,7 @@ class CreateApplicationUseCaseTest : BehaviorSpec({
             applicationType = ApplicationType.SPRING_BOOT,
             env = mapOf(),
             githubUrl = "testGithub",
+            version = "17",
             port = 8080
         )
         val user =

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationEnvUseCaseTest.kt
@@ -35,6 +35,7 @@ class DeleteApplicationEnvUseCaseTest : BehaviorSpec({
             applicationType = ApplicationType.SPRING_BOOT,
             env = mapOf(Pair(key, "testValue")),
             githubUrl = "testUrl",
+            version = "17",
             workspace = Workspace(UUID.randomUUID().toString(), title = "test workspace", description = "test workspace description", owner = user),
             port = 8080
         )

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationUseCaseTest.kt
@@ -36,6 +36,7 @@ class DeleteApplicationUseCaseTest : BehaviorSpec({
             applicationType = ApplicationType.SPRING_BOOT,
             env = mapOf(),
             githubUrl = "testUrl",
+            version = "17",
             workspace = Workspace(UUID.randomUUID().toString(), title = "test workspace", description = "test workspace description", owner = user),
             port = 8080
         )

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCaseTest.kt
@@ -40,6 +40,7 @@ class GetAllApplicationUseCaseTest : BehaviorSpec({
             applicationType = ApplicationType.SPRING_BOOT,
             env = mapOf(),
             githubUrl = "testUrl",
+            version = "17",
             workspace = workspace,
             port = 8080
         )

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCaseTest.kt
@@ -32,6 +32,7 @@ class GetOneApplicationUseCaseTest : BehaviorSpec({
             applicationType = ApplicationType.SPRING_BOOT,
             env = mapOf(),
             githubUrl = "testUrl",
+            version = "17",
             workspace = Workspace(UUID.randomUUID().toString(), title = "test workspace", description = "test workspace description", owner = user),
             port = 8080
         )

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
@@ -36,6 +36,7 @@ class StopApplicationUseCaseTest : BehaviorSpec({
             applicationType = ApplicationType.SPRING_BOOT,
             env = mapOf(),
             githubUrl = "testUrl",
+            version = "17",
             workspace = Workspace(UUID.randomUUID().toString(), title = "test workspace", description = "test workspace description", owner = user),
             port = 8080
         )

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCaseTest.kt
@@ -45,6 +45,7 @@ class UpdateApplicationUseCaseTest : BehaviorSpec({
             applicationType = ApplicationType.SPRING_BOOT,
             env = mapOf(),
             githubUrl = "testUrl",
+            version = "17",
             workspace = workspace,
             port = 8080
         )

--- a/src/test/kotlin/com/dcd/server/core/domain/user/usecase/GetUserProfileUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/user/usecase/GetUserProfileUseCaseTest.kt
@@ -42,6 +42,7 @@ class GetUserProfileUseCaseTest : BehaviorSpec({
             applicationType = ApplicationType.SPRING_BOOT,
             env = mapOf(),
             githubUrl = "testUrl",
+            version = "17",
             workspace = workspace,
             port = 8080
         )

--- a/src/test/kotlin/com/dcd/server/persistence/application/ApplicationPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/persistence/application/ApplicationPersistenceAdapterTest.kt
@@ -38,6 +38,7 @@ class ApplicationPersistenceAdapterTest : BehaviorSpec({
             applicationType = ApplicationType.SPRING_BOOT,
             githubUrl = "testUrl",
             env = mapOf(),
+            version = "17",
             workspace = workspace,
             port = 8080
         )

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -8,7 +8,6 @@ import com.dcd.server.core.domain.application.usecase.*
 import com.dcd.server.presentation.domain.application.data.exetension.toResponse
 import com.dcd.server.presentation.domain.application.data.request.AddApplicationEnvRequest
 import com.dcd.server.presentation.domain.application.data.request.CreateApplicationRequest
-import com.dcd.server.presentation.domain.application.data.request.RunApplicationRequest
 import com.dcd.server.presentation.domain.application.data.request.UpdateApplicationRequest
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -50,10 +49,9 @@ class ApplicationWebAdapterTest : BehaviorSpec({
 
     given("RunApplicationRequest가 주어지고") {
         val id = "testApplicationId"
-        val request = RunApplicationRequest(version = "11")
         `when`("runApplication 메서드를 실행할때") {
-            every { springApplicationRunUseCase.execute(id, any()) } returns Unit
-            val result = applicationWebAdapter.runApplication(id, request)
+            every { springApplicationRunUseCase.execute(id) } returns Unit
+            val result = applicationWebAdapter.runApplication(id)
             then("상태코드가 200이여야함") {
                 result.statusCode shouldBe HttpStatus.OK
             }

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -35,7 +35,8 @@ class ApplicationWebAdapterTest : BehaviorSpec({
             applicationType = ApplicationType.SPRING_BOOT,
             env = mapOf(),
             githubUrl = "testUrl",
-            port = 8080
+            port = 8080,
+            version = "17",
         )
 
         `when`("createApplication 메서드를 실행할때") {


### PR DESCRIPTION
## 🔖 개요
* RunApplicationRequest 객체 제거 및 version 필드 추가

## 📜 작업내용
* RunApplicationRequest 객체 제거
* Application 도메인에 version 필드 추가
* Application 엔티티에 version 필드 추가
* CreateApplicationRequest 객체에 version 필드 추가

## 🔀 변경사항
* Application Service 테스트 코드 수정
* Application UseCase 테스트 코드 수정
* Application Persistence, Presentation 테스트 코드 수정