### PR TITLE
🔀 :: 165 - ssl 인증서 발급후 애플리케이션 재실행 로직 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
@@ -30,6 +30,11 @@ object FileContent {
         "\t\tkey-store-type: PKC12\n" +
         "\t\tkey-store-password: $password"
 
+    fun getSSLPropertyFileContent(name: String, password: String): String =
+        "server.ssl.key-store=classpath:${name}.p12\n" +
+        "server.ssl.key-store-type: PKC12\n" +
+        "server.ssl.key-store-password: $password"
+
     private fun getEnvString(env: Map<String, String>): String {
         val envString = StringBuilder()
         for (it in env) {

--- a/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
@@ -23,6 +23,13 @@ object FileContent {
         "\tarchiveFileName = '$name.jar'\n" +
         "}"
 
+    fun getSSLYmlFileContent(name: String, password: String): String =
+        "server:" +
+        "\tssl:" +
+        "\t\tkey-store: classpath:${name}.p12" +
+        "\t\tkey-store-type: PKC12" +
+        "\t\tkey-store-password: $password"
+
     private fun getEnvString(env: Map<String, String>): String {
         val envString = StringBuilder()
         for (it in env) {

--- a/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
@@ -24,10 +24,10 @@ object FileContent {
         "}"
 
     fun getSSLYmlFileContent(name: String, password: String): String =
-        "server:" +
-        "\tssl:" +
-        "\t\tkey-store: classpath:${name}.p12" +
-        "\t\tkey-store-type: PKC12" +
+        "server:\n" +
+        "\tssl:\n" +
+        "\t\tkey-store: classpath:${name}.p12\n" +
+        "\t\tkey-store-type: PKC12\n" +
         "\t\tkey-store-password: $password"
 
     private fun getEnvString(env: Map<String, String>): String {

--- a/src/main/kotlin/com/dcd/server/core/domain/application/properties/ApplicationSSLProperty.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/properties/ApplicationSSLProperty.kt
@@ -4,5 +4,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties("application.ssl")
 class ApplicationSSLProperty(
-    val directory: String
+    val directory: String,
+    val password: String
 )

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/PutSSLCertificateService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/PutSSLCertificateService.kt
@@ -3,5 +3,5 @@ package com.dcd.server.core.domain.application.service
 import com.dcd.server.core.domain.application.model.Application
 
 interface PutSSLCertificateService {
-    fun putSSLCertificate(domain: String, application: Application)
+    fun putSSLCertificate(domain: String, externalPort: Int, application: Application)
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteContainerServiceImpl.kt
@@ -10,7 +10,7 @@ class DeleteContainerServiceImpl(
     private val commandPort: CommandPort
 ) : DeleteContainerService {
     override fun deleteContainer(application: Application) {
-        val name = application.name
+        val name = application.name.lowercase()
         commandPort.executeShellCommand("docker stop $name && docker rm $name")
     }
 

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/PutSSLCertificateServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/PutSSLCertificateServiceImpl.kt
@@ -1,18 +1,56 @@
 package com.dcd.server.core.domain.application.service.impl
 
 import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.common.file.FileContent
 import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.properties.ApplicationSSLProperty
 import com.dcd.server.core.domain.application.service.PutSSLCertificateService
 import org.springframework.stereotype.Service
+import java.io.BufferedWriter
+import java.io.File
+import java.io.FileWriter
 
 @Service
 class PutSSLCertificateServiceImpl(
     private val commandPort: CommandPort,
     private val applicationSSLProperty: ApplicationSSLProperty
 ) : PutSSLCertificateService {
-    override fun putSSLCertificate(domain: String, application: Application) {
+    override fun putSSLCertificate(domain: String, externalPort: Int, application: Application) {
         val directory = applicationSSLProperty.directory + domain
-        commandPort.executeShellCommand("openssl pkcs12 -export -in $directory/fullchain.pem -inkey $directory/privkey -out ${application.name}/src/main/resources/${application.name}.p12 -name tomcat -CAfile $directory/chain.pem -caname root")
+        val name = application.name
+        commandPort.executeShellCommand("openssl pkcs12 -export -in $directory/fullchain.pem -inkey $directory/privkey -out $name/src/main/resources/$name.p12 -name tomcat -CAfile $directory/chain.pem -caname root")
+        commandPort.executeShellCommand("docker stop ${name.lowercase()}")
+        when(application.applicationType) {
+            ApplicationType.SPRING_BOOT -> {
+                val propertyPath = "./$name/src/main/resources/"
+                if (File("${propertyPath}application.yml").exists()) {
+                    val propertyFile = propertyPath + "application.yml"
+                    FileWriter(propertyFile, true).use { fileWriter ->
+                        BufferedWriter(fileWriter).use {
+                            it.write("${FileContent.getSSLYmlFileContent(name, "")}")
+                            it.newLine()
+                            it.close()
+                        }
+                    }
+                }
+                else {
+                    val propertyFile = propertyPath + "application.properties"
+                    FileWriter(propertyFile, true).use { fileWriter ->
+                        BufferedWriter(fileWriter).use {
+                            it.write("${FileContent.getSSLPropertyFileContent(name, "")}")
+                            it.newLine()
+                            it.close()
+                        }
+                    }
+                }
+                commandPort.executeShellCommand(
+                    "cd ${application.name} " +
+                    "&& docker run --network ${application.workspace.title.replace(' ', '_')} " +
+                    "--name ${application.name.lowercase()} -d " +
+                    "-p ${externalPort}:${application.port} ${application.name.lowercase()}")
+            }
+            else -> {}
+        }
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,5 +37,6 @@ jwt:
 application:
   ssl:
     directory: ${CERTIFICATE_DIRECTORY}
+    password: ${CERTIFICATE_PASSWORD}
 server:
   port: 8081

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/DeleteContainerServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/DeleteContainerServiceImplTest.kt
@@ -31,7 +31,7 @@ class DeleteContainerServiceImplTest : BehaviorSpec({
             service.deleteContainer(application)
 
             then("commandPort가 실행되어야함") {
-                verify { commandPort.executeShellCommand("docker stop ${application.name} && docker rm ${application.name}") }
+                verify { commandPort.executeShellCommand("docker stop ${application.name.lowercase()} && docker rm ${application.name.lowercase()}") }
             }
         }
     }


### PR DESCRIPTION
## 🔖 개요
* PutSSLCertificateService에서 ssl인증서를 애플리케이션에 넣고, 애플리케이션을 재실행 하도록 기능을 추가

## 📜 작업내용
* FileContent에 yml파일의 ssl 설정을 위한 파일 내용추가
* FileContent에 properties파일의 ssl 설정을 위한 파일 내용추가
* ApplicationSSLProperty에 password 필드 추가
* Application 재실행 로직을 PutSSLCertificateService에 추가

## 🔀 변경사항
* 컨테이너 삭제시 application 이름의 lowercase로 실행하도록 변경
* 위의 변경사항에 따른 테스트 검증 수정