### PR TITLE
🔀 :: 189 - 애플리케이션 로그 조회 API 테스트 코드

### DIFF
--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCaseTest.kt
@@ -11,6 +11,7 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import util.application.ApplicationGenerator
 import util.user.UserGenerator
 import util.workspace.WorkspaceGenerator
@@ -67,6 +68,9 @@ class GetApplicationLogUseCaseTest : BehaviorSpec({
             val response = getApplicationLogUseCase.execute(appId)
             then("유스케이스의 반환값은 logs를 가지고 있어야함") {
                 response.logs shouldBe logs
+            }
+            then("유스케이스는 getContainerLogService를 실행해야함") {
+                verify { getContainerLogService.getLogs(application) }
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCaseTest.kt
@@ -8,6 +8,7 @@ import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameExcep
 import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import util.application.ApplicationGenerator
@@ -53,6 +54,19 @@ class GetApplicationLogUseCaseTest : BehaviorSpec({
                 shouldThrow<WorkspaceOwnerNotSameException> {
                     getApplicationLogUseCase.execute(appId)
                 }
+            }
+        }
+
+        `when`("해당 애플리케이션이 존재하고, 로그인된 유저가 워크스페이스의 권한을 가지고 있을때") {
+            val logs = listOf("testLogs")
+
+            every { queryApplicationPort.findById(appId) } returns application
+            every { getCurrentUserService.getCurrentUser() } returns owner
+            every { getContainerLogService.getLogs(application) } returns logs
+
+            val response = getApplicationLogUseCase.execute(appId)
+            then("유스케이스의 반환값은 logs를 가지고 있어야함") {
+                response.logs shouldBe logs
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCaseTest.kt
@@ -1,0 +1,45 @@
+package com.dcd.server.core.domain.application.usecase
+
+import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
+import com.dcd.server.core.domain.application.service.GetContainerLogService
+import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import com.dcd.server.core.domain.user.service.GetCurrentUserService
+import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameException
+import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+import util.application.ApplicationGenerator
+import util.user.UserGenerator
+import util.workspace.WorkspaceGenerator
+
+class GetApplicationLogUseCaseTest : BehaviorSpec({
+    val getContainerLogService = mockk<GetContainerLogService>()
+    val queryApplicationPort = mockk<QueryApplicationPort>()
+    val getCurrentUserService = mockk<GetCurrentUserService>()
+    val validateWorkspaceOwnerService = mockk<ValidateWorkspaceOwnerService>(relaxUnitFun = true)
+    val getApplicationLogUseCase = GetApplicationLogUseCase(
+        getContainerLogService,
+        queryApplicationPort,
+        getCurrentUserService,
+        validateWorkspaceOwnerService
+    )
+
+    given("애플리케이션 id가 주어지고") {
+        val appId = "testApplicationId"
+        val owner = UserGenerator.generateUser()
+        val workspace = WorkspaceGenerator.generateWorkspace(user = owner)
+        val application = ApplicationGenerator.generateApplication(id = appId, workspace = workspace)
+
+        `when`("해당 애플리케이션이 존재하지 않을때") {
+            every { queryApplicationPort.findById(appId) } returns null
+
+            then("유스케이스 실행시 ApplicationNotFoundException이 발생해야함") {
+                shouldThrow<ApplicationNotFoundException> {
+                    getApplicationLogUseCase.execute(appId)
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCaseTest.kt
@@ -41,5 +41,19 @@ class GetApplicationLogUseCaseTest : BehaviorSpec({
                 }
             }
         }
+
+        `when`("해당 애플리케이션이 존재하지만, 로그인된 유저가 워크스페이스의 권한을 가지고 있지 않을때") {
+            val user = UserGenerator.generateUser(email = "thief")
+
+            every { queryApplicationPort.findById(appId) } returns application
+            every { getCurrentUserService.getCurrentUser() } returns user
+            every { validateWorkspaceOwnerService.validateOwner(user, workspace) } throws WorkspaceOwnerNotSameException()
+
+            then("유스케이스 실행시 WorkspaceOwnerNotSameException이 발생해야함") {
+                shouldThrow<WorkspaceOwnerNotSameException> {
+                    getApplicationLogUseCase.execute(appId)
+                }
+            }
+        }
     }
 })

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -2,10 +2,7 @@ package com.dcd.server.presentation.domain.application
 
 import com.dcd.server.core.domain.application.dto.request.GenerateSSLCertificateReqDto
 import com.dcd.server.core.domain.application.dto.request.UpdateApplicationReqDto
-import com.dcd.server.core.domain.application.dto.response.ApplicationListResDto
-import com.dcd.server.core.domain.application.dto.response.ApplicationResDto
-import com.dcd.server.core.domain.application.dto.response.AvailableVersionResDto
-import com.dcd.server.core.domain.application.dto.response.RunApplicationResDto
+import com.dcd.server.core.domain.application.dto.response.*
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.usecase.*
@@ -161,6 +158,18 @@ class ApplicationWebAdapterTest : BehaviorSpec({
             val result = applicationWebAdapter.deleteApplication(testId)
             then("status는 200이여야함") {
                 result.statusCode shouldBe HttpStatus.OK
+            }
+        }
+
+        `when`("getApplicationLog 메서드를 실행할때") {
+            val logs = listOf("testLogs")
+            every { getApplicationLogUseCase.execute(testId) } returns ApplicationLogResDto(logs)
+            val result = applicationWebAdapter.getApplicationLog(testId)
+            then("status는 200이여야함") {
+                result.statusCode shouldBe HttpStatus.OK
+            }
+            then("응답의 바디는 반환된 로그를 포함해야함") {
+                result.body!!.logs shouldBe logs
             }
         }
     }


### PR DESCRIPTION
## 🔖 개요
* 애플리케이션 로그 조회 API 테스트 코드를 작성합니다.

## 📜 작업내용
* GetApplicationLogUseCase 테스트 코드
  * 유스케이스를 실행할때 해당 id를 가진 애플리케이션이 존재하지 않는 테스트 케이스
  * 유스케이스를 실행할때 해당 id를 가진 애플리케이션은 존재하지만, 로그인된 유저는 워크스페이스에 권한이 없는 테스트 케이스
  * 유스케이스를 실행할때 해당 id를 가진 애플리케이션이 존재하고, 로그인된 유저가 워크스페이스에 권한이 있는 테스트 케이스
* ApplicationWebAdapter에서 getApplicationLog 메서드를 호출하는 테스트 케이스