### PR TITLE
🔀 :: 181 - 애플리케이션의 실행상태 필드 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
@@ -10,6 +10,8 @@ enum class ErrorCode(
     ALREADY_USER_EXIST("이미 해당 유저가 존재함", 400),
     APPLICATION_OPTION_NOT_VALID("애플리케이션 옵션이 유효하지 않음", 400),
     NOT_SUPPORTED_APPLICATION_TYPE("지원되는 애플리케이션 타입이 아님", 400),
+    APPLICATION_ALREADY_RUNNING("해당 애플리케이션은 이미 실행중임", 400),
+    APPLICATION_ALREADY_STOPPED("해당 애플리케이션은 이미 정지됨", 400),
 
     UNAUTHORIZED("권한이 없음", 401),
     EXPIRED_TOKEN("토큰이 만료됨", 401),

--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/extenstion/ApplicationDtoExtension.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/extenstion/ApplicationDtoExtension.kt
@@ -4,6 +4,7 @@ import com.dcd.server.core.domain.application.dto.request.CreateApplicationReqDt
 import com.dcd.server.core.domain.application.dto.response.ApplicationProfileResDto
 import com.dcd.server.core.domain.application.dto.response.ApplicationResDto
 import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.workspace.model.Workspace
 
 fun CreateApplicationReqDto.toEntity(workspace: Workspace): Application =
@@ -15,7 +16,8 @@ fun CreateApplicationReqDto.toEntity(workspace: Workspace): Application =
         env = this.env,
         workspace = workspace,
         port = this.port,
-        version = this.version
+        version = this.version,
+        status = ApplicationStatus.STOPPED
     )
 
 fun Application.toDto(): ApplicationResDto =

--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/extenstion/ApplicationDtoExtension.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/extenstion/ApplicationDtoExtension.kt
@@ -28,7 +28,9 @@ fun Application.toDto(): ApplicationResDto =
         githubUrl = this.githubUrl,
         applicationType = this.applicationType,
         env = this.env,
-        port = this.port
+        port = this.port,
+        version = this.version,
+        status = this.status
     )
 
 fun Application.toProfileDto(): ApplicationProfileResDto =

