### PR TITLE
🔀 :: 175 - mariadb 애플리케이션 타입 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/model/enums/ApplicationType.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/model/enums/ApplicationType.kt
@@ -3,5 +3,6 @@ package com.dcd.server.core.domain.application.model.enums
 enum class ApplicationType {
     SPRING_BOOT,
     MYSQL,
+    MARIA_DB,
     REDIS
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DockerRunServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DockerRunServiceImpl.kt
@@ -57,6 +57,15 @@ class DockerRunServiceImpl(
                 )
             }
 
+            ApplicationType.MARIA_DB -> {
+                commandPort.executeShellCommand(
+                    "docker run --network ${application.workspace.title.replace(' ', '_')} " +
+                    "-e MYSQL_ROOT_PASSWORD=${application.env["rootPassword"] ?: throw ApplicationEnvNotFoundException()} " +
+                    "--name ${application.name.lowercase()} -d " +
+                    "-p ${externalPort}:${application.port} mariadb:$version"
+                )
+            }
+
             ApplicationType.REDIS -> {
                 commandPort.executeShellCommand(
                     "docker run --network ${application.workspace.title.replace(' ', '_')} " +

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCase.kt
@@ -36,11 +36,7 @@ class RunApplicationUseCase(
                 dockerRunService.runApplication(application, externalPort)
             }
 
-            ApplicationType.MYSQL -> {
-                dockerRunService.runApplication(application, version, externalPort)
-            }
-
-            ApplicationType.REDIS -> {
+            else -> {
                 dockerRunService.runApplication(application, version, externalPort)
             }
         }


### PR DESCRIPTION
## 🔖 개요
* mariadb 애플리케이션 타입 추가

## 📜 작업내용
* EnumType으로 Maria_DB 추가
* DockerRunService에서 mariadb를 실행하는 로직 추가

## 🔀 변경사항
* RunApplicationUseCase에서 단순히 이미지만 실행하는 로직은 묶어서 실행하도록 else로 리펙토링