### PR TITLE
🔀  :: 173 - 애플리케이션 작동후 어떤 포트에서 동작하는지 반환하게끔 수정

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/response/RunApplicationResDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/response/RunApplicationResDto.kt
@@ -1,0 +1,5 @@
+package com.dcd.server.core.domain.application.dto.response
+
+data class RunApplicationResDto(
+    val port: Int
+)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/response/RunApplicationResDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/response/RunApplicationResDto.kt
@@ -1,5 +1,5 @@
 package com.dcd.server.core.domain.application.dto.response
 
 data class RunApplicationResDto(
-    val port: Int
+    val externalPort: Int
 )

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCase.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.ReadOnlyUseCase
+import com.dcd.server.core.domain.application.dto.response.RunApplicationResDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.*
@@ -18,7 +19,7 @@ class RunApplicationUseCase(
     private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService,
     private val getExternalPortService: GetExternalPortService
 ) {
-    fun execute(id: String) {
+    fun execute(id: String): RunApplicationResDto {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
 
@@ -43,5 +44,7 @@ class RunApplicationUseCase(
                 dockerRunService.runApplication(application, version, externalPort)
             }
         }
+
+        return RunApplicationResDto(externalPort = externalPort)
     }
 }

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
@@ -11,6 +11,7 @@ import com.dcd.server.presentation.domain.application.data.request.UpdateApplica
 import com.dcd.server.presentation.domain.application.data.response.ApplicationListResponse
 import com.dcd.server.presentation.domain.application.data.response.ApplicationResponse
 import com.dcd.server.presentation.domain.application.data.response.AvailableVersionResponse
