### PR TITLE
🔀 :: 153 - shell 명령을 실행하는 port 로직 리펙토링

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExistsPortServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExistsPortServiceImpl.kt
@@ -12,8 +12,9 @@ class ExistsPortServiceImpl
         val cmd = arrayOf("/bin/sh", "-c", "lsof -i :${port}")
         val p = Runtime.getRuntime().exec(cmd)
         val br = BufferedReader(InputStreamReader(p.inputStream))
+        val result = br.readLine() != null
         p.waitFor()
         p.destroy()
-        return br.readLine() != null
+        return result
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExistsPortServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExistsPortServiceImpl.kt
@@ -12,6 +12,8 @@ class ExistsPortServiceImpl
         val cmd = arrayOf("/bin/sh", "-c", "lsof -i :${port}")
         val p = Runtime.getRuntime().exec(cmd)
         val br = BufferedReader(InputStreamReader(p.inputStream))
+        p.waitFor()
+        p.destroy()
         return br.readLine() != null
     }
 }

--- a/src/main/kotlin/com/dcd/server/infrastructure/common/command/CommandAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/common/command/CommandAdapter.kt
@@ -11,8 +11,9 @@ class CommandAdapter : CommandPort {
         val cmd = arrayOf("/bin/sh", "-c", cmd)
         val p = Runtime.getRuntime().exec(cmd)
         val br = BufferedReader(InputStreamReader(p.inputStream))
-        while (br.readLine() != null)
-            println("br.readLine() = ${br.readLine()}")
+        br.readLines().forEach {
+            println("$it")
+        }
         p.waitFor()
         println("p.exitValue() = ${p.exitValue()}")
         p.destroy()


### PR DESCRIPTION
## 🔖 개요
* shell 명령을 실행하는 port 로직 리펙토링

## 📜 작업내용
* ExistsPortServiceImpe에 process destory 로직 추가
* CommandAdapter의 출력 결과를 print하는 로직 수정
  * NPE가 발생할 수 있기 때문에 발생하지 않도록 수정