--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/response/ApplicationResDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/response/ApplicationResDto.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.core.domain.application.dto.response
 
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 
 data class ApplicationResDto(
@@ -9,5 +10,7 @@ data class ApplicationResDto(
     val applicationType: ApplicationType,
     val githubUrl: String?,
     val env: Map<String, String>,
-    val port: Int
+    val port: Int,
+    val version: String,
+    val status: ApplicationStatus
 )

--- a/src/main/kotlin/com/dcd/server/core/domain/application/exception/AlreadyRunningException.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/exception/AlreadyRunningException.kt
@@ -1,0 +1,7 @@
+package com.dcd.server.core.domain.application.exception
+
+import com.dcd.server.core.common.error.BasicException
+import com.dcd.server.core.common.error.ErrorCode
+
+class AlreadyRunningException : BasicException(ErrorCode.APPLICATION_ALREADY_RUNNING) {
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/exception/AlreadyStoppedException.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/exception/AlreadyStoppedException.kt
@@ -1,0 +1,7 @@
+package com.dcd.server.core.domain.application.exception
+
+import com.dcd.server.core.common.error.BasicException
+import com.dcd.server.core.common.error.ErrorCode
+
+class AlreadyStoppedException : BasicException(ErrorCode.APPLICATION_ALREADY_STOPPED) {
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/model/Application.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/model/Application.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.core.domain.application.model
 
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.user.model.User
 import com.dcd.server.core.domain.workspace.model.Workspace
@@ -14,5 +15,6 @@ data class Application(
     val env: Map<String, String>,
     val version: String,
     val workspace: Workspace,
-    val port: Int
+    val port: Int,
+    val status: ApplicationStatus
 )

--- a/src/main/kotlin/com/dcd/server/core/domain/application/model/enums/ApplicationStatus.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/model/enums/ApplicationStatus.kt
@@ -1,0 +1,6 @@
+package com.dcd.server.core.domain.application.model.enums
+
+enum class ApplicationStatus {
+    RUNNING,
+    STOPPED
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/ChangeApplicationStatusService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/ChangeApplicationStatusService.kt
@@ -1,0 +1,8 @@
+package com.dcd.server.core.domain.application.service
+
+import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
+
+interface ChangeApplicationStatusService {
+    fun changeApplicationStatus(application: Application, status: ApplicationStatus)
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ChangeApplicationStatusServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ChangeApplicationStatusServiceImpl.kt
@@ -1,0 +1,16 @@
+package com.dcd.server.core.domain.application.service.impl
+
+import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
+import com.dcd.server.core.domain.application.service.ChangeApplicationStatusService
+import com.dcd.server.core.domain.application.spi.CommandApplicationPort
+import org.springframework.stereotype.Service
+
+@Service
+class ChangeApplicationStatusServiceImpl(
+    private val commandApplicationPort: CommandApplicationPort
+) : ChangeApplicationStatusService {
+    override fun changeApplicationStatus(application: Application, status: ApplicationStatus) {
+        commandApplicationPort.save(application.copy(status = status))
+    }
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCase.kt
@@ -2,6 +2,7 @@ package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.ReadOnlyUseCase
 import com.dcd.server.core.domain.application.dto.response.RunApplicationResDto
+import com.dcd.server.core.domain.application.exception.AlreadyRunningException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
@@ -24,6 +25,9 @@ class RunApplicationUseCase(
     fun execute(id: String): RunApplicationResDto {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
+
+        if (application.status == ApplicationStatus.RUNNING)
+            throw AlreadyRunningException()
 
         validateWorkspaceOwnerService.validateOwner(application.workspace)
 

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCase.kt
@@ -3,6 +3,7 @@ package com.dcd.server.core.domain.application.usecase
 import com.dcd.server.core.common.annotation.ReadOnlyUseCase
 import com.dcd.server.core.domain.application.dto.response.RunApplicationResDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.*
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
@@ -17,7 +18,8 @@ class RunApplicationUseCase(
     private val dockerRunService: DockerRunService,
     private val queryApplicationPort: QueryApplicationPort,
     private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService,
-    private val getExternalPortService: GetExternalPortService
+    private val getExternalPortService: GetExternalPortService,
+    private val changeApplicationStatusService: ChangeApplicationStatusService
 ) {
     fun execute(id: String): RunApplicationResDto {
         val application = (queryApplicationPort.findById(id)
@@ -40,6 +42,8 @@ class RunApplicationUseCase(
                 dockerRunService.runApplication(application, version, externalPort)
             }
         }
+
+        changeApplicationStatusService.changeApplicationStatus(application, ApplicationStatus.RUNNING)
 
         return RunApplicationResDto(externalPort = externalPort)
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCase.kt
@@ -2,6 +2,8 @@ package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.ReadOnlyUseCase
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
+import com.dcd.server.core.domain.application.service.ChangeApplicationStatusService
 import com.dcd.server.core.domain.application.service.DeleteApplicationDirectoryService
 import com.dcd.server.core.domain.application.service.DeleteContainerService
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
@@ -13,7 +15,8 @@ class StopApplicationUseCase(
     private val queryApplicationPort: QueryApplicationPort,
     private val deleteContainerService: DeleteContainerService,
     private val deleteApplicationDirectoryService: DeleteApplicationDirectoryService,
-    private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService
+    private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService,
+    private val changeApplicationStatusService: ChangeApplicationStatusService
 ) {
     fun execute(id: String) {
         val application = (queryApplicationPort.findById(id)
@@ -21,5 +24,6 @@ class StopApplicationUseCase(
         validateWorkspaceOwnerService.validateOwner(application.workspace)
         deleteContainerService.deleteContainer(application)
         deleteApplicationDirectoryService.deleteApplicationDirectory(application)
+        changeApplicationStatusService.changeApplicationStatus(application, ApplicationStatus.STOPPED)
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCase.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.ReadOnlyUseCase
+import com.dcd.server.core.domain.application.exception.AlreadyStoppedException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.service.ChangeApplicationStatusService
@@ -21,6 +22,10 @@ class StopApplicationUseCase(
     fun execute(id: String) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
+
+        if (application.status == ApplicationStatus.STOPPED)
+            throw AlreadyStoppedException()
+
         validateWorkspaceOwnerService.validateOwner(application.workspace)
         deleteContainerService.deleteContainer(application)
         deleteApplicationDirectoryService.deleteApplicationDirectory(application)

--- a/src/main/kotlin/com/dcd/server/persistence/application/adapter/ApplicationAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/application/adapter/ApplicationAdapter.kt
@@ -17,7 +17,8 @@ fun Application.toEntity(): ApplicationJpaEntity =
         env = this.env,
         workspace = this.workspace.toEntity(),
         port = this.port,
-        version = this.version
+        version = this.version,
+        status = this.status
     )
 
 fun ApplicationJpaEntity.toDomain(): Application =
@@ -30,5 +31,6 @@ fun ApplicationJpaEntity.toDomain(): Application =
         env = this.env,
         workspace = this.workspace.toDomain(),
         port = this.port,
-        version = this.version
+        version = this.version,
+        status = this.status
     )

--- a/src/main/kotlin/com/dcd/server/persistence/application/entity/ApplicationJpaEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/application/entity/ApplicationJpaEntity.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.persistence.application.entity
 
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.persistence.user.entity.UserJpaEntity
 import com.dcd.server.persistence.workspace.entity.WorkspaceJpaEntity
@@ -26,4 +27,6 @@ class ApplicationJpaEntity(
     val workspace: WorkspaceJpaEntity,
     val port: Int,
     val version: String,
+    @Enumerated(EnumType.STRING)
+    val status: ApplicationStatus
 )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationResponseDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationResponseDataExtension.kt
@@ -10,7 +10,10 @@ fun ApplicationResDto.toResponse(): ApplicationResponse =
         description = this.description,
         githubUrl = this.githubUrl,
         applicationType = this.applicationType,
-        env = this.env
+        env = this.env,
+        port = this.port,
+        version = this.version,
+        status = this.status
     )
 
 fun ApplicationListResDto.toResponse(): ApplicationListResponse =

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/response/ApplicationResponse.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/response/ApplicationResponse.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.presentation.domain.application.data.response
 
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 
 data class ApplicationResponse(
@@ -8,5 +9,8 @@ data class ApplicationResponse(
     val description: String?,
     val applicationType: ApplicationType,
     val githubUrl: String?,
-    val env: Map<String, String>
+    val env: Map<String, String>,
+    val port: Int,
+    val version: String,
+    val status: ApplicationStatus
 )

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/BuildDockerImageServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/BuildDockerImageServiceImplTest.kt
@@ -2,6 +2,7 @@ package com.dcd.server.core.domain.application.service
 
 import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.impl.BuildDockerImageServiceImpl
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
@@ -31,7 +32,7 @@ class BuildDockerImageServiceImplTest : BehaviorSpec({
                 description = "test workspace description",
                 owner = user
             )
-            val application = Application(appId, "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), "17", workspace, port = 8080)
+            val application = Application(appId, "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), "17", workspace, port = 8080, ApplicationStatus.STOPPED)
             every { queryApplicationPort.findById(appId) } returns application
 
             service.buildImageByApplicationId(appId)
@@ -49,7 +50,7 @@ class BuildDockerImageServiceImplTest : BehaviorSpec({
             description = "test workspace description",
             owner = user
         )
-        val application = Application(UUID.randomUUID().toString(), "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), "17", workspace, port = 8080)
+        val application = Application(UUID.randomUUID().toString(), "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), "17", workspace, port = 8080, ApplicationStatus.STOPPED)
 
         `when`("buildImageByApplication 메서드를 실행할때") {
             service.buildImageByApplication(application)

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/CloneApplicationByUrlServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/CloneApplicationByUrlServiceImplTest.kt
@@ -2,6 +2,7 @@ package com.dcd.server.core.domain.application.service
 
 import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.impl.CloneApplicationByUrlServiceImpl
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
@@ -31,7 +32,7 @@ class CloneApplicationByUrlServiceImplTest : BehaviorSpec({
                 description = "test workspace description",
                 owner = user
             )
-            val application = Application(appId, "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), "17", workspace, port = 8080)
+            val application = Application(appId, "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), "17", workspace, port = 8080, ApplicationStatus.STOPPED)
             every { queryApplicationPort.findById(appId) } returns application
 
             service.cloneById(appId)
@@ -48,7 +49,7 @@ class CloneApplicationByUrlServiceImplTest : BehaviorSpec({
             description = "test workspace description",
             owner = user
         )
-        val application = Application(UUID.randomUUID().toString(), "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), "17", workspace, port = 8080)
+        val application = Application(UUID.randomUUID().toString(), "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), "17", workspace, port = 8080, ApplicationStatus.STOPPED)
 
         `when`("cloneByApplication 메서드를 실행할때") {
             service.cloneByApplication(application)

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/DeleteApplicationDirectoryServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/DeleteApplicationDirectoryServiceImplTest.kt
@@ -2,6 +2,7 @@ package com.dcd.server.core.domain.application.service
 
 import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.impl.DeleteApplicationDirectoryServiceImpl
 import com.dcd.server.core.domain.auth.model.Role
@@ -25,7 +26,7 @@ class DeleteApplicationDirectoryServiceImplTest : BehaviorSpec({
             description = "test workspace description",
             owner = user
         )
-        val application = Application(UUID.randomUUID().toString(), "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), "17", workspace, port = 8080)
+        val application = Application(UUID.randomUUID().toString(), "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), "17", workspace, port = 8080, ApplicationStatus.STOPPED)
 
         `when`("buildImageByApplication 메서드를 실행할때") {
             service.deleteApplicationDirectory(application)

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/DeleteContainerServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/DeleteContainerServiceImplTest.kt
@@ -2,6 +2,7 @@ package com.dcd.server.core.domain.application.service
 
 import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.impl.DeleteContainerServiceImpl
 import com.dcd.server.core.domain.auth.model.Role
@@ -25,7 +26,7 @@ class DeleteContainerServiceImplTest : BehaviorSpec({
             description = "test workspace description",
             owner = user
         )
-        val application = Application(UUID.randomUUID().toString(), "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), "17", workspace, port = 8080)
+        val application = Application(UUID.randomUUID().toString(), "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), "17", workspace, port = 8080, ApplicationStatus.STOPPED)
 
         `when`("buildImageByApplication 메서드를 실행할때") {
             service.deleteContainer(application)

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/DockerRunServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/DockerRunServiceImplTest.kt
@@ -2,6 +2,7 @@ package com.dcd.server.core.domain.application.service
 
 import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.impl.DockerRunServiceImpl
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
@@ -31,7 +32,7 @@ class DockerRunServiceImplTest : BehaviorSpec({
         val appId = UUID.randomUUID().toString()
 
         `when`("executeShellCommand를 실행할때") {
-            val application = Application(appId, "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), "17", workspace, port = 8080)
+            val application = Application(appId, "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), "17", workspace, port = 8080, ApplicationStatus.STOPPED)
             every { queryApplicationPort.findById(appId) } returns application
 
             service.runApplication(appId, application.port)
@@ -43,7 +44,7 @@ class DockerRunServiceImplTest : BehaviorSpec({
     }
 
     given("애플리케이션이 주이지고") {
-        val application = Application(UUID.randomUUID().toString(), "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), "17", workspace, port = 8080)
+        val application = Application(UUID.randomUUID().toString(), "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), "17", workspace, port = 8080, ApplicationStatus.STOPPED)
 
         `when`("executeShellCommand 메서드를 실행할때") {
             service.runApplication(application, application.port)
@@ -65,7 +66,8 @@ class DockerRunServiceImplTest : BehaviorSpec({
             mapOf( Pair("rootPassword", "testMysqlPassword"), Pair("database", "test") ),
             "17",
             workspace,
-            port = 3306
+            port = 3306,
+            ApplicationStatus.STOPPED
         )
 
         `when`("executeShellCommand 메서드를 실행할때") {
@@ -90,7 +92,8 @@ class DockerRunServiceImplTest : BehaviorSpec({
             mapOf( Pair("rootPassword", "testMariaPassword"), Pair("database", "test") ),
             "17",
             workspace,
-            port = 3306
+            port = 3306,
+            ApplicationStatus.STOPPED
         )
 
         `when`("executeShellCommand 메서드를 실행할때") {
@@ -115,7 +118,8 @@ class DockerRunServiceImplTest : BehaviorSpec({
             mapOf(),
             "17",
             workspace,
-            port = 6379
+            port = 6379,
+            ApplicationStatus.STOPPED
         )
 
         `when`("executeShellCommand 메서드를 실행할때") {

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/AddApplicationEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/AddApplicationEnvUseCaseTest.kt
@@ -3,6 +3,7 @@ package com.dcd.server.core.domain.application.usecase
 import com.dcd.server.core.domain.application.dto.request.AddApplicationEnvReqDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
@@ -44,7 +45,8 @@ class AddApplicationEnvUseCaseTest : BehaviorSpec({
             githubUrl = "testUrl",
             version = "17",
             workspace = workspace,
-            port = 8080
+            port = 8080,
+            status = ApplicationStatus.STOPPED
         )
         `when`("usecase를 실행할때") {
             every { queryApplicationPort.findById(application.id) } returns application

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationEnvUseCaseTest.kt
@@ -3,6 +3,7 @@ package com.dcd.server.core.domain.application.usecase
 import com.dcd.server.core.domain.application.exception.ApplicationEnvNotFoundException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
@@ -37,7 +38,8 @@ class DeleteApplicationEnvUseCaseTest : BehaviorSpec({
             githubUrl = "testUrl",
             version = "17",
             workspace = Workspace(UUID.randomUUID().toString(), title = "test workspace", description = "test workspace description", owner = user),
-            port = 8080
+            port = 8080,
+            status = ApplicationStatus.STOPPED
         )
         `when`("usecase를 실행할때") {
             every { queryApplicationPort.findById(applicationId) } returns application

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationUseCaseTest.kt
@@ -2,6 +2,7 @@ package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
@@ -38,7 +39,8 @@ class DeleteApplicationUseCaseTest : BehaviorSpec({
             githubUrl = "testUrl",
             version = "17",
             workspace = Workspace(UUID.randomUUID().toString(), title = "test workspace", description = "test workspace description", owner = user),
-            port = 8080
+            port = 8080,
+            status = ApplicationStatus.STOPPED
         )
         every { getCurrentUserService.getCurrentUser() } returns user
         `when`("usecase를 실행할때") {

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GenerateSSLCertificateUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GenerateSSLCertificateUseCaseTest.kt
@@ -3,6 +3,7 @@ package com.dcd.server.core.domain.application.usecase
 import com.dcd.server.core.domain.application.dto.request.GenerateSSLCertificateReqDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.GenerateSSLCertificateService
 import com.dcd.server.core.domain.application.service.GetExternalPortService
@@ -56,7 +57,8 @@ class GenerateSSLCertificateUseCaseTest : BehaviorSpec({
                 githubUrl = "testUrl",
                 workspace = workspace,
                 port = 8080,
-                version = "17"
+                version = "17",
+                status = ApplicationStatus.STOPPED
             )
             every { queryApplicationPort.findById(applicationId) } returns application
             every { getCurrentUserService.getCurrentUser() } returns user
@@ -105,7 +107,8 @@ class GenerateSSLCertificateUseCaseTest : BehaviorSpec({
                 githubUrl = "testUrl",
                 workspace = workspace,
                 port = 8080,
-                version = "17"
+                version = "17",
+                status = ApplicationStatus.STOPPED
             )
             every { queryApplicationPort.findById(applicationId) } returns application
             every { getCurrentUserService.getCurrentUser() } returns user.copy(id = "another")

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCaseTest.kt
@@ -3,6 +3,7 @@ package com.dcd.server.core.domain.application.usecase
 import com.dcd.server.core.domain.application.dto.extenstion.toDto
 import com.dcd.server.core.domain.application.dto.response.ApplicationListResDto
 import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.auth.model.Role
@@ -42,7 +43,8 @@ class GetAllApplicationUseCaseTest : BehaviorSpec({
             githubUrl = "testUrl",
             version = "17",
             workspace = workspace,
-            port = 8080
+            port = 8080,
+            status = ApplicationStatus.STOPPED
         )
         val applicationList = listOf(application)
         `when`("usecase를 실행할때") {

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCaseTest.kt
@@ -3,6 +3,7 @@ package com.dcd.server.core.domain.application.usecase
 import com.dcd.server.core.domain.application.dto.extenstion.toDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.auth.model.Role
@@ -34,7 +35,8 @@ class GetOneApplicationUseCaseTest : BehaviorSpec({
             githubUrl = "testUrl",
             version = "17",
             workspace = Workspace(UUID.randomUUID().toString(), title = "test workspace", description = "test workspace description", owner = user),
-            port = 8080
+            port = 8080,
+            status = ApplicationStatus.STOPPED
         )
         `when`("해당 애플리케이션이 있을때") {
             every { queryApplicationPort.findById(application.id) } returns application

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCaseTest.kt
@@ -3,6 +3,7 @@ package com.dcd.server.core.domain.application.usecase
 import com.dcd.server.core.domain.application.dto.response.RunApplicationResDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.*
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
@@ -56,7 +57,8 @@ class RunApplicationUseCaseTest : BehaviorSpec({
             githubUrl = "testUrl",
             workspace = workspace,
             port = 8080,
-            version = "17"
+            version = "17",
+            status = ApplicationStatus.STOPPED
         )
         `when`("usecase를 실행할때") {
             every { queryApplicationPort.findById("testId") } returns application
@@ -94,7 +96,8 @@ class RunApplicationUseCaseTest : BehaviorSpec({
             githubUrl = "testUrl",
             workspace = workspace,
             port = 3306,
-            version = "8"
+            version = "8",
+            status = ApplicationStatus.STOPPED
         )
 
         `when`("usecase를 실행하면") {
@@ -124,7 +127,8 @@ class RunApplicationUseCaseTest : BehaviorSpec({
             githubUrl = "testUrl",
             workspace = workspace,
             port = 6379,
-            version = "6"
+            version = "6",
+            status = ApplicationStatus.STOPPED
         )
 
         `when`("usecase를 실행하면") {

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCaseTest.kt
@@ -28,6 +28,7 @@ class RunApplicationUseCaseTest : BehaviorSpec({
     val queryApplicationPort = mockk<QueryApplicationPort>(relaxUnitFun = true)
     val validateWorkspaceOwnerService = mockk<ValidateWorkspaceOwnerService>(relaxUnitFun = true)
     val getExternalPortService = mockk<GetExternalPortService>(relaxed = true)
+    val changeApplicationStatusService = mockk<ChangeApplicationStatusService>(relaxUnitFun = true)
     val runApplicationUseCase = RunApplicationUseCase(
         cloneApplicationByUrlService,
         modifyGradleService,
@@ -36,7 +37,8 @@ class RunApplicationUseCaseTest : BehaviorSpec({
         dockerRunService,
         queryApplicationPort,
         validateWorkspaceOwnerService,
-        getExternalPortService
+        getExternalPortService,
+        changeApplicationStatusService
     )
 
     val user =
@@ -70,6 +72,7 @@ class RunApplicationUseCaseTest : BehaviorSpec({
                 verify { createDockerFileService.createFileToApplication(application, application.version, 0) }
                 verify { buildDockerImageService.buildImageByApplication(application) }
                 verify { dockerRunService.runApplication(application, getExternalPortService.getExternalPort(application.port)) }
+                verify { changeApplicationStatusService.changeApplicationStatus(application, ApplicationStatus.RUNNING) }
             }
             then("반환값은 이용가능한 외부 포트를 담아야함") {
                 result shouldBe RunApplicationResDto(getExternalPortService.getExternalPort(application.port))
@@ -112,6 +115,7 @@ class RunApplicationUseCaseTest : BehaviorSpec({
                     verify { modifyGradleService.modifyGradleByApplication(application) }
                     verify { createDockerFileService.createFileToApplication(application, application.version, 0) }
                     verify { buildDockerImageService.buildImageByApplication(application) }
+                    verify { changeApplicationStatusService.changeApplicationStatus(application, ApplicationStatus.RUNNING) }
                 }
             }
         }
@@ -143,6 +147,7 @@ class RunApplicationUseCaseTest : BehaviorSpec({
                     verify { modifyGradleService.modifyGradleByApplication(application) }
                     verify { createDockerFileService.createFileToApplication(application, application.version, 0) }
                     verify { buildDockerImageService.buildImageByApplication(application) }
+                    verify { changeApplicationStatusService.changeApplicationStatus(application, ApplicationStatus.RUNNING) }
                 }
             }
         }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
@@ -2,6 +2,7 @@ package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.DeleteApplicationDirectoryService
 import com.dcd.server.core.domain.application.service.DeleteContainerService
@@ -38,7 +39,8 @@ class StopApplicationUseCaseTest : BehaviorSpec({
             githubUrl = "testUrl",
             version = "17",
             workspace = Workspace(UUID.randomUUID().toString(), title = "test workspace", description = "test workspace description", owner = user),
-            port = 8080
+            port = 8080,
+            status = ApplicationStatus.STOPPED
         )
         `when`("유스케이스가 오류없이 동작할때") {
             every { queryApplicationPort.findById(applicationId) } returns application

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
@@ -4,6 +4,7 @@ import com.dcd.server.core.domain.application.exception.ApplicationNotFoundExcep
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
+import com.dcd.server.core.domain.application.service.ChangeApplicationStatusService
 import com.dcd.server.core.domain.application.service.DeleteApplicationDirectoryService
 import com.dcd.server.core.domain.application.service.DeleteContainerService
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
@@ -23,8 +24,9 @@ class StopApplicationUseCaseTest : BehaviorSpec({
     val deleteContainerService = mockk<DeleteContainerService>()
     val deleteApplicationDirectoryService = mockk<DeleteApplicationDirectoryService>()
     val validateWorkspaceOwnerService = mockk<ValidateWorkspaceOwnerService>(relaxUnitFun = true)
+    val changeApplicationStatusService = mockk<ChangeApplicationStatusService>(relaxUnitFun = true)
     val stopApplicationUseCase =
-        StopApplicationUseCase(queryApplicationPort, deleteContainerService, deleteApplicationDirectoryService, validateWorkspaceOwnerService)
+        StopApplicationUseCase(queryApplicationPort, deleteContainerService, deleteApplicationDirectoryService, validateWorkspaceOwnerService, changeApplicationStatusService)
 
     given("애플리케이션 Id가 주어지고") {
         val applicationId = "testApplicationId"

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
@@ -42,7 +42,7 @@ class StopApplicationUseCaseTest : BehaviorSpec({
             version = "17",
             workspace = Workspace(UUID.randomUUID().toString(), title = "test workspace", description = "test workspace description", owner = user),
             port = 8080,
-            status = ApplicationStatus.STOPPED
+            status = ApplicationStatus.RUNNING
         )
         `when`("유스케이스가 오류없이 동작할때") {
             every { queryApplicationPort.findById(applicationId) } returns application

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCaseTest.kt
@@ -3,6 +3,7 @@ package com.dcd.server.core.domain.application.usecase
 import com.dcd.server.core.domain.application.dto.request.UpdateApplicationReqDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
@@ -47,7 +48,8 @@ class UpdateApplicationUseCaseTest : BehaviorSpec({
             githubUrl = "testUrl",
             version = "17",
             workspace = workspace,
-            port = 8080
+            port = 8080,
+            status = ApplicationStatus.STOPPED
         )
 
         `when`("usecase를 실행할때") {

--- a/src/test/kotlin/com/dcd/server/core/domain/user/usecase/GetUserProfileUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/user/usecase/GetUserProfileUseCaseTest.kt
@@ -2,6 +2,7 @@ package com.dcd.server.core.domain.user.usecase
 
 import com.dcd.server.core.domain.application.dto.extenstion.toProfileDto
 import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.auth.model.Role
@@ -44,7 +45,8 @@ class GetUserProfileUseCaseTest : BehaviorSpec({
             githubUrl = "testUrl",
             version = "17",
             workspace = workspace,
-            port = 8080
+            port = 8080,
+            status = ApplicationStatus.STOPPED
         )
 
         `when`("usecase를 실행할때") {

--- a/src/test/kotlin/com/dcd/server/persistence/application/ApplicationPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/persistence/application/ApplicationPersistenceAdapterTest.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.persistence.application
 
 import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.auth.model.Role
 import com.dcd.server.core.domain.user.model.User
@@ -40,7 +41,8 @@ class ApplicationPersistenceAdapterTest : BehaviorSpec({
             env = mapOf(),
             version = "17",
             workspace = workspace,
-            port = 8080
+            port = 8080,
+            status = ApplicationStatus.STOPPED
         )
         val id = application.id
 

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -6,6 +6,7 @@ import com.dcd.server.core.domain.application.dto.response.ApplicationListResDto
 import com.dcd.server.core.domain.application.dto.response.ApplicationResDto
 import com.dcd.server.core.domain.application.dto.response.AvailableVersionResDto
 import com.dcd.server.core.domain.application.dto.response.RunApplicationResDto
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.usecase.*
 import com.dcd.server.presentation.domain.application.data.exetension.toResponse
@@ -77,7 +78,9 @@ class ApplicationWebAdapterTest : BehaviorSpec({
             applicationType = ApplicationType.SPRING_BOOT,
             env = mapOf(),
             githubUrl = "testUrl",
-            port = 8080
+            port = 8080,
+            version = "latest",
+            status = ApplicationStatus.STOPPED
         )
         val list = listOf(applicationResponse)
         val responseDto = ApplicationListResDto(list)
@@ -101,7 +104,9 @@ class ApplicationWebAdapterTest : BehaviorSpec({
             applicationType = ApplicationType.SPRING_BOOT,
             env = mapOf(),
             githubUrl = "testUrl",
-            port = 8080
+            port = 8080,
+            version = "latest",
+            status = ApplicationStatus.STOPPED
         )
         `when`("getOneApplication 메서드를 실행할때") {
             every { getOneApplicationUseCase.execute(testId) } returns applicationResponse


### PR DESCRIPTION
## 🔖 개요
* 애플리케이션의 현재 실행 상태를 저장하는 필드를 추가합니다.

## 📜 작업내용
* 애플리케이션의 실행상태를 enum 타입으로 생성
* Application 도메인에 status 필드 추가
* 애플리케이션 생성 요청 DTO에서 application 정지 상태로 생성하도록 변경
* 애플리케이션 응답객체에 status 필드 추가
* ChangeApplicationStatusService 추가
* 애플리케이션이 실행, 정지될때 해당 상태로 변경하는 로직 추가
* 테스트 코드에서 사용하는 application에 status 필드 추가
* 애플리케이션의 상태변경을 적용하는지 검증하는 테스트 추가
* 애플리케이션이 이미 실행/정지 상태일때 API를 호출하면 해당 상황에 맞는 예외 반환

## 🔀 변경사항
* StopApplicationUseCase 테스트 코드에서 Running상태의 애플리케이션을 타켓으로 테스트를 진행하도록 변경