### PR TITLE
🔀  :: 171 - 애플리케이션 수정 API 리펙토링

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/request/UpdateApplicationReqDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/request/UpdateApplicationReqDto.kt
@@ -1,7 +1,12 @@
 package com.dcd.server.core.domain.application.dto.request
 
+import com.dcd.server.core.domain.application.model.enums.ApplicationType
+
 data class UpdateApplicationReqDto(
     val name: String,
     val description: String?,
-    val version: String
+    val applicationType: ApplicationType,
+    val githubUrl: String?,
+    val version: String,
+    val port: Int
 )

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCase.kt
@@ -26,7 +26,10 @@ class UpdateApplicationUseCase(
             application.copy(
                 name = updateApplicationReqDto.name,
                 description = updateApplicationReqDto.description,
-                version = updateApplicationReqDto.version
+                applicationType = updateApplicationReqDto.applicationType,
+                githubUrl = updateApplicationReqDto.githubUrl,
+                version = updateApplicationReqDto.version,
+                port = updateApplicationReqDto.port
             )
         commandApplicationPort.save(updatedApplication)
     }

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationRequestDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationRequestDataExtension.kt
@@ -29,7 +29,10 @@ fun UpdateApplicationRequest.toDto(): UpdateApplicationReqDto =
     UpdateApplicationReqDto(
         name = this.name,
         description = this.description,
-        version = this.version
+        applicationType = this.applicationType,
+        githubUrl = this.githubUrl,
+        version = this.version,
+        port = this.port
     )
 
 fun GenerateSSLCertificateRequest.toDto(): GenerateSSLCertificateReqDto =

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/request/UpdateApplicationRequest.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/request/UpdateApplicationRequest.kt
@@ -1,7 +1,12 @@
 package com.dcd.server.presentation.domain.application.data.request
 
+import com.dcd.server.core.domain.application.model.enums.ApplicationType
+
 data class UpdateApplicationRequest(
     val name: String,
     val description: String?,
-    val version: String
+    val applicationType: ApplicationType,
+    val githubUrl: String?,
+    val version: String,
+    val port: Int
 )

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCaseTest.kt
@@ -35,7 +35,7 @@ class UpdateApplicationUseCaseTest : BehaviorSpec({
         owner = user
     )
     val applicationId = "testId"
-    val updateReqDto = UpdateApplicationReqDto(name = "updated application", description = "dldl", version = "11")
+    val updateReqDto = UpdateApplicationReqDto(name = "updated application", description = "dldl", applicationType = ApplicationType.SPRING_BOOT, githubUrl = null, version = "11", port = 8080)
 
     given("애플리케이션이 주어지고") {
         val application = Application(
@@ -57,7 +57,7 @@ class UpdateApplicationUseCaseTest : BehaviorSpec({
             updateApplicationUseCase.execute(applicationId, updateReqDto)
 
             then("ReqDto의 내용이 반영된 애플리케이션을 저장해야함") {
-                val updatedApplication = application.copy(name = updateReqDto.name, description = updateReqDto.description, version = updateReqDto.version)
+                val updatedApplication = application.copy(name = updateReqDto.name, description = updateReqDto.description, applicationType = updateReqDto.applicationType, githubUrl = updateReqDto.githubUrl, version = updateReqDto.version, port = updateReqDto.port)
                 verify { commandApplicationPort.save(updatedApplication) }
             }
         }

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -156,7 +156,7 @@ class ApplicationWebAdapterTest : BehaviorSpec({
 
     given("UpdateRequest가 주어지고") {
         val testId ="testId"
-        val request = UpdateApplicationRequest(name = "update", description = null, version = "11")
+        val request = UpdateApplicationRequest(name = "update", description = null, applicationType = ApplicationType.SPRING_BOOT, githubUrl = null, version = "11", port = 8080)
 
         `when`("updateApplication 메서드를 실행할때") {
             val result = applicationWebAdapter.updateApplication(testId, request)


### PR DESCRIPTION
## 🔖 개요
* 애플리케이션 수정 API에서 port, applicationType, githubUrl등을 수정할 수 있도록 리펙토링합니다.

## 📜 작업내용
* UpdateApplicationReqDto에 applicationType, githubUrl, port 필드 추가
* UpdateApplicationRequest에 applicationType, githubUrl, port 필드 추가
* UpdateApplicationUseCase의 copy를 Dto의 추가된 필드도 복사하도록 변경
* Request의 객체의 필드추가를 테스트 코드에 반영