### PR TITLE
🔀 :: 177 - DB 개열 애플리케이션이 기본 데이터베이스를 생성할 수 있도록 변경

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/CreateDockerFileService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/CreateDockerFileService.kt
@@ -3,6 +3,6 @@ package com.dcd.server.core.domain.application.service
 import com.dcd.server.core.domain.application.model.Application
 
 interface CreateDockerFileService {
-    fun createFileByApplicationId(id: String, javaVersion: String, externalPort: Int)
-    fun createFileToApplication(application: Application, javaVersion: String, externalPort: Int)
+    fun createFileByApplicationId(id: String, version: String, externalPort: Int)
+    fun createFileToApplication(application: Application, version: String, externalPort: Int)
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DockerRunServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DockerRunServiceImpl.kt
@@ -61,6 +61,7 @@ class DockerRunServiceImpl(
                 commandPort.executeShellCommand(
                     "docker run --network ${application.workspace.title.replace(' ', '_')} " +
                     "-e MYSQL_ROOT_PASSWORD=${application.env["rootPassword"] ?: throw ApplicationEnvNotFoundException()} " +
+                    "-e MYSQL_DATABASE=${application.env["database"] ?: throw ApplicationEnvNotFoundException()} " +
                     "--name ${application.name.lowercase()} -d " +
                     "-p ${externalPort}:${application.port} mariadb:$version"
                 )

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DockerRunServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DockerRunServiceImpl.kt
@@ -49,24 +49,28 @@ class DockerRunServiceImpl(
             }
 
             ApplicationType.MYSQL -> {
+                val defaultDB =
+                    if (application.env.containsKey("database"))
+                        "-e MYSQL_DATABASE=${application.env["database"]} "
+                    else ""
                 commandPort.executeShellCommand(
                     "docker run --network ${application.workspace.title.replace(' ', '_')} " +
                     "-e MYSQL_ROOT_PASSWORD=${application.env["rootPassword"] ?: throw ApplicationEnvNotFoundException()} " +
-                    if (application.env.containsKey("database"))
-                        "-e MYSQL_DATABASE=${application.env["database"]} "
-                    else "" +
+                    defaultDB +
                     "--name ${application.name.lowercase()} -d " +
                     "-p ${externalPort}:${application.port} mysql:$version"
                 )
             }
 
             ApplicationType.MARIA_DB -> {
+                val defaultDB =
+                    if (application.env.containsKey("database"))
+                        "-e MYSQL_DATABASE=${application.env["database"]} "
+                    else ""
                 commandPort.executeShellCommand(
                     "docker run --network ${application.workspace.title.replace(' ', '_')} " +
                     "-e MYSQL_ROOT_PASSWORD=${application.env["rootPassword"] ?: throw ApplicationEnvNotFoundException()} " +
-                    if (application.env.containsKey("database"))
-                        "-e MYSQL_DATABASE=${application.env["database"]} "
-                    else "" +
+                    defaultDB +
                     "--name ${application.name.lowercase()} -d " +
                     "-p ${externalPort}:${application.port} mariadb:$version"
                 )

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DockerRunServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DockerRunServiceImpl.kt
@@ -52,6 +52,7 @@ class DockerRunServiceImpl(
                 commandPort.executeShellCommand(
                     "docker run --network ${application.workspace.title.replace(' ', '_')} " +
                     "-e MYSQL_ROOT_PASSWORD=${application.env["rootPassword"] ?: throw ApplicationEnvNotFoundException()} " +
+                    "-e MYSQL_DATABASE=${application.env["database"] ?: throw ApplicationEnvNotFoundException()} " +
                     "--name ${application.name.lowercase()} -d " +
                     "-p ${externalPort}:${application.port} mysql:$version"
                 )

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DockerRunServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DockerRunServiceImpl.kt
@@ -52,7 +52,9 @@ class DockerRunServiceImpl(
                 commandPort.executeShellCommand(
                     "docker run --network ${application.workspace.title.replace(' ', '_')} " +
                     "-e MYSQL_ROOT_PASSWORD=${application.env["rootPassword"] ?: throw ApplicationEnvNotFoundException()} " +
-                    "-e MYSQL_DATABASE=${application.env["database"] ?: throw ApplicationEnvNotFoundException()} " +
+                    if (application.env.containsKey("database"))
+                        "-e MYSQL_DATABASE=${application.env["database"]} "
+                    else "" +
                     "--name ${application.name.lowercase()} -d " +
                     "-p ${externalPort}:${application.port} mysql:$version"
                 )
@@ -62,7 +64,9 @@ class DockerRunServiceImpl(
                 commandPort.executeShellCommand(
                     "docker run --network ${application.workspace.title.replace(' ', '_')} " +
                     "-e MYSQL_ROOT_PASSWORD=${application.env["rootPassword"] ?: throw ApplicationEnvNotFoundException()} " +
-                    "-e MYSQL_DATABASE=${application.env["database"] ?: throw ApplicationEnvNotFoundException()} " +
+                    if (application.env.containsKey("database"))
+                        "-e MYSQL_DATABASE=${application.env["database"]} "
+                    else "" +
                     "--name ${application.name.lowercase()} -d " +
                     "-p ${externalPort}:${application.port} mariadb:$version"
                 )

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/DockerRunServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/DockerRunServiceImplTest.kt
@@ -67,7 +67,7 @@ class DockerRunServiceImplTest : BehaviorSpec({
             null,
             ApplicationType.MYSQL,
             "testUrl",
-            mapOf( Pair("rootPassword", "testMysqlPassword") ),
+            mapOf( Pair("rootPassword", "testMysqlPassword"), Pair("database", "test") ),
             "17",
             workspace,
             port = 3306
@@ -80,7 +80,7 @@ class DockerRunServiceImplTest : BehaviorSpec({
             then("commandPort가 실행되어야함") {
                 val externalPort = application.port
                 verify {
-                    commandPort.executeShellCommand("docker run --network ${application.workspace.title.replace(' ', '_')} -e MYSQL_ROOT_PASSWORD=${application.env["rootPassword"] ?: throw ApplicationEnvNotFoundException()} --name ${application.name.lowercase()} -d -p ${externalPort}:${application.port} mysql:latest")
+                    commandPort.executeShellCommand("docker run --network ${application.workspace.title.replace(' ', '_')} -e MYSQL_ROOT_PASSWORD=${application.env["rootPassword"]} -e MYSQL_DATABASE=${application.env["database"]} --name ${application.name.lowercase()} -d -p ${externalPort}:${application.port} mysql:latest")
                 }
             }
         }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/DockerRunServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/DockerRunServiceImplTest.kt
@@ -86,6 +86,32 @@ class DockerRunServiceImplTest : BehaviorSpec({
         }
     }
 
+    given("mariadb 애플리케이션이 주어지고") {
+        val application = Application(
+            UUID.randomUUID().toString(),
+            "mysqlTest",
+            null,
+            ApplicationType.MARIA_DB,
+            "testUrl",
+            mapOf( Pair("rootPassword", "testMariaPassword"), Pair("database", "test") ),
+            "17",
+            workspace,
+            port = 3306
+        )
+
+        `when`("executeShellCommand 메서드를 실행할때") {
+            every { existsPortService.existsPort(application.port) } returns false
+            service.runApplication(application, application.port)
+
+            then("commandPort가 실행되어야함") {
+                val externalPort = application.port
+                verify {
+                    commandPort.executeShellCommand("docker run --network ${application.workspace.title.replace(' ', '_')} -e MYSQL_ROOT_PASSWORD=${application.env["rootPassword"]} -e MYSQL_DATABASE=${application.env["database"]} --name ${application.name.lowercase()} -d -p ${externalPort}:${application.port} mariadb:latest")
+                }
+            }
+        }
+    }
+
     given("redis 애플리케이션이 주어지고") {
         val application = Application(
             UUID.randomUUID().toString(),


### PR DESCRIPTION
## 🔖 개요
* DB개열의 애플리케이션에서 유저가 선택적으로 초기에 생성되는 데이터베이스를 생성할 수 있도록 변경합니다.

## 📜 작업내용
* CreateDockerImageService 인터페이스의 메서드 매개변수중 javaVersion으로 명명된 매개변수를 version으로 변경
* mariadb, mysql을 실행할때 기본 데이터베이스를 추가할 수 있도록 변경
* mariadb 실행 테스트 코드 추가

## 🔀 변경사항
* DockerRunSerivce 테스트 코드에 기본 데이터베이스를 추가할 수 있게 수정된 명령 반영