### PR TITLE
🔀 :: 187 - 애플리케이션 로그 조회 API

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/response/ApplicationLogResDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/response/ApplicationLogResDto.kt
@@ -1,0 +1,5 @@
+package com.dcd.server.core.domain.application.dto.response
+
+data class ApplicationLogResDto(
+    val logs: List<String>
+)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/GetContainerLogService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/GetContainerLogService.kt
@@ -1,0 +1,7 @@
+package com.dcd.server.core.domain.application.service
+
+import com.dcd.server.core.domain.application.model.Application
+
+interface GetContainerLogService {
+    fun getLogs(application: Application): List<String>
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetContainerLogServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetContainerLogServiceImpl.kt
@@ -1,0 +1,20 @@
+package com.dcd.server.core.domain.application.service.impl
+
+import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.service.GetContainerLogService
+import org.springframework.stereotype.Service
+import java.io.BufferedReader
+import java.io.InputStreamReader
+
+@Service
+class GetContainerLogServiceImpl : GetContainerLogService {
+    override fun getLogs(application: Application): List<String> {
+        val cmd = arrayOf("/bin/sh", "-c", "docker logs ${application.name}")
+        val p = Runtime.getRuntime().exec(cmd)
+        val br = BufferedReader(InputStreamReader(p.inputStream))
+        val result = br.readLines()
+        p.waitFor()
+        p.destroy()
+        return result
+    }
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCase.kt
@@ -1,0 +1,27 @@
+package com.dcd.server.core.domain.application.usecase
+
+import com.dcd.server.core.common.annotation.ReadOnlyUseCase
+import com.dcd.server.core.domain.application.dto.response.ApplicationLogResDto
+import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
+import com.dcd.server.core.domain.application.service.GetContainerLogService
+import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import com.dcd.server.core.domain.user.service.GetCurrentUserService
+import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
+
+@ReadOnlyUseCase
+class GetApplicationLogUseCase(
+    private val getContainerLogService: GetContainerLogService,
+    private val queryApplicationPort: QueryApplicationPort,
+    private val getCurrentUserService: GetCurrentUserService,
+    private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService
+) {
+    fun execute(id: String): ApplicationLogResDto {
+        val application = (queryApplicationPort.findById(id)
+            ?: throw ApplicationNotFoundException())
+        val user = getCurrentUserService.getCurrentUser()
+        validateWorkspaceOwnerService.validateOwner(user, application.workspace)
+
+        val logs = getContainerLogService.getLogs(application)
+        return ApplicationLogResDto(logs)
+    }
+}

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
@@ -62,6 +62,7 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.PATCH, "/application/{id}").authenticated()
                 it.requestMatchers(HttpMethod.GET, "/application/version/{applicationType}").authenticated()
                 it.requestMatchers(HttpMethod.POST, "/application/{id}/certificate").authenticated()
+                it.requestMatchers(HttpMethod.GET, "/application/{id}/logs").authenticated()
 
                 //workspace
                 it.requestMatchers(HttpMethod.POST, "/workspace").authenticated()

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
@@ -8,10 +8,7 @@ import com.dcd.server.presentation.domain.application.data.request.AddApplicatio
 import com.dcd.server.presentation.domain.application.data.request.CreateApplicationRequest
 import com.dcd.server.presentation.domain.application.data.request.GenerateSSLCertificateRequest
 import com.dcd.server.presentation.domain.application.data.request.UpdateApplicationRequest
-import com.dcd.server.presentation.domain.application.data.response.ApplicationListResponse
-import com.dcd.server.presentation.domain.application.data.response.ApplicationResponse
-import com.dcd.server.presentation.domain.application.data.response.AvailableVersionResponse
-import com.dcd.server.presentation.domain.application.data.response.RunApplicationResponse
+import com.dcd.server.presentation.domain.application.data.response.*
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
@@ -30,7 +27,8 @@ class ApplicationWebAdapter(
     private val deleteApplicationUseCase: DeleteApplicationUseCase,
     private val updateApplicationUseCase: UpdateApplicationUseCase,
     private val getAvailableVersionUseCase: GetAvailableVersionUseCase,
-    private val generateSSLCertificateUseCase: GenerateSSLCertificateUseCase
+    private val generateSSLCertificateUseCase: GenerateSSLCertificateUseCase,
+    private val getApplicationLogUseCase: GetApplicationLogUseCase
 ) {
     @PostMapping("/{workspaceId}")
     fun createApplication(@PathVariable workspaceId: String, @Validated @RequestBody createApplicationRequest: CreateApplicationRequest): ResponseEntity<Void> =
@@ -86,4 +84,9 @@ class ApplicationWebAdapter(
     fun generateSSLCertificate(@PathVariable id: String, @RequestBody generateSSLCertificateRequest: GenerateSSLCertificateRequest): ResponseEntity<Void> =
         generateSSLCertificateUseCase.execute(id, generateSSLCertificateRequest.toDto())
             .run { ResponseEntity.ok().build() }
+
+    @GetMapping("/{id}/logs")
+    fun getApplicationLog(@PathVariable id: String): ResponseEntity<ApplicationLogResponse> =
+        getApplicationLogUseCase.execute(id)
+            .let { ResponseEntity.ok(it.toResponse()) }
 }

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationResponseDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationResponseDataExtension.kt
@@ -37,3 +37,8 @@ fun RunApplicationResDto.toResponse(): RunApplicationResponse =
     RunApplicationResponse(
         externalPort = this.externalPort
     )
+
+fun ApplicationLogResDto.toResponse(): ApplicationLogResponse =
+    ApplicationLogResponse(
+        logs = this.logs
+    )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/response/ApplicationLogResponse.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/response/ApplicationLogResponse.kt
@@ -1,0 +1,5 @@
+package com.dcd.server.presentation.domain.application.data.response
+
+data class ApplicationLogResponse(
+    val logs: List<String>
+)

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -34,7 +34,8 @@ class ApplicationWebAdapterTest : BehaviorSpec({
     val updateApplicationUseCase = mockk<UpdateApplicationUseCase>(relaxUnitFun = true)
     val getAvailableVersionUseCase = mockk<GetAvailableVersionUseCase>()
     val generateSSLCertificateUseCase = mockk<GenerateSSLCertificateUseCase>(relaxUnitFun = true)
-    val applicationWebAdapter = ApplicationWebAdapter(createApplicationUseCase, springRunApplicationUseCase, getAllApplicationUseCase, getOneApplicationUseCase, addApplicationEnvUseCase, deleteApplicationEnvUseCase, stopApplicationUseCase, deleteApplicationUseCase, updateApplicationUseCase, getAvailableVersionUseCase, generateSSLCertificateUseCase)
+    val getApplicationLogUseCase = mockk<GetApplicationLogUseCase>()
+    val applicationWebAdapter = ApplicationWebAdapter(createApplicationUseCase, springRunApplicationUseCase, getAllApplicationUseCase, getOneApplicationUseCase, addApplicationEnvUseCase, deleteApplicationEnvUseCase, stopApplicationUseCase, deleteApplicationUseCase, updateApplicationUseCase, getAvailableVersionUseCase, generateSSLCertificateUseCase, getApplicationLogUseCase)
 
     given("CreateApplicationRequest가 주어지고") {
         val request = CreateApplicationRequest(


### PR DESCRIPTION
## 🔖 개요
* 애플리케이션 로그 조회 API를 추가합니다.

## 📜 작업내용
* GetContainerLogService 추가
* 애플리케이션 로그 응답 객체 추가
* GetApplicationLogUseCase 추가
* API 엔드포인트 추가
* 추가된 엔드포인트 권한 설정