### PR TITLE
🔀 :: 149 - 해당 애플리케이션 타입에서 사용 가능한 버전 조회 API

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/response/AvailableVersionResDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/response/AvailableVersionResDto.kt
@@ -1,0 +1,5 @@
+package com.dcd.server.core.domain.application.dto.response
+
+data class AvailableVersionResDto(
+    val version: List<String>
+)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/GetApplicationVersionService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/GetApplicationVersionService.kt
@@ -1,7 +1,7 @@
 package com.dcd.server.core.domain.application.service
 
-import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.enums.ApplicationType
 
 interface GetApplicationVersionService {
-    fun getAvailableVersion(application: Application): List<String>
+    fun getAvailableVersion(applicationType: ApplicationType): List<String>
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/GetApplicationVersionService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/GetApplicationVersionService.kt
@@ -1,0 +1,7 @@
+package com.dcd.server.core.domain.application.service
+
+import com.dcd.server.core.domain.application.model.Application
+
+interface GetApplicationVersionService {
+    fun getAvailableVersion(application: Application): List<String>
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetApplicationVersionServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetApplicationVersionServiceImpl.kt
@@ -1,0 +1,31 @@
+package com.dcd.server.core.domain.application.service.impl
+
+import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.service.GetApplicationVersionService
+import org.springframework.stereotype.Service
+import java.io.BufferedReader
+import java.io.InputStreamReader
+
+@Service
+class GetApplicationVersionServiceImpl(
+    private val commandPort: CommandPort
+) : GetApplicationVersionService {
+    override fun getAvailableVersion(application: Application): List<String> {
+        val cmd = arrayOf("docker images ${application.applicationType.name.lowercase()}")
+        val p = Runtime.getRuntime().exec(cmd)
+        val br = BufferedReader(InputStreamReader(p.inputStream))
+        var isFirst = true
+        val result = mutableListOf<String>()
+        while (br.readLine() != null) {
+            if (isFirst) {
+                isFirst = !isFirst
+                continue
+            }
+            val split = br.readLine().split("    ")
+            val tag = split[1]
+            result.add(tag)
+        }
+        return result
+    }
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetApplicationVersionServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetApplicationVersionServiceImpl.kt
@@ -1,18 +1,16 @@
 package com.dcd.server.core.domain.application.service.impl
 
 import com.dcd.server.core.common.command.CommandPort
-import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.GetApplicationVersionService
 import org.springframework.stereotype.Service
 import java.io.BufferedReader
 import java.io.InputStreamReader
 
 @Service
-class GetApplicationVersionServiceImpl(
-    private val commandPort: CommandPort
-) : GetApplicationVersionService {
-    override fun getAvailableVersion(application: Application): List<String> {
-        val cmd = arrayOf("docker images ${application.applicationType.name.lowercase()}")
+class GetApplicationVersionServiceImpl : GetApplicationVersionService {
+    override fun getAvailableVersion(applicationType: ApplicationType): List<String> {
+        val cmd = arrayOf("docker images ${applicationType.name.lowercase()}")
         val p = Runtime.getRuntime().exec(cmd)
         val br = BufferedReader(InputStreamReader(p.inputStream))
         var isFirst = true

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetAvailableVersionUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetAvailableVersionUseCase.kt
@@ -2,19 +2,15 @@ package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.domain.application.dto.response.AvailableVersionResDto
-import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
+import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.GetApplicationVersionService
-import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 
 @UseCase
 class GetAvailableVersionUseCase(
-    private val queryApplicationPort: QueryApplicationPort,
     private val getApplicationVersionService: GetApplicationVersionService
 ) {
-    fun execute(id: String): AvailableVersionResDto {
-        val application = (queryApplicationPort.findById(id)
-            ?: throw ApplicationNotFoundException())
-        val availableVersion = getApplicationVersionService.getAvailableVersion(application)
+    fun execute(applicationType: ApplicationType): AvailableVersionResDto {
+        val availableVersion = getApplicationVersionService.getAvailableVersion(applicationType)
         return AvailableVersionResDto(availableVersion)
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetAvailableVersionUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetAvailableVersionUseCase.kt
@@ -1,0 +1,20 @@
+package com.dcd.server.core.domain.application.usecase
+
+import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.domain.application.dto.response.AvailableVersionResDto
+import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
+import com.dcd.server.core.domain.application.service.GetApplicationVersionService
+import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+
+@UseCase
+class GetAvailableVersionUseCase(
+    private val queryApplicationPort: QueryApplicationPort,
+    private val getApplicationVersionService: GetApplicationVersionService
+) {
+    fun execute(id: String): AvailableVersionResDto {
+        val application = (queryApplicationPort.findById(id)
+            ?: throw ApplicationNotFoundException())
+        val availableVersion = getApplicationVersionService.getAvailableVersion(application)
+        return AvailableVersionResDto(availableVersion)
+    }
+}

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
@@ -60,6 +60,7 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.POST, "/application/{id}/stop").authenticated()
                 it.requestMatchers(HttpMethod.DELETE, "/application/{id}").authenticated()
                 it.requestMatchers(HttpMethod.PATCH, "/application/{id}").authenticated()
+                it.requestMatchers(HttpMethod.GET, "/application/version/{applicationType}").authenticated()
 
                 //workspace
                 it.requestMatchers(HttpMethod.POST, "/workspace").authenticated()

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.presentation.domain.application
 
+import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.usecase.*
 import com.dcd.server.presentation.domain.application.data.exetension.toDto
 import com.dcd.server.presentation.domain.application.data.exetension.toResponse
@@ -8,6 +9,7 @@ import com.dcd.server.presentation.domain.application.data.request.CreateApplica
 import com.dcd.server.presentation.domain.application.data.request.UpdateApplicationRequest
 import com.dcd.server.presentation.domain.application.data.response.ApplicationListResponse
 import com.dcd.server.presentation.domain.application.data.response.ApplicationResponse
+import com.dcd.server.presentation.domain.application.data.response.AvailableVersionResponse
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
@@ -24,7 +26,8 @@ class ApplicationWebAdapter(
     private val deleteApplicationEnvUseCase: DeleteApplicationEnvUseCase,
     private val stopApplicationUseCase: StopApplicationUseCase,
     private val deleteApplicationUseCase: DeleteApplicationUseCase,
-    private val updateApplicationUseCase: UpdateApplicationUseCase
+    private val updateApplicationUseCase: UpdateApplicationUseCase,
+    private val getAvailableVersionUseCase: GetAvailableVersionUseCase
 ) {
     @PostMapping("/{workspaceId}")
     fun createApplication(@PathVariable workspaceId: String, @Validated @RequestBody createApplicationRequest: CreateApplicationRequest): ResponseEntity<Void> =
@@ -70,4 +73,9 @@ class ApplicationWebAdapter(
     fun updateApplication(@PathVariable id: String, @RequestBody updateApplicationRequest: UpdateApplicationRequest): ResponseEntity<Void> =
         updateApplicationUseCase.execute(id, updateApplicationRequest.toDto())
             .run { ResponseEntity.ok().build() }
+
+    @GetMapping("/version/{applicationType}")
+    fun getAvailableVersion(@PathVariable applicationType: ApplicationType): ResponseEntity<AvailableVersionResponse> =
+        getAvailableVersionUseCase.execute(applicationType)
+            .let { ResponseEntity.ok(it.toResponse()) }
 }

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationResponseDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationResponseDataExtension.kt
@@ -3,9 +3,11 @@ package com.dcd.server.presentation.domain.application.data.exetension
 import com.dcd.server.core.domain.application.dto.response.ApplicationListResDto
 import com.dcd.server.core.domain.application.dto.response.ApplicationProfileResDto
 import com.dcd.server.core.domain.application.dto.response.ApplicationResDto
+import com.dcd.server.core.domain.application.dto.response.AvailableVersionResDto
 import com.dcd.server.presentation.domain.application.data.response.ApplicationListResponse
 import com.dcd.server.presentation.domain.application.data.response.ApplicationProfileResponse
 import com.dcd.server.presentation.domain.application.data.response.ApplicationResponse
+import com.dcd.server.presentation.domain.application.data.response.AvailableVersionResponse
 
 fun ApplicationResDto.toResponse(): ApplicationResponse =
     ApplicationResponse(
@@ -27,4 +29,9 @@ fun ApplicationProfileResDto.toResponse(): ApplicationProfileResponse =
         id = this.id,
         name = this.name,
         description = this.description
+    )
+
+fun AvailableVersionResDto.toResponse(): AvailableVersionResponse =
+    AvailableVersionResponse(
+        version = this.version
     )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/response/AvailableVersionResponse.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/response/AvailableVersionResponse.kt
@@ -1,0 +1,5 @@
+package com.dcd.server.presentation.domain.application.data.response
+
+data class AvailableVersionResponse(
+    val version: List<String>
+)

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -26,7 +26,8 @@ class ApplicationWebAdapterTest : BehaviorSpec({
     val stopApplicationUseCase = mockk<StopApplicationUseCase>()
     val deleteApplicationUseCase = mockk<DeleteApplicationUseCase>()
     val updateApplicationUseCase = mockk<UpdateApplicationUseCase>(relaxUnitFun = true)
-    val applicationWebAdapter = ApplicationWebAdapter(createApplicationUseCase, springApplicationRunUseCase, getAllApplicationUseCase, getOneApplicationUseCase, addApplicationEnvUseCase, deleteApplicationEnvUseCase, stopApplicationUseCase, deleteApplicationUseCase, updateApplicationUseCase)
+    val getAvailableVersionUseCase = mockk<GetAvailableVersionUseCase>()
+    val applicationWebAdapter = ApplicationWebAdapter(createApplicationUseCase, springApplicationRunUseCase, getAllApplicationUseCase, getOneApplicationUseCase, addApplicationEnvUseCase, deleteApplicationEnvUseCase, stopApplicationUseCase, deleteApplicationUseCase, updateApplicationUseCase, getAvailableVersionUseCase)
 
     given("CreateApplicationRequest가 주어지고") {
         val request = CreateApplicationRequest(


### PR DESCRIPTION
## 🔖 개요
* 해당 애플리케이션 타입에서 사용 가능한 버전 조회 API 추가

## 📜 작업내용
* GetApplicationVersionService 추가
* GetAvailableVersionUseCase 추가
* API 엔드포인트 추가
* 엔드포인트 권한 설정