### PR TITLE
🔀 :: 155 - 애플리케이션 수정 API 리펙토링

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/request/UpdateApplicationReqDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/request/UpdateApplicationReqDto.kt
@@ -2,5 +2,6 @@ package com.dcd.server.core.domain.application.dto.request
 
 data class UpdateApplicationReqDto(
     val name: String,
-    val description: String?
+    val description: String?,
+    val version: String
 )

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCase.kt
@@ -23,7 +23,11 @@ class UpdateApplicationUseCase(
             throw WorkspaceOwnerNotSameException()
 
         val updatedApplication =
-            application.copy(name = updateApplicationReqDto.name, description = updateApplicationReqDto.description)
+            application.copy(
+                name = updateApplicationReqDto.name,
+                description = updateApplicationReqDto.description,
+                version = updateApplicationReqDto.version
+            )
         commandApplicationPort.save(updatedApplication)
     }
 }

--- a/src/main/kotlin/com/dcd/server/persistence/application/entity/ApplicationJpaEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/application/entity/ApplicationJpaEntity.kt
@@ -12,6 +12,7 @@ class ApplicationJpaEntity(
     val id: String,
     val name: String,
     val description: String?,
+    @Enumerated(EnumType.STRING)
     val applicationType: ApplicationType,
     val githubUrl: String,
     @ElementCollection

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationRequestDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationRequestDataExtension.kt
@@ -26,5 +26,6 @@ fun CreateApplicationRequest.toDto(): CreateApplicationReqDto =
 fun UpdateApplicationRequest.toDto(): UpdateApplicationReqDto =
     UpdateApplicationReqDto(
         name = this.name,
-        description = this.description
+        description = this.description,
+        version = this.version
     )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/request/UpdateApplicationRequest.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/request/UpdateApplicationRequest.kt
@@ -2,5 +2,6 @@ package com.dcd.server.presentation.domain.application.data.request
 
 data class UpdateApplicationRequest(
     val name: String,
-    val description: String?
+    val description: String?,
+    val version: String
 )

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCaseTest.kt
@@ -35,7 +35,7 @@ class UpdateApplicationUseCaseTest : BehaviorSpec({
         owner = user
     )
     val applicationId = "testId"
-    val updateReqDto = UpdateApplicationReqDto(name = "updated application", description = "dldl")
+    val updateReqDto = UpdateApplicationReqDto(name = "updated application", description = "dldl", version = "11")
 
     given("애플리케이션이 주어지고") {
         val application = Application(
@@ -57,7 +57,7 @@ class UpdateApplicationUseCaseTest : BehaviorSpec({
             updateApplicationUseCase.execute(applicationId, updateReqDto)
 
             then("ReqDto의 내용이 반영된 애플리케이션을 저장해야함") {
-                val updatedApplication = application.copy(name = updateReqDto.name, description = updateReqDto.description)
+                val updatedApplication = application.copy(name = updateReqDto.name, description = updateReqDto.description, version = updateReqDto.version)
                 verify { commandApplicationPort.save(updatedApplication) }
             }
         }

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -154,7 +154,7 @@ class ApplicationWebAdapterTest : BehaviorSpec({
 
     given("UpdateRequest가 주어지고") {
         val testId ="testId"
-        val request = UpdateApplicationRequest(name = "update", description = null)
+        val request = UpdateApplicationRequest(name = "update", description = null, version = "11")
 
         `when`("updateApplication 메서드를 실행할때") {
             val result = applicationWebAdapter.updateApplication(testId, request)


### PR DESCRIPTION
## 🔖 개요
* 애플리케이션 수정 API에서 version필드도 같이 수정할 수 있게끔 변경합니다.

## 📜 작업내용
* UpdateApplicationRequest 객체에 version 필드 추가
* UpdateApplicationUseCase에서 version을 반영해서 수정하도록 수정
* 테스트 코드를 API 변경사항에 맞게끔 수정

## 🔀 변경사항
* ApplicationType을 String으로 저장하도록 수정