+import com.dcd.server.presentation.domain.application.data.response.RunApplicationResponse
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
@@ -37,9 +38,9 @@ class ApplicationWebAdapter(
             .run { ResponseEntity(HttpStatus.CREATED) }
 
     @PostMapping("/{id}/run")
-    fun runApplication(@PathVariable id: String): ResponseEntity<Void> =
+    fun runApplication(@PathVariable id: String): ResponseEntity<RunApplicationResponse> =
         runApplicationUseCase.execute(id)
-            .run { ResponseEntity.ok().build() }
+            .let { ResponseEntity.ok(it.toResponse()) }
 
     @GetMapping
     fun getAllApplication(@RequestParam workspaceId: String): ResponseEntity<ApplicationListResponse> =

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationResponseDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationResponseDataExtension.kt
@@ -1,13 +1,7 @@
 package com.dcd.server.presentation.domain.application.data.exetension
 
-import com.dcd.server.core.domain.application.dto.response.ApplicationListResDto
-import com.dcd.server.core.domain.application.dto.response.ApplicationProfileResDto
-import com.dcd.server.core.domain.application.dto.response.ApplicationResDto
-import com.dcd.server.core.domain.application.dto.response.AvailableVersionResDto
-import com.dcd.server.presentation.domain.application.data.response.ApplicationListResponse
-import com.dcd.server.presentation.domain.application.data.response.ApplicationProfileResponse
-import com.dcd.server.presentation.domain.application.data.response.ApplicationResponse
-import com.dcd.server.presentation.domain.application.data.response.AvailableVersionResponse
+import com.dcd.server.core.domain.application.dto.response.*
+import com.dcd.server.presentation.domain.application.data.response.*
 
 fun ApplicationResDto.toResponse(): ApplicationResponse =
     ApplicationResponse(
@@ -34,4 +28,9 @@ fun ApplicationProfileResDto.toResponse(): ApplicationProfileResponse =
 fun AvailableVersionResDto.toResponse(): AvailableVersionResponse =
     AvailableVersionResponse(
         version = this.version
+    )
+
+fun RunApplicationResDto.toResponse(): RunApplicationResponse =
+    RunApplicationResponse(
+        externalPort = this.externalPort
     )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/response/RunApplicationResponse.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/response/RunApplicationResponse.kt
@@ -1,0 +1,5 @@
+package com.dcd.server.presentation.domain.application.data.response
+
+data class RunApplicationResponse(
+    val externalPort: Int
+)

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/ApplicationRunUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/ApplicationRunUseCaseTest.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.core.domain.application.usecase
 
+import com.dcd.server.core.domain.application.dto.response.RunApplicationResDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
@@ -11,6 +12,7 @@ import com.dcd.server.core.domain.workspace.model.Workspace
 import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -58,7 +60,7 @@ class ApplicationRunUseCaseTest : BehaviorSpec({
         )
         `when`("usecase를 실행할때") {
             every { queryApplicationPort.findById("testId") } returns application
-            runApplicationUseCase.execute("testId")
+            val result = runApplicationUseCase.execute("testId")
             then("애플리케이션 실행에 관한 service들이 실행되어야함") {
                 verify { cloneApplicationByUrlService.cloneByApplication(application) }
                 verify { validateWorkspaceOwnerService.validateOwner(workspace) }
@@ -66,6 +68,9 @@ class ApplicationRunUseCaseTest : BehaviorSpec({
                 verify { createDockerFileService.createFileToApplication(application, application.version, 0) }
                 verify { buildDockerImageService.buildImageByApplication(application) }
                 verify { dockerRunService.runApplication(application, getExternalPortService.getExternalPort(application.port)) }
+            }
+            then("반환값은 이용가능한 외부 포트를 담아야함") {
+                result shouldBe RunApplicationResDto(getExternalPortService.getExternalPort(application.port))
             }
         }
 

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCaseTest.kt
@@ -18,7 +18,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import java.util.*
 
-class ApplicationRunUseCaseTest : BehaviorSpec({
+class RunApplicationUseCaseTest : BehaviorSpec({
     val cloneApplicationByUrlService = mockk<CloneApplicationByUrlService>(relaxUnitFun = true)
     val modifyGradleService = mockk<ModifyGradleService>(relaxUnitFun = true)
     val createDockerFileService = mockk<CreateDockerFileService>(relaxUnitFun = true)

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -5,6 +5,7 @@ import com.dcd.server.core.domain.application.dto.request.UpdateApplicationReqDt
 import com.dcd.server.core.domain.application.dto.response.ApplicationListResDto
 import com.dcd.server.core.domain.application.dto.response.ApplicationResDto
 import com.dcd.server.core.domain.application.dto.response.AvailableVersionResDto
+import com.dcd.server.core.domain.application.dto.response.RunApplicationResDto
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.usecase.*
 import com.dcd.server.presentation.domain.application.data.exetension.toResponse
@@ -12,6 +13,7 @@ import com.dcd.server.presentation.domain.application.data.request.AddApplicatio
 import com.dcd.server.presentation.domain.application.data.request.CreateApplicationRequest
 import com.dcd.server.presentation.domain.application.data.request.GenerateSSLCertificateRequest
 import com.dcd.server.presentation.domain.application.data.request.UpdateApplicationRequest
+import com.dcd.server.presentation.domain.application.data.response.RunApplicationResponse
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -56,10 +58,13 @@ class ApplicationWebAdapterTest : BehaviorSpec({
     given("RunApplicationRequest가 주어지고") {
         val id = "testApplicationId"
         `when`("runApplication 메서드를 실행할때") {
-            every { springRunApplicationUseCase.execute(id) } returns Unit
+            every { springRunApplicationUseCase.execute(id) } returns RunApplicationResDto(externalPort = 8080)
             val result = applicationWebAdapter.runApplication(id)
             then("상태코드가 200이여야함") {
                 result.statusCode shouldBe HttpStatus.OK
+            }
+            then("반환값은 RunApplicationResDto의 필드를 가져야함") {
+                result.body shouldBe RunApplicationResponse(8080)
             }
         }
     }


### PR DESCRIPTION
## 🔖 개요
* 애플리케이션을 동작시킨후 어떤 포트에서 동작하는지 반환

## 📜 작업내용
* 실행중인 포트를 담기위한 Response객체 추가
* RunApplicationUseCase에서 externalPort를 반환하는 로직 추가
* ApplicationWebAdapter의 runApplication 메서드에서 RunApplicationResponse를 반환하는 로직 추가
* ApplicationWebAdapter의 runApplication 테스트에서 runApplication 메서드의 반환값을 검증하는 로직 추가
* RunApplicationUseCaseTest에서 유스케이스의 반환값 검증 추가

## 🔀 변경사항
* ApplicationRunUseCaseTest의 네이밍을 RunApplicationUseCaseTest로 변경