### PR TITLE
🔀 :: 159 - 애플리케이션 실행 로직 리펙토링

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/CreateDockerFileService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/CreateDockerFileService.kt
@@ -3,6 +3,6 @@ package com.dcd.server.core.domain.application.service
 import com.dcd.server.core.domain.application.model.Application
 
 interface CreateDockerFileService {
-    fun createFileByApplicationId(id: String, javaVersion: String)
-    fun createFileToApplication(application: Application, javaVersion: String)
+    fun createFileByApplicationId(id: String, javaVersion: String, externalPort: Int)
+    fun createFileToApplication(application: Application, javaVersion: String, externalPort: Int)
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/DockerRunService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/DockerRunService.kt
@@ -3,12 +3,12 @@ package com.dcd.server.core.domain.application.service
 import com.dcd.server.core.domain.application.model.Application
 
 interface DockerRunService {
-    fun runApplication(id: String)
+    fun runApplication(id: String, externalPort: Int)
 
-    fun runApplication(application: Application)
+    fun runApplication(application: Application, externalPort: Int)
 
-    fun runApplication(id: String, version: String)
+    fun runApplication(id: String, version: String, externalPort: Int)
 
-    fun runApplication(application: Application, version: String)
+    fun runApplication(application: Application, version: String, externalPort: Int)
 
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/GetExternalPortService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/GetExternalPortService.kt
@@ -1,0 +1,6 @@
+package com.dcd.server.core.domain.application.service
+
+interface GetExternalPortService {
+    fun getExternalPort(port: Int): Int
+
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateDockerFileServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateDockerFileServiceImpl.kt
@@ -15,7 +15,7 @@ import java.io.IOException
 class CreateDockerFileServiceImpl(
     private val queryApplicationPort: QueryApplicationPort
 ) : CreateDockerFileService {
-    override fun createFileByApplicationId(id: String, version: String) {
+    override fun createFileByApplicationId(id: String, version: String, externalPort: Int) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
         when(application.applicationType){
@@ -23,7 +23,7 @@ class CreateDockerFileServiceImpl(
                 val name = application.name
                 try {
                     val file = File("./$name/Dockerfile")
-                    file.writeText(FileContent.getSpringBootDockerFileContent(name, version, application.port, application.env))
+                    file.writeText(FileContent.getSpringBootDockerFileContent(name, version, externalPort, application.env))
                         if (!file.createNewFile())
                             return
                 } catch (e: IOException) {
@@ -36,12 +36,12 @@ class CreateDockerFileServiceImpl(
         }
     }
 
-    override fun createFileToApplication(application: Application, version: String) {
+    override fun createFileToApplication(application: Application, version: String, externalPort: Int) {
         when(application.applicationType){
             ApplicationType.SPRING_BOOT -> {
                 val name = application.name
                 val file = File("./$name/Dockerfile")
-                file.writeText(FileContent.getSpringBootDockerFileContent(name, version, application.port, application.env))
+                file.writeText(FileContent.getSpringBootDockerFileContent(name, version, externalPort, application.env))
                 try {
                     if (!file.createNewFile())
                         return

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetExternalServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetExternalServiceImpl.kt
@@ -1,0 +1,18 @@
+package com.dcd.server.core.domain.application.service.impl
+
+import com.dcd.server.core.domain.application.service.ExistsPortService
+import com.dcd.server.core.domain.application.service.GetExternalPortService
+import org.springframework.stereotype.Service
+
+@Service
+class GetExternalServiceImpl(
+    private val existsPortService: ExistsPortService,
+) : GetExternalPortService {
+    override fun getExternalPort(port: Int): Int {
+        var externalPort = port
+        while (existsPortService.existsPort(externalPort)) {
+            externalPort += 1
+        }
+        return externalPort
+    }
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCase.kt
@@ -8,7 +8,7 @@ import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 
 @ReadOnlyUseCase
-class ApplicationRunUseCase(
+class RunApplicationUseCase(
     private val cloneApplicationByUrlService: CloneApplicationByUrlService,
     private val modifyGradleService: ModifyGradleService,
     private val createDockerFileService: CreateDockerFileService,

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.*
 @RequestMapping("/application")
 class ApplicationWebAdapter(
     private val createApplicationUseCase: CreateApplicationUseCase,
-    private val applicationRunUseCase: ApplicationRunUseCase,
+    private val runApplicationUseCase: RunApplicationUseCase,
     private val getAllApplicationUseCase: GetAllApplicationUseCase,
     private val getOneApplicationUseCase: GetOneApplicationUseCase,
     private val addApplicationEnvUseCase: AddApplicationEnvUseCase,
@@ -36,7 +36,7 @@ class ApplicationWebAdapter(
 
     @PostMapping("/{id}/run")
     fun runApplication(@PathVariable id: String): ResponseEntity<Void> =
-        applicationRunUseCase.execute(id)
+        runApplicationUseCase.execute(id)
             .run { ResponseEntity.ok().build() }
 
     @GetMapping

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/DockerRunServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/DockerRunServiceImplTest.kt
@@ -38,7 +38,7 @@ class DockerRunServiceImplTest : BehaviorSpec({
             every { queryApplicationPort.findById(appId) } returns application
             every { existsPortService.existsPort(application.port) } returns false
 
-            service.runApplication(appId)
+            service.runApplication(appId, application.port)
             then("commandPort가 실행되어야함") {
                 val externalPort = application.port
                 verify { commandPort.executeShellCommand("cd ${application.name} && docker run --network ${application.workspace.title.replace(' ', '_')} --name ${application.name.lowercase()} -d -p ${externalPort}:${application.port} ${application.name.lowercase()}:latest") }
@@ -51,7 +51,7 @@ class DockerRunServiceImplTest : BehaviorSpec({
 
         `when`("executeShellCommand 메서드를 실행할때") {
             every { existsPortService.existsPort(application.port) } returns false
-            service.runApplication(application)
+            service.runApplication(application, application.port)
 
             then("commandPort가 실행되어야함") {
                 val externalPort = application.port
@@ -75,7 +75,7 @@ class DockerRunServiceImplTest : BehaviorSpec({
 
         `when`("executeShellCommand 메서드를 실행할때") {
             every { existsPortService.existsPort(application.port) } returns false
-            service.runApplication(application)
+            service.runApplication(application, application.port)
 
             then("commandPort가 실행되어야함") {
                 val externalPort = application.port
@@ -101,7 +101,7 @@ class DockerRunServiceImplTest : BehaviorSpec({
 
         `when`("executeShellCommand 메서드를 실행할때") {
             every { existsPortService.existsPort(application.port) } returns false
-            service.runApplication(application)
+            service.runApplication(application, application.port)
 
             then("commandPort가 실행되어야함") {
                 val externalPort = application.port

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/ApplicationRunUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/ApplicationRunUseCaseTest.kt
@@ -24,7 +24,7 @@ class ApplicationRunUseCaseTest : BehaviorSpec({
     val dockerRunService = mockk<DockerRunService>(relaxUnitFun = true)
     val queryApplicationPort = mockk<QueryApplicationPort>(relaxUnitFun = true)
     val validateWorkspaceOwnerService = mockk<ValidateWorkspaceOwnerService>(relaxUnitFun = true)
-    val applicationRunUseCase = ApplicationRunUseCase(
+    val runApplicationUseCase = RunApplicationUseCase(
         cloneApplicationByUrlService,
         modifyGradleService,
         createDockerFileService,
@@ -56,7 +56,7 @@ class ApplicationRunUseCaseTest : BehaviorSpec({
         )
         `when`("usecase를 실행할때") {
             every { queryApplicationPort.findById("testId") } returns application
-            applicationRunUseCase.execute("testId")
+            runApplicationUseCase.execute("testId")
             then("애플리케이션 실행에 관한 service들이 실행되어야함") {
                 verify { cloneApplicationByUrlService.cloneByApplication(application) }
                 verify { validateWorkspaceOwnerService.validateOwner(workspace) }
@@ -71,7 +71,7 @@ class ApplicationRunUseCaseTest : BehaviorSpec({
             every { queryApplicationPort.findById("testId") } returns null
             then("ApplicationNotFoundException이 발생해야함") {
                 shouldThrow<ApplicationNotFoundException> {
-                    applicationRunUseCase.execute("testId")
+                    runApplicationUseCase.execute("testId")
                 }
             }
         }
@@ -93,7 +93,7 @@ class ApplicationRunUseCaseTest : BehaviorSpec({
         `when`("usecase를 실행하면") {
             every { queryApplicationPort.findById(application.id) } returns application
 
-            applicationRunUseCase.execute(application.id)
+            runApplicationUseCase.execute(application.id)
             then("dockerRunService만 실행되어야함") {
                 verify { dockerRunService.runApplication(application, application.version) }
                 shouldThrow<AssertionError> {
@@ -123,7 +123,7 @@ class ApplicationRunUseCaseTest : BehaviorSpec({
         `when`("usecase를 실행하면") {
             every { queryApplicationPort.findById(application.id) } returns application
 
-            applicationRunUseCase.execute(application.id)
+            runApplicationUseCase.execute(application.id)
             then("dockerRunService만 실행되어야함") {
                 verify { dockerRunService.runApplication(application, application.version) }
                 shouldThrow<AssertionError> {

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/ApplicationRunUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/ApplicationRunUseCaseTest.kt
@@ -24,6 +24,7 @@ class ApplicationRunUseCaseTest : BehaviorSpec({
     val dockerRunService = mockk<DockerRunService>(relaxUnitFun = true)
     val queryApplicationPort = mockk<QueryApplicationPort>(relaxUnitFun = true)
     val validateWorkspaceOwnerService = mockk<ValidateWorkspaceOwnerService>(relaxUnitFun = true)
+    val getExternalPortService = mockk<GetExternalPortService>(relaxed = true)
     val runApplicationUseCase = RunApplicationUseCase(
         cloneApplicationByUrlService,
         modifyGradleService,
@@ -31,7 +32,8 @@ class ApplicationRunUseCaseTest : BehaviorSpec({
         buildDockerImageService,
         dockerRunService,
         queryApplicationPort,
-        validateWorkspaceOwnerService
+        validateWorkspaceOwnerService,
+        getExternalPortService
     )
 
     val user =
@@ -61,9 +63,9 @@ class ApplicationRunUseCaseTest : BehaviorSpec({
                 verify { cloneApplicationByUrlService.cloneByApplication(application) }
                 verify { validateWorkspaceOwnerService.validateOwner(workspace) }
                 verify { modifyGradleService.modifyGradleByApplication(application) }
-                verify { createDockerFileService.createFileToApplication(application, application.version) }
+                verify { createDockerFileService.createFileToApplication(application, application.version, 0) }
                 verify { buildDockerImageService.buildImageByApplication(application) }
-                verify { dockerRunService.runApplication(application) }
+                verify { dockerRunService.runApplication(application, getExternalPortService.getExternalPort(application.port)) }
             }
         }
 
@@ -95,12 +97,12 @@ class ApplicationRunUseCaseTest : BehaviorSpec({
 
             runApplicationUseCase.execute(application.id)
             then("dockerRunService만 실행되어야함") {
-                verify { dockerRunService.runApplication(application, application.version) }
+                verify { dockerRunService.runApplication(application, application.version, getExternalPortService.getExternalPort(application.port)) }
                 shouldThrow<AssertionError> {
                     verify { cloneApplicationByUrlService.cloneByApplication(application) }
                     verify { validateWorkspaceOwnerService.validateOwner(workspace) }
                     verify { modifyGradleService.modifyGradleByApplication(application) }
-                    verify { createDockerFileService.createFileToApplication(application, application.version) }
+                    verify { createDockerFileService.createFileToApplication(application, application.version, 0) }
                     verify { buildDockerImageService.buildImageByApplication(application) }
                 }
             }
@@ -125,12 +127,12 @@ class ApplicationRunUseCaseTest : BehaviorSpec({
 
             runApplicationUseCase.execute(application.id)
             then("dockerRunService만 실행되어야함") {
-                verify { dockerRunService.runApplication(application, application.version) }
+                verify { dockerRunService.runApplication(application, application.version, getExternalPortService.getExternalPort(application.port)) }
                 shouldThrow<AssertionError> {
                     verify { cloneApplicationByUrlService.cloneByApplication(application) }
                     verify { validateWorkspaceOwnerService.validateOwner(workspace) }
                     verify { modifyGradleService.modifyGradleByApplication(application) }
-                    verify { createDockerFileService.createFileToApplication(application, application.version) }
+                    verify { createDockerFileService.createFileToApplication(application, application.version, 0) }
                     verify { buildDockerImageService.buildImageByApplication(application) }
                 }
             }

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -10,7 +10,6 @@ import com.dcd.server.presentation.domain.application.data.exetension.toResponse
 import com.dcd.server.presentation.domain.application.data.request.AddApplicationEnvRequest
 import com.dcd.server.presentation.domain.application.data.request.CreateApplicationRequest
 import com.dcd.server.presentation.domain.application.data.request.UpdateApplicationRequest
-import com.dcd.server.presentation.domain.application.data.response.AvailableVersionResponse
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -20,7 +19,7 @@ import org.springframework.http.HttpStatus
 
 class ApplicationWebAdapterTest : BehaviorSpec({
     val createApplicationUseCase = mockk<CreateApplicationUseCase>()
-    val springApplicationRunUseCase = mockk<ApplicationRunUseCase>()
+    val springRunApplicationUseCase = mockk<RunApplicationUseCase>()
     val getAllApplicationUseCase = mockk<GetAllApplicationUseCase>()
     val getOneApplicationUseCase = mockk<GetOneApplicationUseCase>()
     val addApplicationEnvUseCase = mockk<AddApplicationEnvUseCase>()
@@ -29,7 +28,7 @@ class ApplicationWebAdapterTest : BehaviorSpec({
     val deleteApplicationUseCase = mockk<DeleteApplicationUseCase>()
     val updateApplicationUseCase = mockk<UpdateApplicationUseCase>(relaxUnitFun = true)
     val getAvailableVersionUseCase = mockk<GetAvailableVersionUseCase>()
-    val applicationWebAdapter = ApplicationWebAdapter(createApplicationUseCase, springApplicationRunUseCase, getAllApplicationUseCase, getOneApplicationUseCase, addApplicationEnvUseCase, deleteApplicationEnvUseCase, stopApplicationUseCase, deleteApplicationUseCase, updateApplicationUseCase, getAvailableVersionUseCase)
+    val applicationWebAdapter = ApplicationWebAdapter(createApplicationUseCase, springRunApplicationUseCase, getAllApplicationUseCase, getOneApplicationUseCase, addApplicationEnvUseCase, deleteApplicationEnvUseCase, stopApplicationUseCase, deleteApplicationUseCase, updateApplicationUseCase, getAvailableVersionUseCase)
 
     given("CreateApplicationRequest가 주어지고") {
         val request = CreateApplicationRequest(
@@ -54,7 +53,7 @@ class ApplicationWebAdapterTest : BehaviorSpec({
     given("RunApplicationRequest가 주어지고") {
         val id = "testApplicationId"
         `when`("runApplication 메서드를 실행할때") {
-            every { springApplicationRunUseCase.execute(id) } returns Unit
+            every { springRunApplicationUseCase.execute(id) } returns Unit
             val result = applicationWebAdapter.runApplication(id)
             then("상태코드가 200이여야함") {
                 result.statusCode shouldBe HttpStatus.OK


### PR DESCRIPTION
## 🔖 개요
* 애플리케이션 실행 로직을 리펙토링합니다.

## 📜 작업내용
* ApplicationRunUseCase의 네이밍을 컨벤션에 맞춰 RunApplicationUseCase로 수정
* 사용 가능한 외부 포트를 가져오는 서비스인 GetExternalPortService를 추가
* CreateDockerFileService에서 매개변수로 받는 외부 포트를 공개하도록 변경
* DockerRunService에서 외부 포트를 매개변수로 받게끔 수정
* RunApplicationUseCase의 애플리케이션 실행 로직을 수정사항에 맞게끔 리펙토링
* 수정사항에 따른 테스트 코드 수정