### PR TITLE
🔀 :: 161 - ssl 인증서를 발급해주는 서비스 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/GenerateSSLCertificateService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/GenerateSSLCertificateService.kt
@@ -3,4 +3,6 @@ package com.dcd.server.core.domain.application.service
 interface GenerateSSLCertificateService {
 
     fun generateSSL(domain: String)
+
+    fun generateSSL(domain: String, email: String)
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/GenerateSSLCertificateService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/GenerateSSLCertificateService.kt
@@ -1,0 +1,6 @@
+package com.dcd.server.core.domain.application.service
+
+interface GenerateSSLCertificateService {
+
+    fun generateSSL(domain: String)
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GenerateSSLCertificateServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GenerateSSLCertificateServiceImpl.kt
@@ -22,4 +22,16 @@ class GenerateSSLCertificateServiceImpl(
             "-d $domain"
         )
     }
+
+    override fun generateSSL(domain: String, email: String) {
+        commandPort.executeShellCommand(
+            "certbot certonly " +
+            "--webroot " +
+            "--webroot-path=/var/www/certbot" +
+            "--email ${email} " +
+            "--agree-tos " +
+            "--no-eff-email " +
+            "-d $domain"
+        )
+    }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GenerateSSLCertificateServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GenerateSSLCertificateServiceImpl.kt
@@ -1,0 +1,25 @@
+package com.dcd.server.core.domain.application.service.impl
+
+import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.domain.application.service.GenerateSSLCertificateService
+import com.dcd.server.core.domain.user.service.GetCurrentUserService
+import org.springframework.stereotype.Service
+
+@Service
+class GenerateSSLCertificateServiceImpl(
+    private val commandPort: CommandPort,
+    private val getCurrentUserService: GetCurrentUserService
+) : GenerateSSLCertificateService {
+    override fun generateSSL(domain: String) {
+        val user = getCurrentUserService.getCurrentUser()
+        commandPort.executeShellCommand(
+            "certbot certonly " +
+            "--webroot " +
+            "--webroot-path=/var/www/certbot" +
+            "--email ${user.email} " +
+            "--agree-tos " +
+            "--no-eff-email " +
+            "-d $domain"
+        )
+    }
+}


### PR DESCRIPTION
## 🔖 개요
* 애플리케이션에 https를 적용하기 위해서 certbot을 사용해서 ssl인증서를 발급하는 서비스 추가

## 📜 작업내용
* GenerateSSLCertificateService 추가

## 📖 사용방법
* domain을 매개변수로 메서드 호출
* domain, email을 매개변수로 메서드 호출