### PR TITLE
🔀  :: 169 - 애플리케이션 ssl 인증서 발급 API 테스트 코드

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GenerateSSLCertificateUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GenerateSSLCertificateUseCase.kt
@@ -7,10 +7,13 @@ import com.dcd.server.core.domain.application.service.GenerateSSLCertificateServ
 import com.dcd.server.core.domain.application.service.GetExternalPortService
 import com.dcd.server.core.domain.application.service.PutSSLCertificateService
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import com.dcd.server.core.domain.user.service.GetCurrentUserService
+import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameException
 
 @UseCase
 class GenerateSSLCertificateUseCase(
     private val queryApplicationPort: QueryApplicationPort,
+    private val getCurrentUserService: GetCurrentUserService,
     private val generateSSLCertificateService: GenerateSSLCertificateService,
     private val putSSLCertificateService: PutSSLCertificateService,
     private val getExternalPortService: GetExternalPortService
@@ -18,6 +21,9 @@ class GenerateSSLCertificateUseCase(
     fun execute(id: String, generateSSLCertificateReqDto: GenerateSSLCertificateReqDto) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
+        val currentUser = getCurrentUserService.getCurrentUser()
+        if (currentUser.equals(application.workspace.owner).not())
+            throw WorkspaceOwnerNotSameException()
         val domain = generateSSLCertificateReqDto.domain
         val externalPort = getExternalPortService.getExternalPort(application.port)
         generateSSLCertificateService.generateSSL(domain)

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GenerateSSLCertificateUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GenerateSSLCertificateUseCaseTest.kt
@@ -1,0 +1,74 @@
+package com.dcd.server.core.domain.application.usecase
+
+import com.dcd.server.core.domain.application.dto.request.GenerateSSLCertificateReqDto
+import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.enums.ApplicationType
+import com.dcd.server.core.domain.application.service.GenerateSSLCertificateService
+import com.dcd.server.core.domain.application.service.GetExternalPortService
+import com.dcd.server.core.domain.application.service.PutSSLCertificateService
+import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import com.dcd.server.core.domain.auth.model.Role
+import com.dcd.server.core.domain.user.model.User
+import com.dcd.server.core.domain.workspace.model.Workspace
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.*
+
+class GenerateSSLCertificateUseCaseTest : BehaviorSpec({
+    val queryApplicationPort = mockk<QueryApplicationPort>()
+    val generateSSLCertificateService = mockk<GenerateSSLCertificateService>(relaxUnitFun = true)
+    val putSSLCertificateService = mockk<PutSSLCertificateService>(relaxUnitFun = true)
+    val getExternalPortService = mockk<GetExternalPortService>(relaxed = true)
+    val generateSSLCertificateUseCase = GenerateSSLCertificateUseCase(
+        queryApplicationPort,
+        generateSSLCertificateService,
+        putSSLCertificateService,
+        getExternalPortService
+    )
+
+    given("application id, GenerateSSLCertificateReqDto가 주어지고") {
+        val applicationId = UUID.randomUUID().toString()
+        val reqDto = GenerateSSLCertificateReqDto(domain = "dcd-server.dolong.co.kr")
+
+        `when`("usecase를 실행하면") {
+            val user =
+                User(email = "email", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
+            val workspace = Workspace(
+                UUID.randomUUID().toString(),
+                title = "test workspace",
+                description = "test workspace description",
+                owner = user
+            )
+            val application = Application(
+                id = "testId",
+                name = "test",
+                description = "test",
+                applicationType = ApplicationType.SPRING_BOOT,
+                env = mapOf(),
+                githubUrl = "testUrl",
+                workspace = workspace,
+                port = 8080,
+                version = "17"
+            )
+            every { queryApplicationPort.findById(applicationId) } returns application
+
+            generateSSLCertificateUseCase.execute(applicationId, reqDto)
+
+            then("ssl 인증서를 발급하고, 애플리케이션에 적용해야함") {
+                verify { generateSSLCertificateService.generateSSL(reqDto.domain) }
+                verify { putSSLCertificateService.putSSLCertificate(reqDto.domain, getExternalPortService.getExternalPort(application.port), application) }
+            }
+
+            then("주어진 id로 애플리케이션을 조회해야함") {
+                verify { queryApplicationPort.findById(applicationId) }
+            }
+
+            then("외부 포트중에 사용할 수 있는 포트를 조회해야함") {
+                verify { getExternalPortService.getExternalPort(application.port) }
+            }
+        }
+    }
+
+})

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GenerateSSLCertificateUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GenerateSSLCertificateUseCaseTest.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.domain.application.dto.request.GenerateSSLCertificateReqDto
+import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.GenerateSSLCertificateService
@@ -10,6 +11,7 @@ import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.auth.model.Role
 import com.dcd.server.core.domain.user.model.User
 import com.dcd.server.core.domain.workspace.model.Workspace
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.every
 import io.mockk.mockk
@@ -67,6 +69,16 @@ class GenerateSSLCertificateUseCaseTest : BehaviorSpec({
 
             then("외부 포트중에 사용할 수 있는 포트를 조회해야함") {
                 verify { getExternalPortService.getExternalPort(application.port) }
+            }
+        }
+
+        `when`("해당 id를 가진 애플리케이션이 없을때") {
+            every { queryApplicationPort.findById(applicationId) } returns null
+
+            then("ApplicationNotFoundException이 발생해야함") {
+                shouldThrow<ApplicationNotFoundException> {
+                    generateSSLCertificateUseCase.execute(applicationId, reqDto)
+                }
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.presentation.domain.application
 
+import com.dcd.server.core.domain.application.dto.request.GenerateSSLCertificateReqDto
 import com.dcd.server.core.domain.application.dto.request.UpdateApplicationReqDto
 import com.dcd.server.core.domain.application.dto.response.ApplicationListResDto
 import com.dcd.server.core.domain.application.dto.response.ApplicationResDto
@@ -9,6 +10,7 @@ import com.dcd.server.core.domain.application.usecase.*
 import com.dcd.server.presentation.domain.application.data.exetension.toResponse
 import com.dcd.server.presentation.domain.application.data.request.AddApplicationEnvRequest
 import com.dcd.server.presentation.domain.application.data.request.CreateApplicationRequest
+import com.dcd.server.presentation.domain.application.data.request.GenerateSSLCertificateRequest
 import com.dcd.server.presentation.domain.application.data.request.UpdateApplicationRequest
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -178,6 +180,22 @@ class ApplicationWebAdapterTest : BehaviorSpec({
             val result = applicationWebAdapter.getAvailableVersion(applicationType)
             then("result의 바디는 availableVersionResDto랑 같아야함") {
                 result.body?.version shouldBe availableVersionResDto.version
+            }
+            then("result는 200 상태코드를 가져야함") {
+                result.statusCode shouldBe HttpStatus.OK
+            }
+        }
+    }
+
+    given("애플리케이션 id와 GenerateSSLCertificateRequest가 주어지고") {
+        val testId ="testId"
+        val request = GenerateSSLCertificateRequest("test.domain.com")
+
+        `when`("generateSSLCertificate 메서드를 실행할때") {
+            val result = applicationWebAdapter.generateSSLCertificate(testId, request)
+
+            then("GenerateSSLCertificateUseCase를 실행해야함") {
+                verify { generateSSLCertificateUseCase.execute(testId, any() as GenerateSSLCertificateReqDto) }
             }
             then("result는 200 상태코드를 가져야함") {
                 result.statusCode shouldBe HttpStatus.OK


### PR DESCRIPTION
## 🔖 개요
* ssl 인증서 발급 API의 테스트 코드를 작성합니다.

## 📜 작업내용
* GenerateSSLCertificateUseCase가 정상적으로 실행되는 테스트 케이스
* 매개변수로 받은 id를 가진 애플리케이션이 존재하지 않는 테스트 케이스
* 현재 로그인된 유저가 해당 workspace에 권한을 가지고 있지 않은 테스트 케이스
* 엔드포인트 테스트 코드 추가

## 🔀 변경사항
* GenerateSSLCertificateUseCase에 유저를 검증하는 로직 추가