### PR TITLE
🔀 :: 163 - 발급된 인증서를 애플리케이션에 넣는 로직 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/properties/ApplicationSSLProperty.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/properties/ApplicationSSLProperty.kt
@@ -1,0 +1,8 @@
+package com.dcd.server.core.domain.application.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties("application.ssl")
+class ApplicationSSLProperty(
+    val directory: String
+)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/PutSSLCertificateService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/PutSSLCertificateService.kt
@@ -1,0 +1,7 @@
+package com.dcd.server.core.domain.application.service
+
+import com.dcd.server.core.domain.application.model.Application
+
+interface PutSSLCertificateService {
+    fun putSSLCertificate(domain: String, application: Application)
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/PutSSLCertificateServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/PutSSLCertificateServiceImpl.kt
@@ -1,0 +1,18 @@
+package com.dcd.server.core.domain.application.service.impl
+
+import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.properties.ApplicationSSLProperty
+import com.dcd.server.core.domain.application.service.PutSSLCertificateService
+import org.springframework.stereotype.Service
+
+@Service
+class PutSSLCertificateServiceImpl(
+    private val commandPort: CommandPort,
+    private val applicationSSLProperty: ApplicationSSLProperty
+) : PutSSLCertificateService {
+    override fun putSSLCertificate(domain: String, application: Application) {
+        val directory = applicationSSLProperty.directory + domain
+        commandPort.executeShellCommand("openssl pkcs12 -export -in $directory/fullchain.pem -inkey $directory/privkey -out ${application.name}/src/main/resources/${application.name}.p12 -name tomcat -CAfile $directory/chain.pem -caname root")
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,5 +34,8 @@ jwt:
   time:
     accessTime: ${JWT_ACCESS_TIME}
     refreshTime: ${JWT_REFRESH_TIME}
+application:
+  ssl:
+    directory: ${CERTIFICATE_DIRECTORY}
 server:
   port: 8081


### PR DESCRIPTION
## 🔖 개요
* 발급된 ssl 인증서를 애플리케이션에 넣는 로직 추가

## 📜 작업내용
* yml에 ssl 인증서가 저장되는 경로 추가
* ApplicationSSLProperty 추가
* PutSSLCertificateService 추가

## 🎸 기타
* PutSSLCertificateService에서 application 재실행 시킬지 따로 메서드를 호출할지 고민해봐야 될듯