### PR TITLE
🔀 :: 185 - 애플리케이션 실행/정지 API 테스트 커버리지 높이기

### DIFF
--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCaseTest.kt
@@ -1,15 +1,12 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.domain.application.dto.response.RunApplicationResDto
+import com.dcd.server.core.domain.application.exception.AlreadyRunningException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
-import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.*
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
-import com.dcd.server.core.domain.auth.model.Role
-import com.dcd.server.core.domain.user.model.User
-import com.dcd.server.core.domain.workspace.model.Workspace
 import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
@@ -20,7 +17,6 @@ import io.mockk.verify
 import util.application.ApplicationGenerator
 import util.user.UserGenerator
 import util.workspace.WorkspaceGenerator
-import java.util.*
 
 class RunApplicationUseCaseTest : BehaviorSpec({
     val cloneApplicationByUrlService = mockk<CloneApplicationByUrlService>(relaxUnitFun = true)
@@ -73,6 +69,15 @@ class RunApplicationUseCaseTest : BehaviorSpec({
                 }
             }
         }
+
+        `when`("해당 애플리케이션이 이미 실행된 있는 상태일때") {
+            every { queryApplicationPort.findById("testId") } returns application.copy(status = ApplicationStatus.RUNNING)
+            then("AlreadyRunningException이 발생해야됨") {
+                shouldThrow<AlreadyRunningException> {
+                    runApplicationUseCase.execute("testId")
+                }
+            }
+        }
     }
 
     given("mysql application, runApplicationReqDto가 주어지고") {
@@ -94,6 +99,15 @@ class RunApplicationUseCaseTest : BehaviorSpec({
                 }
             }
         }
+
+        `when`("해당 애플리케이션이 이미 실행된 있는 상태일때") {
+            every { queryApplicationPort.findById("testId") } returns application.copy(status = ApplicationStatus.RUNNING)
+            then("AlreadyRunningException이 발생해야됨") {
+                shouldThrow<AlreadyRunningException> {
+                    runApplicationUseCase.execute("testId")
+                }
+            }
+        }
     }
 
     given("redis application, runApplicationReqDto가 주어지고") {
@@ -112,6 +126,15 @@ class RunApplicationUseCaseTest : BehaviorSpec({
                     verify { createDockerFileService.createFileToApplication(application, application.version, 0) }
                     verify { buildDockerImageService.buildImageByApplication(application) }
                     verify { changeApplicationStatusService.changeApplicationStatus(application, ApplicationStatus.RUNNING) }
+                }
+            }
+        }
+
+        `when`("해당 애플리케이션이 이미 실행된 있는 상태일때") {
+            every { queryApplicationPort.findById("testId") } returns application.copy(status = ApplicationStatus.RUNNING)
+            then("AlreadyRunningException이 발생해야됨") {
+                shouldThrow<AlreadyRunningException> {
+                    runApplicationUseCase.execute("testId")
                 }
             }
         }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
@@ -38,6 +38,7 @@ class StopApplicationUseCaseTest : BehaviorSpec({
             then("deleteContainerService와 deleteApplicationDirectoryService가 실행되어야함") {
                 verify { deleteApplicationDirectoryService.deleteApplicationDirectory(application) }
                 verify { deleteContainerService.deleteContainer(application) }
+                verify { changeApplicationStatusService.changeApplicationStatus(application, ApplicationStatus.STOPPED) }
             }
         }
         `when`("해당 애플리케이션이 존재하지 않을때") {

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.core.domain.application.usecase
 
+import com.dcd.server.core.domain.application.exception.AlreadyStoppedException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
@@ -49,6 +50,14 @@ class StopApplicationUseCaseTest : BehaviorSpec({
             every { queryApplicationPort.findById(applicationId) } returns null
             then("ApplicationNotFoundException이 발생해야함") {
                 shouldThrow<ApplicationNotFoundException> {
+                    stopApplicationUseCase.execute(applicationId)
+                }
+            }
+        }
+        `when`("해당 애플리케이션이 이미 정지된 있는 상태일때") {
+            every { queryApplicationPort.findById(applicationId) } returns application.copy(status = ApplicationStatus.STOPPED)
+            then("AlreadyStoppedException이 발생해야됨") {
+                shouldThrow<AlreadyStoppedException> {
                     stopApplicationUseCase.execute(applicationId)
                 }
             }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
@@ -2,16 +2,11 @@ package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.domain.application.exception.AlreadyStoppedException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
-import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
-import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.ChangeApplicationStatusService
 import com.dcd.server.core.domain.application.service.DeleteApplicationDirectoryService
 import com.dcd.server.core.domain.application.service.DeleteContainerService
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
-import com.dcd.server.core.domain.auth.model.Role
-import com.dcd.server.core.domain.user.model.User
-import com.dcd.server.core.domain.workspace.model.Workspace
 import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
@@ -21,7 +16,6 @@ import io.mockk.verify
 import util.application.ApplicationGenerator
 import util.user.UserGenerator
 import util.workspace.WorkspaceGenerator
-import java.util.*
 
 class StopApplicationUseCaseTest : BehaviorSpec({
     val queryApplicationPort = mockk<QueryApplicationPort>()


### PR DESCRIPTION
## 🔖 개요
* 애플리케이션 실행/정지 API 테스트 코드의 테스트 커버리지를 높입니다.

## 📜 작업내용
* 애플리케이션 정지 테스트 코드에 이미 정지되어있는 경우 실행할때 에러가 발생하는지 검증하는 테스트 케이스
* 애플리케이션 실행 테스트 코드에 이미 실행되어있는 경우 실행할때 에러가 발생하는지 검증하는 테스트 케이스
* 애플리케이션 정지 테스트 코드에 애플리케이션 상태 변경되는지 검증하는 로직 추가

## 🎸 기타
* 실행/정지 테스트 코드에서 사용되지 않는 임포트 제거