### PR TITLE
🔀 :: 183 - 테스트 코드에서 객체를 생성할때 중복되는 코드 개선

### DIFF
--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/BuildDockerImageServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/BuildDockerImageServiceImplTest.kt
@@ -13,6 +13,9 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import util.application.ApplicationGenerator
+import util.user.UserGenerator
+import util.workspace.WorkspaceGenerator
 import java.util.*
 
 class BuildDockerImageServiceImplTest : BehaviorSpec({
@@ -20,19 +23,13 @@ class BuildDockerImageServiceImplTest : BehaviorSpec({
     val queryApplicationPort = mockk<QueryApplicationPort>()
     val service = BuildDockerImageServiceImpl(commandPort, queryApplicationPort)
 
-    val user =
-        User(email = "email", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
+    val user = UserGenerator.generateUser()
     given("애플리케이션id가 주어지고") {
         val appId = UUID.randomUUID().toString()
 
         `when`("buildImageByApplicationId를 실행할때") {
-            val workspace = Workspace(
-                UUID.randomUUID().toString(),
-                title = "test workspace",
-                description = "test workspace description",
-                owner = user
-            )
-            val application = Application(appId, "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), "17", workspace, port = 8080, ApplicationStatus.STOPPED)
+            val workspace = WorkspaceGenerator.generateWorkspace(user = user)
+            val application = ApplicationGenerator.generateApplication(id = appId, workspace = workspace)
             every { queryApplicationPort.findById(appId) } returns application
 
             service.buildImageByApplicationId(appId)
@@ -44,13 +41,8 @@ class BuildDockerImageServiceImplTest : BehaviorSpec({
     }
 
     given("애플리케이션이 주이지고") {
-        val workspace = Workspace(
-            UUID.randomUUID().toString(),
-            title = "test workspace",
-            description = "test workspace description",
-            owner = user
-        )
-        val application = Application(UUID.randomUUID().toString(), "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), "17", workspace, port = 8080, ApplicationStatus.STOPPED)
+        val workspace = WorkspaceGenerator.generateWorkspace(user = user)
+        val application = ApplicationGenerator.generateApplication(workspace = workspace)
 
         `when`("buildImageByApplication 메서드를 실행할때") {
             service.buildImageByApplication(application)

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/CloneApplicationByUrlServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/CloneApplicationByUrlServiceImplTest.kt
@@ -13,6 +13,9 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import util.application.ApplicationGenerator
+import util.user.UserGenerator
+import util.workspace.WorkspaceGenerator
 import java.util.*
 
 class CloneApplicationByUrlServiceImplTest : BehaviorSpec({
@@ -20,19 +23,12 @@ class CloneApplicationByUrlServiceImplTest : BehaviorSpec({
     val queryApplicationPort = mockk<QueryApplicationPort>()
     val service = CloneApplicationByUrlServiceImpl(queryApplicationPort, commandPort)
 
-    val user =
-        User(email = "email", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
     given("애플리케이션id가 주어지고") {
         val appId = UUID.randomUUID().toString()
 
         `when`("cloneById 메서드를 실행할때") {
-            val workspace = Workspace(
-                UUID.randomUUID().toString(),
-                title = "test workspace",
-                description = "test workspace description",
-                owner = user
-            )
-            val application = Application(appId, "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), "17", workspace, port = 8080, ApplicationStatus.STOPPED)
+            val workspace = WorkspaceGenerator.generateWorkspace()
+            val application = ApplicationGenerator.generateApplication(id = appId, workspace = workspace)
             every { queryApplicationPort.findById(appId) } returns application
 
             service.cloneById(appId)
@@ -43,13 +39,8 @@ class CloneApplicationByUrlServiceImplTest : BehaviorSpec({
     }
 
     given("애플리케이션이 주이지고") {
-        val workspace = Workspace(
-            UUID.randomUUID().toString(),
-            title = "test workspace",
-            description = "test workspace description",
-            owner = user
-        )
-        val application = Application(UUID.randomUUID().toString(), "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), "17", workspace, port = 8080, ApplicationStatus.STOPPED)
+        val workspace = WorkspaceGenerator.generateWorkspace()
+        val application = ApplicationGenerator.generateApplication(workspace = workspace)
 
         `when`("cloneByApplication 메서드를 실행할때") {
             service.cloneByApplication(application)

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/DeleteApplicationDirectoryServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/DeleteApplicationDirectoryServiceImplTest.kt
@@ -11,22 +11,16 @@ import com.dcd.server.core.domain.workspace.model.Workspace
 import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.mockk
 import io.mockk.verify
+import util.application.ApplicationGenerator
+import util.user.UserGenerator
 import java.util.*
 
 class DeleteApplicationDirectoryServiceImplTest : BehaviorSpec({
     val commandPort = mockk<CommandPort>(relaxed = true)
     val service = DeleteApplicationDirectoryServiceImpl(commandPort)
 
-    val user =
-        User(email = "email", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
     given("애플리케이션이 주이지고") {
-        val workspace = Workspace(
-            UUID.randomUUID().toString(),
-            title = "test workspace",
-            description = "test workspace description",
-            owner = user
-        )
-        val application = Application(UUID.randomUUID().toString(), "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), "17", workspace, port = 8080, ApplicationStatus.STOPPED)
+        val application = ApplicationGenerator.generateApplication()
 
         `when`("buildImageByApplication 메서드를 실행할때") {
             service.deleteApplicationDirectory(application)

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/DeleteContainerServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/DeleteContainerServiceImplTest.kt
@@ -1,32 +1,18 @@
 package com.dcd.server.core.domain.application.service
 
 import com.dcd.server.core.common.command.CommandPort
-import com.dcd.server.core.domain.application.model.Application
-import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
-import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.impl.DeleteContainerServiceImpl
-import com.dcd.server.core.domain.auth.model.Role
-import com.dcd.server.core.domain.user.model.User
-import com.dcd.server.core.domain.workspace.model.Workspace
 import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.mockk
 import io.mockk.verify
-import java.util.*
+import util.application.ApplicationGenerator
 
 class DeleteContainerServiceImplTest : BehaviorSpec({
     val commandPort = mockk<CommandPort>(relaxed = true)
     val service = DeleteContainerServiceImpl(commandPort)
 
-    val user =
-        User(email = "email", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
     given("애플리케이션이 주이지고") {
-        val workspace = Workspace(
-            UUID.randomUUID().toString(),
-            title = "test workspace",
-            description = "test workspace description",
-            owner = user
-        )
-        val application = Application(UUID.randomUUID().toString(), "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), "17", workspace, port = 8080, ApplicationStatus.STOPPED)
+        val application = ApplicationGenerator.generateApplication()
 
         `when`("buildImageByApplication 메서드를 실행할때") {
             service.deleteContainer(application)

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/DockerRunServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/DockerRunServiceImplTest.kt
@@ -6,13 +6,11 @@ import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.impl.DockerRunServiceImpl
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
-import com.dcd.server.core.domain.auth.model.Role
-import com.dcd.server.core.domain.user.model.User
-import com.dcd.server.core.domain.workspace.model.Workspace
 import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import util.application.ApplicationGenerator
 import java.util.*
 
 class DockerRunServiceImplTest : BehaviorSpec({
@@ -20,19 +18,11 @@ class DockerRunServiceImplTest : BehaviorSpec({
     val queryApplicationPort = mockk<QueryApplicationPort>()
     val service = DockerRunServiceImpl(queryApplicationPort, commandPort)
 
-    val user =
-        User(email = "email", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
-    val workspace = Workspace(
-        UUID.randomUUID().toString(),
-        title = "test workspace",
-        description = "test workspace description",
-        owner = user
-    )
     given("애플리케이션id가 주어지고") {
         val appId = UUID.randomUUID().toString()
 
         `when`("executeShellCommand를 실행할때") {
-            val application = Application(appId, "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), "17", workspace, port = 8080, ApplicationStatus.STOPPED)
+            val application = ApplicationGenerator.generateApplication()
             every { queryApplicationPort.findById(appId) } returns application
 
             service.runApplication(appId, application.port)
@@ -44,7 +34,7 @@ class DockerRunServiceImplTest : BehaviorSpec({
     }
 
     given("애플리케이션이 주이지고") {
-        val application = Application(UUID.randomUUID().toString(), "testName", null, ApplicationType.SPRING_BOOT, "testUrl", mapOf(), "17", workspace, port = 8080, ApplicationStatus.STOPPED)
+        val application = ApplicationGenerator.generateApplication()
 
         `when`("executeShellCommand 메서드를 실행할때") {
             service.runApplication(application, application.port)
@@ -57,18 +47,7 @@ class DockerRunServiceImplTest : BehaviorSpec({
     }
 
     given("mysql 애플리케이션이 주어지고") {
-        val application = Application(
-            UUID.randomUUID().toString(),
-            "mysqlTest",
-            null,
-            ApplicationType.MYSQL,
-            "testUrl",
-            mapOf( Pair("rootPassword", "testMysqlPassword"), Pair("database", "test") ),
-            "17",
-            workspace,
-            port = 3306,
-            ApplicationStatus.STOPPED
-        )
+        val application = ApplicationGenerator.generateApplication(applicationType = ApplicationType.MYSQL, env = mapOf(Pair("rootPassword", "test"), Pair("database", "test")))
 
         `when`("executeShellCommand 메서드를 실행할때") {
             service.runApplication(application, application.port)
@@ -83,18 +62,7 @@ class DockerRunServiceImplTest : BehaviorSpec({
     }
 
     given("mariadb 애플리케이션이 주어지고") {
-        val application = Application(
-            UUID.randomUUID().toString(),
-            "mysqlTest",
-            null,
-            ApplicationType.MARIA_DB,
-            "testUrl",
-            mapOf( Pair("rootPassword", "testMariaPassword"), Pair("database", "test") ),
-            "17",
-            workspace,
-            port = 3306,
-            ApplicationStatus.STOPPED
-        )
+        val application = ApplicationGenerator.generateApplication(applicationType = ApplicationType.MARIA_DB, env = mapOf(Pair("rootPassword", "test"), Pair("database", "test")))
 
         `when`("executeShellCommand 메서드를 실행할때") {
             service.runApplication(application, application.port)
@@ -109,18 +77,7 @@ class DockerRunServiceImplTest : BehaviorSpec({
     }
 
     given("redis 애플리케이션이 주어지고") {
-        val application = Application(
-            UUID.randomUUID().toString(),
-            "redisTest",
-            null,
-            ApplicationType.REDIS,
-            "testUrl",
-            mapOf(),
-            "17",
-            workspace,
-            port = 6379,
-            ApplicationStatus.STOPPED
-        )
+        val application = ApplicationGenerator.generateApplication(applicationType = ApplicationType.REDIS)
 
         `when`("executeShellCommand 메서드를 실행할때") {
             service.runApplication(application, application.port)

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/AddApplicationEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/AddApplicationEnvUseCaseTest.kt
@@ -16,6 +16,7 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import util.application.ApplicationGenerator
 import java.util.*
 
 class AddApplicationEnvUseCaseTest : BehaviorSpec({
@@ -28,26 +29,7 @@ class AddApplicationEnvUseCaseTest : BehaviorSpec({
         val request = AddApplicationEnvReqDto(
             envList = mapOf(Pair("testA", "testB"))
         )
-        val user =
-            User(email = "email", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
-        val workspace = Workspace(
-            UUID.randomUUID().toString(),
-            title = "test workspace",
-            description = "test workspace description",
-            owner = user
-        )
-        val application = Application(
-            id = "testId",
-            name = "test",
-            description = "test",
-            applicationType = ApplicationType.SPRING_BOOT,
-            env = mapOf(),
-            githubUrl = "testUrl",
-            version = "17",
-            workspace = workspace,
-            port = 8080,
-            status = ApplicationStatus.STOPPED
-        )
+        val application = ApplicationGenerator.generateApplication()
         `when`("usecase를 실행할때") {
             every { queryApplicationPort.findById(application.id) } returns application
             every { commandApplicationPort.save(any()) } answers { callOriginal() }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
@@ -16,6 +16,8 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import util.user.UserGenerator
+import util.workspace.WorkspaceGenerator
 import java.util.*
 
 class CreateApplicationUseCaseTest : BehaviorSpec({
@@ -36,14 +38,8 @@ class CreateApplicationUseCaseTest : BehaviorSpec({
             version = "17",
             port = 8080
         )
-        val user =
-            User(email = "email", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
-        val workspace = Workspace(
-            UUID.randomUUID().toString(),
-            title = "test workspace",
-            description = "test workspace description",
-            owner = user
-        )
+        val user = UserGenerator.generateUser()
+        val workspace = WorkspaceGenerator.generateWorkspace(user = user)
         val id = user.id
         `when`("usecase를 실행하면") {
             every { securityService.getCurrentUserId() } returns id

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationEnvUseCaseTest.kt
@@ -16,6 +16,7 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import util.application.ApplicationGenerator
 import java.util.*
 
 class DeleteApplicationEnvUseCaseTest : BehaviorSpec({
@@ -27,20 +28,7 @@ class DeleteApplicationEnvUseCaseTest : BehaviorSpec({
     given("애플리케이션 Id와 삭제할 key가 주어지고") {
         val applicationId = "testId"
         val key = "testKey"
-        val user =
-            User(email = "email", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
-        val application = Application(
-            id = applicationId,
-            name = "test",
-            description = "test",
-            applicationType = ApplicationType.SPRING_BOOT,
-            env = mapOf(Pair(key, "testValue")),
-            githubUrl = "testUrl",
-            version = "17",
-            workspace = Workspace(UUID.randomUUID().toString(), title = "test workspace", description = "test workspace description", owner = user),
-            port = 8080,
-            status = ApplicationStatus.STOPPED
-        )
+        val application = ApplicationGenerator.generateApplication(env = mapOf(Pair("testKey", "testValue")))
         `when`("usecase를 실행할때") {
             every { queryApplicationPort.findById(applicationId) } returns application
             every { commandApplicationPort.save(any()) } answers { callOriginal() }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationUseCaseTest.kt
@@ -16,6 +16,9 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import util.application.ApplicationGenerator
+import util.user.UserGenerator
+import util.workspace.WorkspaceGenerator
 import java.lang.RuntimeException
 import java.util.*
 
@@ -28,20 +31,8 @@ class DeleteApplicationUseCaseTest : BehaviorSpec({
         DeleteApplicationUseCase(getCurrentUserService, commandApplicationPort, queryApplicationPort, validateWorkspaceOwnerService)
     given("애플리케이션 id가 주어지고") {
         val applicationId = "testId"
-        val user =
-            User(email = "email", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
-        val application = Application(
-            id = applicationId,
-            name = "test",
-            description = "test",
-            applicationType = ApplicationType.SPRING_BOOT,
-            env = mapOf(),
-            githubUrl = "testUrl",
-            version = "17",
-            workspace = Workspace(UUID.randomUUID().toString(), title = "test workspace", description = "test workspace description", owner = user),
-            port = 8080,
-            status = ApplicationStatus.STOPPED
-        )
+        val user = UserGenerator.generateUser()
+        val application = ApplicationGenerator.generateApplication(workspace = WorkspaceGenerator.generateWorkspace(user = user))
         every { getCurrentUserService.getCurrentUser() } returns user
         `when`("usecase를 실행할때") {
             every { commandApplicationPort.delete(application) } returns Unit

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GenerateSSLCertificateUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GenerateSSLCertificateUseCaseTest.kt
@@ -19,6 +19,9 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import util.application.ApplicationGenerator
+import util.user.UserGenerator
+import util.workspace.WorkspaceGenerator
 import java.util.*
 
 class GenerateSSLCertificateUseCaseTest : BehaviorSpec({
@@ -40,26 +43,9 @@ class GenerateSSLCertificateUseCaseTest : BehaviorSpec({
         val reqDto = GenerateSSLCertificateReqDto(domain = "dcd-server.dolong.co.kr")
 
         `when`("usecase를 실행하면") {
-            val user =
-                User(email = "email", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
-            val workspace = Workspace(
-                UUID.randomUUID().toString(),
-                title = "test workspace",
-                description = "test workspace description",
-                owner = user
-            )
-            val application = Application(
-                id = "testId",
-                name = "test",
-                description = "test",
-                applicationType = ApplicationType.SPRING_BOOT,
-                env = mapOf(),
-                githubUrl = "testUrl",
-                workspace = workspace,
-                port = 8080,
-                version = "17",
-                status = ApplicationStatus.STOPPED
-            )
+            val user = UserGenerator.generateUser()
+            val workspace = WorkspaceGenerator.generateWorkspace(user = user)
+            val application = ApplicationGenerator.generateApplication(workspace = workspace)
             every { queryApplicationPort.findById(applicationId) } returns application
             every { getCurrentUserService.getCurrentUser() } returns user
 
@@ -90,26 +76,9 @@ class GenerateSSLCertificateUseCaseTest : BehaviorSpec({
         }
 
         `when`("현재 로그인된 유저가 해당 workspace에 권한이 없을때") {
-            val user =
-                User(email = "email", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
-            val workspace = Workspace(
-                UUID.randomUUID().toString(),
-                title = "test workspace",
-                description = "test workspace description",
-                owner = user
-            )
-            val application = Application(
-                id = "testId",
-                name = "test",
-                description = "test",
-                applicationType = ApplicationType.SPRING_BOOT,
-                env = mapOf(),
-                githubUrl = "testUrl",
-                workspace = workspace,
-                port = 8080,
-                version = "17",
-                status = ApplicationStatus.STOPPED
-            )
+            val user = UserGenerator.generateUser()
+            val workspace = WorkspaceGenerator.generateWorkspace(user = user)
+            val application = ApplicationGenerator.generateApplication(workspace = workspace)
             every { queryApplicationPort.findById(applicationId) } returns application
             every { getCurrentUserService.getCurrentUser() } returns user.copy(id = "another")
 

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCaseTest.kt
@@ -17,6 +17,9 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import util.application.ApplicationGenerator
+import util.user.UserGenerator
+import util.workspace.WorkspaceGenerator
 import java.util.*
 
 class GetAllApplicationUseCaseTest : BehaviorSpec({
@@ -26,26 +29,9 @@ class GetAllApplicationUseCaseTest : BehaviorSpec({
     val getAllApplicationUseCase = GetAllApplicationUseCase(queryApplicationPort, getCurrentUserService, queryWorkspacePort)
 
     given("applicationList가 주어지고") {
-        val user =
-            User(email = "email", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
-        val workspace = Workspace(
-            UUID.randomUUID().toString(),
-            title = "test workspace",
-            description = "test workspace description",
-            owner = user
-        )
-        val application = Application(
-            id = "testId",
-            name = "test",
-            description = "test",
-            applicationType = ApplicationType.SPRING_BOOT,
-            env = mapOf(),
-            githubUrl = "testUrl",
-            version = "17",
-            workspace = workspace,
-            port = 8080,
-            status = ApplicationStatus.STOPPED
-        )
+        val user = UserGenerator.generateUser()
+        val workspace = WorkspaceGenerator.generateWorkspace(user = user)
+        val application = ApplicationGenerator.generateApplication(workspace = workspace)
         val applicationList = listOf(application)
         `when`("usecase를 실행할때") {
             every { getCurrentUserService.getCurrentUser() } returns user

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCaseTest.kt
@@ -16,6 +16,9 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import util.application.ApplicationGenerator
+import util.user.UserGenerator
+import util.workspace.WorkspaceGenerator
 import java.util.*
 
 class GetOneApplicationUseCaseTest : BehaviorSpec({
@@ -24,20 +27,8 @@ class GetOneApplicationUseCaseTest : BehaviorSpec({
     val getOneApplicationUseCase = GetOneApplicationUseCase(queryApplicationPort, getCurrentUserService)
 
     given("애플리케이션이 주어지고") {
-        val user =
-            User(email = "email", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
-        val application = Application(
-            id = "testId",
-            name = "test",
-            description = "test",
-            applicationType = ApplicationType.SPRING_BOOT,
-            env = mapOf(),
-            githubUrl = "testUrl",
-            version = "17",
-            workspace = Workspace(UUID.randomUUID().toString(), title = "test workspace", description = "test workspace description", owner = user),
-            port = 8080,
-            status = ApplicationStatus.STOPPED
-        )
+        val user = UserGenerator.generateUser()
+        val application = ApplicationGenerator.generateApplication(workspace = WorkspaceGenerator.generateWorkspace(user = user))
         `when`("해당 애플리케이션이 있을때") {
             every { queryApplicationPort.findById(application.id) } returns application
             every { getCurrentUserService.getCurrentUser() } returns user
@@ -56,8 +47,7 @@ class GetOneApplicationUseCaseTest : BehaviorSpec({
             }
         }
         `when`("현재 유저가 해당 애플리케이션의 워크스페이스 주인이 아닐때") {
-            val another =
-                User(email = "another", password = "password", name = "another", roles = mutableListOf(Role.ROLE_USER))
+            val another = UserGenerator.generateUser(email = "another")
 
             every { queryApplicationPort.findById(application.id) } returns application
             every { getCurrentUserService.getCurrentUser() } returns another

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCaseTest.kt
@@ -17,6 +17,9 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import util.application.ApplicationGenerator
+import util.user.UserGenerator
+import util.workspace.WorkspaceGenerator
 import java.util.*
 
 class RunApplicationUseCaseTest : BehaviorSpec({
@@ -41,27 +44,10 @@ class RunApplicationUseCaseTest : BehaviorSpec({
         changeApplicationStatusService
     )
 
-    val user =
-        User(email = "email", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
-    val workspace = Workspace(
-        UUID.randomUUID().toString(),
-        title = "test workspace",
-        description = "test workspace description",
-        owner = user
-    )
+    val user = UserGenerator.generateUser()
+    val workspace = WorkspaceGenerator.generateWorkspace(user = user)
     given("spring boot application, runApplicationDto가 주어지고") {
-        val application = Application(
-            id = "testId",
-            name = "test",
-            description = "test",
-            applicationType = ApplicationType.SPRING_BOOT,
-            env = mapOf(),
-            githubUrl = "testUrl",
-            workspace = workspace,
-            port = 8080,
-            version = "17",
-            status = ApplicationStatus.STOPPED
-        )
+        val application = ApplicationGenerator.generateApplication(workspace = workspace)
         `when`("usecase를 실행할때") {
             every { queryApplicationPort.findById("testId") } returns application
             val result = runApplicationUseCase.execute("testId")
@@ -90,18 +76,7 @@ class RunApplicationUseCaseTest : BehaviorSpec({
     }
 
     given("mysql application, runApplicationReqDto가 주어지고") {
-        val application = Application(
-            id = "testId",
-            name = "mysqlTest",
-            description = "test",
-            applicationType = ApplicationType.MYSQL,
-            env = mapOf(),
-            githubUrl = "testUrl",
-            workspace = workspace,
-            port = 3306,
-            version = "8",
-            status = ApplicationStatus.STOPPED
-        )
+        val application = ApplicationGenerator.generateApplication(workspace = workspace, applicationType = ApplicationType.MYSQL)
 
         `when`("usecase를 실행하면") {
             every { queryApplicationPort.findById(application.id) } returns application
@@ -122,18 +97,7 @@ class RunApplicationUseCaseTest : BehaviorSpec({
     }
 
     given("redis application, runApplicationReqDto가 주어지고") {
-        val application = Application(
-            id = "testId",
-            name = "redisTest",
-            description = "test",
-            applicationType = ApplicationType.REDIS,
-            env = mapOf(),
-            githubUrl = "testUrl",
-            workspace = workspace,
-            port = 6379,
-            version = "6",
-            status = ApplicationStatus.STOPPED
-        )
+        val application = ApplicationGenerator.generateApplication(applicationType = ApplicationType.REDIS)
 
         `when`("usecase를 실행하면") {
             every { queryApplicationPort.findById(application.id) } returns application

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
@@ -17,6 +17,9 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import util.application.ApplicationGenerator
+import util.user.UserGenerator
+import util.workspace.WorkspaceGenerator
 import java.util.*
 
 class StopApplicationUseCaseTest : BehaviorSpec({
@@ -30,20 +33,8 @@ class StopApplicationUseCaseTest : BehaviorSpec({
 
     given("애플리케이션 Id가 주어지고") {
         val applicationId = "testApplicationId"
-        val user =
-            User(email = "email", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
-        val application = Application(
-            id = applicationId,
-            name = "test",
-            description = "test",
-            applicationType = ApplicationType.SPRING_BOOT,
-            env = mapOf(),
-            githubUrl = "testUrl",
-            version = "17",
-            workspace = Workspace(UUID.randomUUID().toString(), title = "test workspace", description = "test workspace description", owner = user),
-            port = 8080,
-            status = ApplicationStatus.RUNNING
-        )
+        val user = UserGenerator.generateUser()
+        val application = ApplicationGenerator.generateApplication(id = applicationId, workspace = WorkspaceGenerator.generateWorkspace(user = user), status = ApplicationStatus.RUNNING)
         `when`("유스케이스가 오류없이 동작할때") {
             every { queryApplicationPort.findById(applicationId) } returns application
             every { deleteContainerService.deleteContainer(application) } returns Unit

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCaseTest.kt
@@ -17,6 +17,9 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import util.application.ApplicationGenerator
+import util.user.UserGenerator
+import util.workspace.WorkspaceGenerator
 import java.util.*
 
 class UpdateApplicationUseCaseTest : BehaviorSpec({
@@ -27,30 +30,13 @@ class UpdateApplicationUseCaseTest : BehaviorSpec({
     val updateApplicationUseCase =
         UpdateApplicationUseCase(queryApplicationPort, commandApplicationPort, getCurrentUserService)
 
-    val user =
-        User(email = "email", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
-    val workspace = Workspace(
-        UUID.randomUUID().toString(),
-        title = "test workspace",
-        description = "test workspace description",
-        owner = user
-    )
+    val user = UserGenerator.generateUser()
+    val workspace = WorkspaceGenerator.generateWorkspace(user = user)
     val applicationId = "testId"
     val updateReqDto = UpdateApplicationReqDto(name = "updated application", description = "dldl", applicationType = ApplicationType.SPRING_BOOT, githubUrl = null, version = "11", port = 8080)
 
     given("애플리케이션이 주어지고") {
-        val application = Application(
-            id = applicationId,
-            name = "test",
-            description = "test",
-            applicationType = ApplicationType.SPRING_BOOT,
-            env = mapOf(),
-            githubUrl = "testUrl",
-            version = "17",
-            workspace = workspace,
-            port = 8080,
-            status = ApplicationStatus.STOPPED
-        )
+        val application = ApplicationGenerator.generateApplication(id = applicationId, workspace = workspace)
 
         `when`("usecase를 실행할때") {
             every { getCurrentUserService.getCurrentUser() } returns user

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/NonAuthChangePasswordUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/NonAuthChangePasswordUseCaseTest.kt
@@ -12,6 +12,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.springframework.security.crypto.password.PasswordEncoder
+import util.user.UserGenerator
 
 class NonAuthChangePasswordUseCaseTest : BehaviorSpec({
     val queryUserPort = mockk<QueryUserPort>()
@@ -20,8 +21,7 @@ class NonAuthChangePasswordUseCaseTest : BehaviorSpec({
     val nonAuthChangePasswordUseCase = NonAuthChangePasswordUseCase(queryUserPort, commandUserPort, passwordEncoder)
 
     given("유저와 NonAuthChangePasswordReqDto가 주어지고") {
-        val user =
-            User(email = "email", password = "existingPassword", name = "testName", roles = mutableListOf(Role.ROLE_USER))
+        val user = UserGenerator.generateUser()
         val nonAuthChangePasswordReqDto = NonAuthChangePasswordReqDto(email = "email", newPassword = "newPassword")
 
         `when`("유스케이스를 실행할때") {

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/ReissueTokenUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/ReissueTokenUseCaseTest.kt
@@ -16,6 +16,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import util.user.UserGenerator
 import java.time.LocalDateTime
 
 class ReissueTokenUseCaseTest : BehaviorSpec({
@@ -29,8 +30,7 @@ class ReissueTokenUseCaseTest : BehaviorSpec({
     val userId = "testUserId"
     val token = "testRefreshToken"
     val ttl = 1L
-    val user =
-        User(email = "email", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
+    val user = UserGenerator.generateUser()
     val tokenResDto = TokenResDto("newAccessToken", LocalDateTime.of(2023, 9, 7, 8, 30), "newRefreshToken", LocalDateTime.of(2023, 9, 7, 8, 30))
 
     given("리프레시 토큰이 주어지고") {

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/SignInUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/SignInUseCaseTest.kt
@@ -14,6 +14,7 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import util.user.UserGenerator
 import java.time.LocalDateTime
 
 class SignInUseCaseTest : BehaviorSpec({
@@ -27,8 +28,7 @@ class SignInUseCaseTest : BehaviorSpec({
         val testPassword = "testPassword"
         val requestDto = SignInReqDto(testEmail, testPassword)
 
-        val user =
-            User(email = testEmail, password = testPassword, name = "testName", roles = mutableListOf(Role.ROLE_USER))
+        val user = UserGenerator.generateUser()
         val accessTokenExp = LocalDateTime.of(2023, 9, 5, 8, 3)
         val refreshTokenExp = LocalDateTime.of(2023, 9, 5, 8, 3)
         val accessToken = "testAccessToken"

--- a/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangePasswordUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangePasswordUseCaseTest.kt
@@ -12,6 +12,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.springframework.security.crypto.password.PasswordEncoder
+import util.user.UserGenerator
 
 class ChangePasswordUseCaseTest : BehaviorSpec({
     val getCurrentUserService = mockk<GetCurrentUserService>()
@@ -20,8 +21,7 @@ class ChangePasswordUseCaseTest : BehaviorSpec({
     val changePasswordUseCase = ChangePasswordUseCase(getCurrentUserService, commandUserPort, passwordEncoder)
 
     given("User, PasswordChangeReqDto가 주어지고") {
-        val user =
-            User(email = "email", password = "existingPassword", name = "testName", roles = mutableListOf(Role.ROLE_USER))
+        val user = UserGenerator.generateUser()
         val passwordChangeReqDto = PasswordChangeReqDto(
             existingPassword = "existingPassword",
             newPassword = "newPassword"

--- a/src/test/kotlin/com/dcd/server/core/domain/user/usecase/GetUserProfileUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/user/usecase/GetUserProfileUseCaseTest.kt
@@ -18,6 +18,9 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import util.application.ApplicationGenerator
+import util.user.UserGenerator
+import util.workspace.WorkspaceGenerator
 import java.util.*
 
 class GetUserProfileUseCaseTest : BehaviorSpec({
@@ -28,26 +31,9 @@ class GetUserProfileUseCaseTest : BehaviorSpec({
     val getUserProfileUseCase = GetUserProfileUseCase(getCurrentUserService, queryWorkspacePort, queryApplicationPort)
 
     given("유저, 애플리케이션, 워크스페이스가 주어지고") {
-        val user =
-            User(email = "email", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
-        val workspace = Workspace(
-            UUID.randomUUID().toString(),
-            title = "test workspace",
-            description = "test workspace description",
-            owner = user
-        )
-        val application = Application(
-            id = "testId",
-            name = "test",
-            description = "test",
-            applicationType = ApplicationType.SPRING_BOOT,
-            env = mapOf(),
-            githubUrl = "testUrl",
-            version = "17",
-            workspace = workspace,
-            port = 8080,
-            status = ApplicationStatus.STOPPED
-        )
+        val user = UserGenerator.generateUser()
+        val workspace = WorkspaceGenerator.generateWorkspace(user = user)
+        val application = ApplicationGenerator.generateApplication(workspace = workspace)
 
         `when`("usecase를 실행할때") {
             every { getCurrentUserService.getCurrentUser() } returns user
@@ -69,8 +55,7 @@ class GetUserProfileUseCaseTest : BehaviorSpec({
     }
 
     given("유저가 주어지고") {
-        val user =
-            User(email = "email", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
+        val user = UserGenerator.generateUser()
 
         `when`("usecase를 실행할때") {
             every { getCurrentUserService.getCurrentUser() } returns user

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/service/ValidateWorkspaceOwnerServiceTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/service/ValidateWorkspaceOwnerServiceTest.kt
@@ -10,6 +10,8 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.mockk
+import util.user.UserGenerator
+import util.workspace.WorkspaceGenerator
 import java.util.*
 
 class ValidateWorkspaceOwnerServiceTest : BehaviorSpec({
@@ -17,14 +19,8 @@ class ValidateWorkspaceOwnerServiceTest : BehaviorSpec({
     val service = ValidateWorkspaceOwnerServiceImpl(getCurrentUserService)
 
     given("user와 workspace가 주어지고") {
-        val user =
-            User(email = "email", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
-        val workspace = Workspace(
-            id = UUID.randomUUID().toString(),
-            title = "workspace",
-            description = "test workspace",
-            owner = user
-        )
+        val user = UserGenerator.generateUser()
+        val workspace = WorkspaceGenerator.generateWorkspace(user = user)
         `when`("현재 인증된 유저가 workspace의 주인일때") {
             val result = service.validateOwner(user, workspace)
             then("결과값은 Unit이여야됨") {

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/CreateWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/CreateWorkspaceUseCaseTest.kt
@@ -11,6 +11,7 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import util.user.UserGenerator
 
 class CreateWorkspaceUseCaseTest : BehaviorSpec({
     val commandWorkspacePort = mockk<CommandWorkspacePort>(relaxed = true)
@@ -25,8 +26,7 @@ class CreateWorkspaceUseCaseTest : BehaviorSpec({
             description = "test workspace description"
         )
         `when`("useCase를 실행할때") {
-            val user =
-                User(email = "email", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
+            val user = UserGenerator.generateUser()
             every { getCurrentUserService.getCurrentUser() } returns user
             createWorkspaceUseCase.execute(createWorkspaceReqDto)
             then("워크스페이스를 저장하고 네트워크를 생성해야함") {

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteWorkspaceUseCaseTest.kt
@@ -14,6 +14,8 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import util.user.UserGenerator
+import util.workspace.WorkspaceGenerator
 import java.util.*
 
 class DeleteWorkspaceUseCaseTest : BehaviorSpec({
@@ -27,14 +29,8 @@ class DeleteWorkspaceUseCaseTest : BehaviorSpec({
         val workspaceId = UUID.randomUUID().toString()
 
         `when`("해당 id를 가진 workspace가 있을때") {
-            val user =
-                User(email = "email", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
-            val workspace = Workspace(
-                id = workspaceId,
-                title = "workspace",
-                description = "test workspace",
-                owner = user
-            )
+            val user = UserGenerator.generateUser()
+            val workspace = WorkspaceGenerator.generateWorkspace(user = user)
 
             every { getCurrentUserService.getCurrentUser() } returns user
             every { queryWorkspacePort.findById(workspaceId) } returns workspace

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/GetAllWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/GetAllWorkspaceUseCaseTest.kt
@@ -11,6 +11,8 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import util.user.UserGenerator
+import util.workspace.WorkspaceGenerator
 import java.util.*
 
 class GetAllWorkspaceUseCaseTest : BehaviorSpec({
@@ -20,22 +22,11 @@ class GetAllWorkspaceUseCaseTest : BehaviorSpec({
     val getAllWorkspaceUseCase = GetAllWorkspaceUseCase(getCurrentUserService, queryWorkspacePort, queryApplicationPort)
 
     given("workspaceId, workspace, workspaceList, user가 주어지고") {
-        val user =
-            User(email = "email", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
+        val user = UserGenerator.generateUser()
         val firstWorkspaceId = UUID.randomUUID().toString()
-        val firstWorkspace = Workspace(
-            id = firstWorkspaceId,
-            title = "workspace",
-            description = "test workspace",
-            owner = user
-        )
+        val firstWorkspace = WorkspaceGenerator.generateWorkspace(id = firstWorkspaceId, user = user)
         val secondWorkspaceId = UUID.randomUUID().toString()
-        val secondWorkspace = Workspace(
-            id = secondWorkspaceId,
-            title = "workspace",
-            description = "test workspace",
-            owner = user
-        )
+        val secondWorkspace = WorkspaceGenerator.generateWorkspace(id = secondWorkspaceId, user = user)
         val workspaceList = listOf(firstWorkspace, secondWorkspace)
 
         `when`("해당 user가 workspace를 여러개 가지고 있을때") {

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/GetWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/GetWorkspaceUseCaseTest.kt
@@ -13,6 +13,8 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import util.user.UserGenerator
+import util.workspace.WorkspaceGenerator
 import java.util.*
 
 class GetWorkspaceUseCaseTest : BehaviorSpec({
@@ -22,14 +24,8 @@ class GetWorkspaceUseCaseTest : BehaviorSpec({
 
     given("workspaceId, workspace가 주어지고") {
         val workspaceId = UUID.randomUUID().toString()
-        val user =
-            User(email = "email", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
-        val workspace = Workspace(
-            id = workspaceId,
-            title = "workspace",
-            description = "test workspace",
-            owner = user
-        )
+        val user = UserGenerator.generateUser()
+        val workspace = WorkspaceGenerator.generateWorkspace(id = workspaceId, user = user)
 
         `when`("해당 id를 가진 workspace가 있을때") {
             every { queryWorkspacePort.findById(workspaceId) } returns workspace

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/UpdateWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/UpdateWorkspaceUseCaseTest.kt
@@ -15,6 +15,8 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
+import util.user.UserGenerator
+import util.workspace.WorkspaceGenerator
 import java.util.*
 
 class UpdateWorkspaceUseCaseTest : BehaviorSpec({
@@ -28,8 +30,7 @@ class UpdateWorkspaceUseCaseTest : BehaviorSpec({
         val reqDto = UpdateWorkspaceReqDto(title = "test title", description = "test description")
 
         `when`("해당 아이디를 가진 워크스페이스가 있을때") {
-            val user =
-                User(email = "email", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
+            val user = UserGenerator.generateUser()
             val workspace = spyk(
                 Workspace(
                     id = workspaceId,
@@ -60,17 +61,10 @@ class UpdateWorkspaceUseCaseTest : BehaviorSpec({
         }
 
         `when`("워크스페이스의 유저와 로그인된 유저가 다를때") {
-            val user =
-                User(email = "email", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
-            val workspace = Workspace(
-                id = workspaceId,
-                title = "workspace",
-                description = "test workspace",
-                owner = user
-            )
+            val user = UserGenerator.generateUser()
+            val workspace = WorkspaceGenerator.generateWorkspace(user = user)
 
-            val anotherUser =
-                User(email = "anotherEmail", password = "password", name = "another", roles = mutableListOf(Role.ROLE_USER))
+            val anotherUser = UserGenerator.generateUser(email = "another")
 
             every { getCurrentUserService.getCurrentUser() } returns anotherUser
             every { queryWorkspacePort.findById(workspaceId) } returns workspace

--- a/src/test/kotlin/util/application/ApplicationGenerator.kt
+++ b/src/test/kotlin/util/application/ApplicationGenerator.kt
@@ -15,7 +15,7 @@ object ApplicationGenerator {
         env: Map<String, String> = mapOf(),
         githubUrl: String = "testUrl",
         version: String = "17",
-        workspace: Workspace = WorkspaceGenerator.createWorkspace(),
+        workspace: Workspace = WorkspaceGenerator.generateWorkspace(),
         port: Int = 8080,
         status: ApplicationStatus = ApplicationStatus.STOPPED
     ): Application =

--- a/src/test/kotlin/util/application/ApplicationGenerator.kt
+++ b/src/test/kotlin/util/application/ApplicationGenerator.kt
@@ -1,0 +1,34 @@
+package util.application
+
+import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
+import com.dcd.server.core.domain.application.model.enums.ApplicationType
+import com.dcd.server.core.domain.workspace.model.Workspace
+import util.workspace.WorkspaceGenerator
+
+object ApplicationGenerator {
+    fun generateApplication(
+        id: String = "testId",
+        name: String = "testName",
+        description: String = "testDescription",
+        applicationType: ApplicationType = ApplicationType.SPRING_BOOT,
+        env: Map<String, String> = mapOf(),
+        githubUrl: String = "testUrl",
+        version: String = "17",
+        workspace: Workspace = WorkspaceGenerator.createWorkspace(),
+        port: Int = 8080,
+        status: ApplicationStatus = ApplicationStatus.STOPPED
+    ): Application =
+        Application(
+            id = id,
+            name = name,
+            description = description,
+            applicationType = applicationType,
+            env = env,
+            githubUrl = githubUrl,
+            version = version,
+            workspace = workspace,
+            port = port,
+            status = status
+        )
+}

--- a/src/test/kotlin/util/user/UserGenerator.kt
+++ b/src/test/kotlin/util/user/UserGenerator.kt
@@ -1,0 +1,19 @@
+package util.user
+
+import com.dcd.server.core.domain.auth.model.Role
+import com.dcd.server.core.domain.user.model.User
+
+object UserGenerator {
+    fun createUser(
+        email: String = "testEmail",
+        password: String = "testPassword",
+        name: String = "testName",
+        roles: MutableList<Role> = mutableListOf(Role.ROLE_USER)
+    ): User =
+        User(
+            email = email,
+            password = password,
+            name = name,
+            roles = roles
+        )
+}

--- a/src/test/kotlin/util/user/UserGenerator.kt
+++ b/src/test/kotlin/util/user/UserGenerator.kt
@@ -4,7 +4,7 @@ import com.dcd.server.core.domain.auth.model.Role
 import com.dcd.server.core.domain.user.model.User
 
 object UserGenerator {
-    fun createUser(
+    fun generateUser(
         email: String = "testEmail",
         password: String = "testPassword",
         name: String = "testName",

--- a/src/test/kotlin/util/workspace/WorkspaceGenerator.kt
+++ b/src/test/kotlin/util/workspace/WorkspaceGenerator.kt
@@ -6,11 +6,11 @@ import util.user.UserGenerator
 import java.util.*
 
 object WorkspaceGenerator {
-    fun createWorkspace(
+    fun generateWorkspace(
         id: String = UUID.randomUUID().toString(),
         title: String = "testTitle",
         description: String = "testDescription",
-        user: User = UserGenerator.createUser()
+        user: User = UserGenerator.generateUser()
     ): Workspace =
         Workspace(
             id = id,

--- a/src/test/kotlin/util/workspace/WorkspaceGenerator.kt
+++ b/src/test/kotlin/util/workspace/WorkspaceGenerator.kt
@@ -1,0 +1,21 @@
+package util.workspace
+
+import com.dcd.server.core.domain.user.model.User
+import com.dcd.server.core.domain.workspace.model.Workspace
+import util.user.UserGenerator
+import java.util.*
+
+object WorkspaceGenerator {
+    fun createWorkspace(
+        id: String = UUID.randomUUID().toString(),
+        title: String = "testTitle",
+        description: String = "testDescription",
+        user: User = UserGenerator.createUser()
+    ): Workspace =
+        Workspace(
+            id = id,
+            title = title,
+            description = description,
+            owner = user
+        )
+}


### PR DESCRIPTION
## 🔖 개요
* 테스트 코드에서 객체를 생성할때 중복되는 부분이 너무 많아서 따로 생성하는 메서드 추가

## 📜 작업내용
* UserGenerator 추가
* WorkspaceGenerator 추가
* ApplicationGenerator 추가
* 애플리케이션 테스트에 generator 적용
* 인증/인가 테스트에 generator 적용
* 유저 테스트에 generator 적용
* 워크스페이스 테스트에 generator 적용