### PR TITLE
🔀  :: 167 - 애플리케이션에 도메인을 적용시켜서 ssl 인증서를 발급하는 API

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/request/GenerateSSLCertificateReqDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/request/GenerateSSLCertificateReqDto.kt
@@ -1,0 +1,5 @@
+package com.dcd.server.core.domain.application.dto.request
+
+data class GenerateSSLCertificateReqDto(
+    val domain: String
+)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/PutSSLCertificateServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/PutSSLCertificateServiceImpl.kt
@@ -28,7 +28,7 @@ class PutSSLCertificateServiceImpl(
                     val propertyFile = propertyPath + "application.yml"
                     FileWriter(propertyFile, true).use { fileWriter ->
                         BufferedWriter(fileWriter).use {
-                            it.write("${FileContent.getSSLYmlFileContent(name, "")}")
+                            it.write("${FileContent.getSSLYmlFileContent(name, applicationSSLProperty.password)}")
                             it.newLine()
                             it.close()
                         }
@@ -38,7 +38,7 @@ class PutSSLCertificateServiceImpl(
                     val propertyFile = propertyPath + "application.properties"
                     FileWriter(propertyFile, true).use { fileWriter ->
                         BufferedWriter(fileWriter).use {
-                            it.write("${FileContent.getSSLPropertyFileContent(name, "")}")
+                            it.write("${FileContent.getSSLPropertyFileContent(name, applicationSSLProperty.password)}")
                             it.newLine()
                             it.close()
                         }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GenerateSSLCertificateUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GenerateSSLCertificateUseCase.kt
@@ -1,0 +1,26 @@
+package com.dcd.server.core.domain.application.usecase
+
+import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.domain.application.dto.request.GenerateSSLCertificateReqDto
+import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
+import com.dcd.server.core.domain.application.service.GenerateSSLCertificateService
+import com.dcd.server.core.domain.application.service.GetExternalPortService
+import com.dcd.server.core.domain.application.service.PutSSLCertificateService
+import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+
+@UseCase
+class GenerateSSLCertificateUseCase(
+    private val queryApplicationPort: QueryApplicationPort,
+    private val generateSSLCertificateService: GenerateSSLCertificateService,
+    private val putSSLCertificateService: PutSSLCertificateService,
+    private val getExternalPortService: GetExternalPortService
+) {
+    fun execute(id: String, generateSSLCertificateReqDto: GenerateSSLCertificateReqDto) {
+        val application = (queryApplicationPort.findById(id)
+            ?: throw ApplicationNotFoundException())
+        val domain = generateSSLCertificateReqDto.domain
+        val externalPort = getExternalPortService.getExternalPort(application.port)
+        generateSSLCertificateService.generateSSL(domain)
+        putSSLCertificateService.putSSLCertificate(domain, externalPort, application)
+    }
+}

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
@@ -61,6 +61,7 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.DELETE, "/application/{id}").authenticated()
                 it.requestMatchers(HttpMethod.PATCH, "/application/{id}").authenticated()
                 it.requestMatchers(HttpMethod.GET, "/application/version/{applicationType}").authenticated()
+                it.requestMatchers(HttpMethod.POST, "/application/{id}/certificate").authenticated()
 
                 //workspace
                 it.requestMatchers(HttpMethod.POST, "/workspace").authenticated()

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
@@ -6,6 +6,7 @@ import com.dcd.server.presentation.domain.application.data.exetension.toDto
 import com.dcd.server.presentation.domain.application.data.exetension.toResponse
 import com.dcd.server.presentation.domain.application.data.request.AddApplicationEnvRequest
 import com.dcd.server.presentation.domain.application.data.request.CreateApplicationRequest
+import com.dcd.server.presentation.domain.application.data.request.GenerateSSLCertificateRequest
 import com.dcd.server.presentation.domain.application.data.request.UpdateApplicationRequest
 import com.dcd.server.presentation.domain.application.data.response.ApplicationListResponse
 import com.dcd.server.presentation.domain.application.data.response.ApplicationResponse
@@ -27,7 +28,8 @@ class ApplicationWebAdapter(
     private val stopApplicationUseCase: StopApplicationUseCase,
     private val deleteApplicationUseCase: DeleteApplicationUseCase,
     private val updateApplicationUseCase: UpdateApplicationUseCase,
-    private val getAvailableVersionUseCase: GetAvailableVersionUseCase
+    private val getAvailableVersionUseCase: GetAvailableVersionUseCase,
+    private val generateSSLCertificateUseCase: GenerateSSLCertificateUseCase
 ) {
     @PostMapping("/{workspaceId}")
     fun createApplication(@PathVariable workspaceId: String, @Validated @RequestBody createApplicationRequest: CreateApplicationRequest): ResponseEntity<Void> =
@@ -78,4 +80,9 @@ class ApplicationWebAdapter(
     fun getAvailableVersion(@PathVariable applicationType: ApplicationType): ResponseEntity<AvailableVersionResponse> =
         getAvailableVersionUseCase.execute(applicationType)
             .let { ResponseEntity.ok(it.toResponse()) }
+
+    @PostMapping("/{id}/certificate")
+    fun generateSSLCertificate(@PathVariable id: String, @RequestBody generateSSLCertificateRequest: GenerateSSLCertificateRequest): ResponseEntity<Void> =
+        generateSSLCertificateUseCase.execute(id, generateSSLCertificateRequest.toDto())
+            .run { ResponseEntity.ok().build() }
 }

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationRequestDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationRequestDataExtension.kt
@@ -2,9 +2,11 @@ package com.dcd.server.presentation.domain.application.data.exetension
 
 import com.dcd.server.core.domain.application.dto.request.AddApplicationEnvReqDto
 import com.dcd.server.core.domain.application.dto.request.CreateApplicationReqDto
+import com.dcd.server.core.domain.application.dto.request.GenerateSSLCertificateReqDto
 import com.dcd.server.core.domain.application.dto.request.UpdateApplicationReqDto
 import com.dcd.server.presentation.domain.application.data.request.AddApplicationEnvRequest
 import com.dcd.server.presentation.domain.application.data.request.CreateApplicationRequest
+import com.dcd.server.presentation.domain.application.data.request.GenerateSSLCertificateRequest
 import com.dcd.server.presentation.domain.application.data.request.UpdateApplicationRequest
 
 fun AddApplicationEnvRequest.toDto(): AddApplicationEnvReqDto =
@@ -28,4 +30,9 @@ fun UpdateApplicationRequest.toDto(): UpdateApplicationReqDto =
         name = this.name,
         description = this.description,
         version = this.version
+    )
+
+fun GenerateSSLCertificateRequest.toDto(): GenerateSSLCertificateReqDto =
+    GenerateSSLCertificateReqDto(
+        domain = this.domain
     )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/request/GenerateSSLCertificateRequest.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/request/GenerateSSLCertificateRequest.kt
@@ -1,0 +1,5 @@
+package com.dcd.server.presentation.domain.application.data.request
+
+data class GenerateSSLCertificateRequest(
+    val domain: String
+)

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -28,7 +28,8 @@ class ApplicationWebAdapterTest : BehaviorSpec({
     val deleteApplicationUseCase = mockk<DeleteApplicationUseCase>()
     val updateApplicationUseCase = mockk<UpdateApplicationUseCase>(relaxUnitFun = true)
     val getAvailableVersionUseCase = mockk<GetAvailableVersionUseCase>()
-    val applicationWebAdapter = ApplicationWebAdapter(createApplicationUseCase, springRunApplicationUseCase, getAllApplicationUseCase, getOneApplicationUseCase, addApplicationEnvUseCase, deleteApplicationEnvUseCase, stopApplicationUseCase, deleteApplicationUseCase, updateApplicationUseCase, getAvailableVersionUseCase)
+    val generateSSLCertificateUseCase = mockk<GenerateSSLCertificateUseCase>(relaxUnitFun = true)
+    val applicationWebAdapter = ApplicationWebAdapter(createApplicationUseCase, springRunApplicationUseCase, getAllApplicationUseCase, getOneApplicationUseCase, addApplicationEnvUseCase, deleteApplicationEnvUseCase, stopApplicationUseCase, deleteApplicationUseCase, updateApplicationUseCase, getAvailableVersionUseCase, generateSSLCertificateUseCase)
 
     given("CreateApplicationRequest가 주어지고") {
         val request = CreateApplicationRequest(


### PR DESCRIPTION
## 🔖 개요
* ssl 인증서를 발급후 적용하는 API추가

## 📜 작업내용
* GenerateSSLCertificateRequest 관련 객체 추가
* GenerateSSLCertificateUseCase 추가
* ssl 발급 엔드포인트 추가
* ssl 발급 엔드포인트에 권한 설정 추가
* ApplicationWebAdapter의 테스트 코드에 adapter의 매개변수로 GenerateSSLCertificateUseCase를 추가

## 🔀 변경사항
* PutSSLService에서 SSLProperty의 password 필드를 사용해서 password를 지정하도록 변경