### PR TITLE
🔀 :: 191 - 애플리케이션 배포/실행 개념의 분리

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
@@ -31,6 +31,7 @@ enum class ErrorCode(
     WORKSPACE_NOT_FOUND("해당 워크스페이스를 찾을 수 없음", 404),
 
     CONTAINER_NOT_RUN("해당 애플리케이션을 실행할 수 없음", 500),
+    CONTAINER_NOT_CREATED("해당 애플리케이션의 이미지를 컨테이너로 빌드할 수 없음", 500),
     IMAGE_NOT_BUILT("해당 애플리케이션을 이미지로 빌드할 수 없음", 500),
     INTERNAL_ERROR("서버 내부 에러", 500)
 }

--- a/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
@@ -31,6 +31,7 @@ enum class ErrorCode(
     WORKSPACE_NOT_FOUND("해당 워크스페이스를 찾을 수 없음", 404),
 
     CONTAINER_NOT_RUN("해당 애플리케이션을 실행할 수 없음", 500),
+    CONTAINER_NOT_STOPPED("해당 애플리케이션을 정지할 수 없음", 500),
     CONTAINER_NOT_CREATED("해당 애플리케이션의 이미지를 컨테이너로 빌드할 수 없음", 500),
     IMAGE_NOT_BUILT("해당 애플리케이션을 이미지로 빌드할 수 없음", 500),
     INTERNAL_ERROR("서버 내부 에러", 500)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/exception/ContainerNotCreatedException.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/exception/ContainerNotCreatedException.kt
@@ -1,0 +1,7 @@
+package com.dcd.server.core.domain.application.exception
+
+import com.dcd.server.core.common.error.BasicException
+import com.dcd.server.core.common.error.ErrorCode
+
+class ContainerNotCreatedException : BasicException(ErrorCode.CONTAINER_NOT_CREATED) {
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/exception/ContainerNotStoppedException.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/exception/ContainerNotStoppedException.kt
@@ -1,0 +1,7 @@
+package com.dcd.server.core.domain.application.exception
+
+import com.dcd.server.core.common.error.BasicException
+import com.dcd.server.core.common.error.ErrorCode
+
+class ContainerNotStoppedException : BasicException(ErrorCode.CONTAINER_NOT_STOPPED) {
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/CreateContainerService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/CreateContainerService.kt
@@ -1,0 +1,9 @@
+package com.dcd.server.core.domain.application.service
+
+import com.dcd.server.core.domain.application.model.Application
+
+interface CreateContainerService {
+    fun createContainer(application: Application, externalPort: Int)
+
+    fun createContainer(application: Application, version: String, externalPort: Int)
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/DockerRunService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/DockerRunService.kt
@@ -3,12 +3,9 @@ package com.dcd.server.core.domain.application.service
 import com.dcd.server.core.domain.application.model.Application
 
 interface DockerRunService {
-    fun runApplication(id: String, externalPort: Int)
+    fun runApplication(id: String)
 
-    fun runApplication(application: Application, externalPort: Int)
+    fun runApplication(application: Application)
 
-    fun runApplication(id: String, version: String, externalPort: Int)
-
-    fun runApplication(application: Application, version: String, externalPort: Int)
 
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/StopContainerService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/StopContainerService.kt
@@ -1,0 +1,7 @@
+package com.dcd.server.core.domain.application.service
+
+import com.dcd.server.core.domain.application.model.Application
+
+interface StopContainerService {
+    fun stopContainer(application: Application)
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateContainerServiceImpl.kt
@@ -1,0 +1,66 @@
+package com.dcd.server.core.domain.application.service.impl
+
+import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.domain.application.exception.ApplicationEnvNotFoundException
+import com.dcd.server.core.domain.application.exception.ContainerNotCreatedException
+import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.enums.ApplicationType
+import com.dcd.server.core.domain.application.service.CreateContainerService
+import org.springframework.stereotype.Service
+
+@Service
+class CreateContainerServiceImpl(
+    private val commandPort: CommandPort
+) : CreateContainerService{
+    override fun createContainer(application: Application, externalPort: Int) {
+        create(application, externalPort = externalPort)
+    }
+
+    override fun createContainer(application: Application, version: String, externalPort: Int) {
+        create(application, version, externalPort)
+    }
+
+    private fun create(application: Application, version: String = "latest", externalPort: Int) {
+        val cmd =
+            when (application.applicationType) {
+                ApplicationType.SPRING_BOOT -> {
+                    "docker create --network ${application.workspace.title.replace(' ', '_')} " +
+                    "--name ${application.name.lowercase()} -d " +
+                    "-p ${externalPort}:${application.port} ${application.name.lowercase()}:$version"
+                }
+
+                ApplicationType.MYSQL -> {
+                    val defaultDB =
+                        if (application.env.containsKey("database"))
+                            "-e MYSQL_DATABASE=${application.env["database"]} "
+                        else ""
+                    "docker create --network ${application.workspace.title.replace(' ', '_')} " +
+                    "-e MYSQL_ROOT_PASSWORD=${application.env["rootPassword"] ?: throw ApplicationEnvNotFoundException()} " +
+                    defaultDB +
+                    "--name ${application.name.lowercase()} -d " +
+                    "-p ${externalPort}:${application.port} mysql:$version"
+                }
+
+                ApplicationType.MARIA_DB -> {
+                    val defaultDB =
+                        if (application.env.containsKey("database"))
+                            "-e MYSQL_DATABASE=${application.env["database"]} "
+                        else ""
+                    "docker create --network ${application.workspace.title.replace(' ', '_')} " +
+                    "-e MYSQL_ROOT_PASSWORD=${application.env["rootPassword"] ?: throw ApplicationEnvNotFoundException()} " +
+                    defaultDB +
+                    "--name ${application.name.lowercase()} -d " +
+                    "-p ${externalPort}:${application.port} mariadb:$version"
+                }
+
+                ApplicationType.REDIS -> {
+                    "docker run --network ${application.workspace.title.replace(' ', '_')} " +
+                    "--name ${application.name.lowercase()} -d " +
+                    "-p ${externalPort}:${application.port} redis:$version"
+                }
+            }
+
+        val exitValue = commandPort.executeShellCommand(cmd)
+        if (exitValue != 0) throw ContainerNotCreatedException()
+    }
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DockerRunServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DockerRunServiceImpl.kt
@@ -3,6 +3,7 @@ package com.dcd.server.core.domain.application.service.impl
 import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.domain.application.exception.ApplicationEnvNotFoundException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
+import com.dcd.server.core.domain.application.exception.ContainerNotCreatedException
 import com.dcd.server.core.domain.application.exception.ContainerNotRunException
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
@@ -15,75 +16,18 @@ class DockerRunServiceImpl(
     private val queryApplicationPort: QueryApplicationPort,
     private val commandPort: CommandPort
 ) : DockerRunService {
-    override fun runApplication(id: String, externalPort: Int) {
+    override fun runApplication(id: String) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
-        run(application, externalPort = externalPort)
+        run(application)
     }
 
-    override fun runApplication(application: Application, externalPort: Int) {
-        run(application, externalPort = externalPort)
+    override fun runApplication(application: Application) {
+        run(application)
     }
 
-    override fun runApplication(id: String, version: String, externalPort: Int) {
-        val application = (queryApplicationPort.findById(id)
-            ?: throw ApplicationNotFoundException())
-        run(application, version, externalPort)
-    }
-
-    override fun runApplication(application: Application, version: String, externalPort: Int) {
-        run(application, version, externalPort)
-    }
-
-    private fun run(application: Application, version: String = "latest", externalPort: Int) {
-        val exitValue =
-            when (application.applicationType) {
-                ApplicationType.SPRING_BOOT -> {
-                    commandPort.executeShellCommand(
-                        "cd ${application.name} " +
-                        "&& docker run --network ${application.workspace.title.replace(' ', '_')} " +
-                        "--name ${application.name.lowercase()} -d " +
-                        "-p ${externalPort}:${application.port} ${application.name.lowercase()}:$version"
-                    )
-                }
-
-                ApplicationType.MYSQL -> {
-                    val defaultDB =
-                        if (application.env.containsKey("database"))
-                            "-e MYSQL_DATABASE=${application.env["database"]} "
-                        else ""
-                    commandPort.executeShellCommand(
-                        "docker run --network ${application.workspace.title.replace(' ', '_')} " +
-                        "-e MYSQL_ROOT_PASSWORD=${application.env["rootPassword"] ?: throw ApplicationEnvNotFoundException()} " +
-                        defaultDB +
-                        "--name ${application.name.lowercase()} -d " +
-                        "-p ${externalPort}:${application.port} mysql:$version"
-                    )
-                }
-
-                ApplicationType.MARIA_DB -> {
-                    val defaultDB =
-                        if (application.env.containsKey("database"))
-                            "-e MYSQL_DATABASE=${application.env["database"]} "
-                        else ""
-                    commandPort.executeShellCommand(
-                        "docker run --network ${application.workspace.title.replace(' ', '_')} " +
-                        "-e MYSQL_ROOT_PASSWORD=${application.env["rootPassword"] ?: throw ApplicationEnvNotFoundException()} " +
-                        defaultDB +
-                        "--name ${application.name.lowercase()} -d " +
-                        "-p ${externalPort}:${application.port} mariadb:$version"
-                    )
-                }
-
-                ApplicationType.REDIS -> {
-                    commandPort.executeShellCommand(
-                        "docker run --network ${application.workspace.title.replace(' ', '_')} " +
-                        "--name ${application.name.lowercase()} -d " +
-                        "-p ${externalPort}:${application.port} redis:$version"
-                    )
-                }
-            }
-
+    private fun run(application: Application) {
+        val exitValue = commandPort.executeShellCommand("docker start ${application.name.lowercase()}")
         if (exitValue != 0) throw ContainerNotRunException()
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/StopContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/StopContainerServiceImpl.kt
@@ -1,0 +1,16 @@
+package com.dcd.server.core.domain.application.service.impl
+
+import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.service.StopContainerService
+import org.springframework.stereotype.Service
+
+@Service
+class StopContainerServiceImpl(
+    private val commandPort: CommandPort
+) : StopContainerService {
+    override fun stopContainer(application: Application) {
+        val exitValue = commandPort.executeShellCommand("docker stop ${application.name.lowercase()}")
+        if (exitValue != 0) throw RuntimeException()
+    }
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCase.kt
@@ -3,6 +3,8 @@ package com.dcd.server.core.domain.application.usecase
 import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.domain.application.dto.extenstion.toEntity
 import com.dcd.server.core.domain.application.dto.request.CreateApplicationReqDto
+import com.dcd.server.core.domain.application.model.enums.ApplicationType
+import com.dcd.server.core.domain.application.service.*
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
 import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
@@ -12,7 +14,13 @@ import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
 class CreateApplicationUseCase(
     private val commandApplicationPort: CommandApplicationPort,
     private val queryWorkspacePort: QueryWorkspacePort,
-    private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService
+    private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService,
+    private val cloneApplicationByUrlService: CloneApplicationByUrlService,
+    private val modifyGradleService: ModifyGradleService,
+    private val createDockerFileService: CreateDockerFileService,
+    private val getExternalPortService: GetExternalPortService,
+    private val buildDockerImageService: BuildDockerImageService,
+    private val createContainerService: CreateContainerService
 ) {
     fun execute(workspaceId: String, createApplicationReqDto: CreateApplicationReqDto) {
         val workspace = queryWorkspacePort.findById(workspaceId)
@@ -20,5 +28,21 @@ class CreateApplicationUseCase(
         validateWorkspaceOwnerService.validateOwner(workspace)
         val application = createApplicationReqDto.toEntity(workspace)
         commandApplicationPort.save(application)
+
+        val version = application.version
+        val externalPort = getExternalPortService.getExternalPort(application.port)
+        when(application.applicationType){
+            ApplicationType.SPRING_BOOT -> {
+                cloneApplicationByUrlService.cloneByApplication(application)
+                modifyGradleService.modifyGradleByApplication(application)
+                createDockerFileService.createFileToApplication(application, version, externalPort)
+                buildDockerImageService.buildImageByApplication(application)
+                createContainerService.createContainer(application, externalPort)
+            }
+
+            else -> {
+                createContainerService.createContainer(application, version, externalPort)
+            }
+        }
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCase.kt
@@ -1,28 +1,21 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.ReadOnlyUseCase
-import com.dcd.server.core.domain.application.dto.response.RunApplicationResDto
 import com.dcd.server.core.domain.application.exception.AlreadyRunningException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
-import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.*
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 
 @ReadOnlyUseCase
 class RunApplicationUseCase(
-    private val cloneApplicationByUrlService: CloneApplicationByUrlService,
-    private val modifyGradleService: ModifyGradleService,
-    private val createDockerFileService: CreateDockerFileService,
-    private val buildDockerImageService: BuildDockerImageService,
     private val dockerRunService: DockerRunService,
     private val queryApplicationPort: QueryApplicationPort,
     private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService,
-    private val getExternalPortService: GetExternalPortService,
     private val changeApplicationStatusService: ChangeApplicationStatusService
 ) {
-    fun execute(id: String): RunApplicationResDto {
+    fun execute(id: String) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
 
@@ -31,24 +24,8 @@ class RunApplicationUseCase(
 
         validateWorkspaceOwnerService.validateOwner(application.workspace)
 
-        val version = application.version
-        val externalPort = getExternalPortService.getExternalPort(application.port)
-        when(application.applicationType){
-            ApplicationType.SPRING_BOOT -> {
-                cloneApplicationByUrlService.cloneByApplication(application)
-                modifyGradleService.modifyGradleByApplication(application)
-                createDockerFileService.createFileToApplication(application, version, externalPort)
-                buildDockerImageService.buildImageByApplication(application)
-                dockerRunService.runApplication(application, externalPort)
-            }
-
-            else -> {
-                dockerRunService.runApplication(application, version, externalPort)
-            }
-        }
+        dockerRunService.runApplication(application)
 
         changeApplicationStatusService.changeApplicationStatus(application, ApplicationStatus.RUNNING)
-
-        return RunApplicationResDto(externalPort = externalPort)
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCase.kt
@@ -7,6 +7,7 @@ import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.service.ChangeApplicationStatusService
 import com.dcd.server.core.domain.application.service.DeleteApplicationDirectoryService
 import com.dcd.server.core.domain.application.service.DeleteContainerService
+import com.dcd.server.core.domain.application.service.StopContainerService
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.user.service.GetCurrentUserService
 import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
@@ -14,8 +15,7 @@ import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerServic
 @ReadOnlyUseCase
 class StopApplicationUseCase(
     private val queryApplicationPort: QueryApplicationPort,
-    private val deleteContainerService: DeleteContainerService,
-    private val deleteApplicationDirectoryService: DeleteApplicationDirectoryService,
+    private val stopContainerService: StopContainerService,
     private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService,
     private val changeApplicationStatusService: ChangeApplicationStatusService
 ) {
@@ -27,8 +27,9 @@ class StopApplicationUseCase(
             throw AlreadyStoppedException()
 
         validateWorkspaceOwnerService.validateOwner(application.workspace)
-        deleteContainerService.deleteContainer(application)
-        deleteApplicationDirectoryService.deleteApplicationDirectory(application)
+
+        stopContainerService.stopContainer(application)
+
         changeApplicationStatusService.changeApplicationStatus(application, ApplicationStatus.STOPPED)
     }
 }

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
@@ -36,9 +36,9 @@ class ApplicationWebAdapter(
             .run { ResponseEntity(HttpStatus.CREATED) }
 
     @PostMapping("/{id}/run")
-    fun runApplication(@PathVariable id: String): ResponseEntity<RunApplicationResponse> =
+    fun runApplication(@PathVariable id: String): ResponseEntity<Void> =
         runApplicationUseCase.execute(id)
-            .let { ResponseEntity.ok(it.toResponse()) }
+            .run { ResponseEntity.ok().build() }
 
     @GetMapping
     fun getAllApplication(@RequestParam workspaceId: String): ResponseEntity<ApplicationListResponse> =

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationResponseDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationResponseDataExtension.kt
@@ -33,11 +33,6 @@ fun AvailableVersionResDto.toResponse(): AvailableVersionResponse =
         version = this.version
     )
 
-fun RunApplicationResDto.toResponse(): RunApplicationResponse =
-    RunApplicationResponse(
-        externalPort = this.externalPort
-    )
-
 fun ApplicationLogResDto.toResponse(): ApplicationLogResponse =
     ApplicationLogResponse(
         logs = this.logs

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/DockerRunServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/DockerRunServiceImplTest.kt
@@ -25,10 +25,9 @@ class DockerRunServiceImplTest : BehaviorSpec({
             val application = ApplicationGenerator.generateApplication()
             every { queryApplicationPort.findById(appId) } returns application
 
-            service.runApplication(appId, application.port)
+            service.runApplication(appId)
             then("commandPort가 실행되어야함") {
-                val externalPort = application.port
-                verify { commandPort.executeShellCommand("cd ${application.name} && docker run --network ${application.workspace.title.replace(' ', '_')} --name ${application.name.lowercase()} -d -p ${externalPort}:${application.port} ${application.name.lowercase()}:latest") }
+                verify { commandPort.executeShellCommand("docker start ${application.name.lowercase()}") }
             }
         }
     }
@@ -37,57 +36,12 @@ class DockerRunServiceImplTest : BehaviorSpec({
         val application = ApplicationGenerator.generateApplication()
 
         `when`("executeShellCommand 메서드를 실행할때") {
-            service.runApplication(application, application.port)
+            service.runApplication(application)
 
             then("commandPort가 실행되어야함") {
-                val externalPort = application.port
-                verify { commandPort.executeShellCommand("cd ${application.name} && docker run --network ${application.workspace.title.replace(' ', '_')} --name ${application.name.lowercase()} -d -p ${externalPort}:${application.port} ${application.name.lowercase()}:latest") }
+                verify { commandPort.executeShellCommand("docker start ${application.name.lowercase()}") }
             }
         }
     }
 
-    given("mysql 애플리케이션이 주어지고") {
-        val application = ApplicationGenerator.generateApplication(applicationType = ApplicationType.MYSQL, env = mapOf(Pair("rootPassword", "test"), Pair("database", "test")))
-
-        `when`("executeShellCommand 메서드를 실행할때") {
-            service.runApplication(application, application.port)
-
-            then("commandPort가 실행되어야함") {
-                val externalPort = application.port
-                verify {
-                    commandPort.executeShellCommand("docker run --network ${application.workspace.title.replace(' ', '_')} -e MYSQL_ROOT_PASSWORD=${application.env["rootPassword"]} -e MYSQL_DATABASE=${application.env["database"]} --name ${application.name.lowercase()} -d -p ${externalPort}:${application.port} mysql:latest")
-                }
-            }
-        }
-    }
-
-    given("mariadb 애플리케이션이 주어지고") {
-        val application = ApplicationGenerator.generateApplication(applicationType = ApplicationType.MARIA_DB, env = mapOf(Pair("rootPassword", "test"), Pair("database", "test")))
-
-        `when`("executeShellCommand 메서드를 실행할때") {
-            service.runApplication(application, application.port)
-
-            then("commandPort가 실행되어야함") {
-                val externalPort = application.port
-                verify {
-                    commandPort.executeShellCommand("docker run --network ${application.workspace.title.replace(' ', '_')} -e MYSQL_ROOT_PASSWORD=${application.env["rootPassword"]} -e MYSQL_DATABASE=${application.env["database"]} --name ${application.name.lowercase()} -d -p ${externalPort}:${application.port} mariadb:latest")
-                }
-            }
-        }
-    }
-
-    given("redis 애플리케이션이 주어지고") {
-        val application = ApplicationGenerator.generateApplication(applicationType = ApplicationType.REDIS)
-
-        `when`("executeShellCommand 메서드를 실행할때") {
-            service.runApplication(application, application.port)
-
-            then("commandPort가 실행되어야함") {
-                val externalPort = application.port
-                verify {
-                    commandPort.executeShellCommand("docker run --network ${application.workspace.title.replace(' ', '_')} --name ${application.name.lowercase()} -d -p ${externalPort}:${application.port} redis:latest")
-                }
-            }
-        }
-    }
 })

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCaseTest.kt
@@ -19,24 +19,15 @@ import util.user.UserGenerator
 import util.workspace.WorkspaceGenerator
 
 class RunApplicationUseCaseTest : BehaviorSpec({
-    val cloneApplicationByUrlService = mockk<CloneApplicationByUrlService>(relaxUnitFun = true)
-    val modifyGradleService = mockk<ModifyGradleService>(relaxUnitFun = true)
-    val createDockerFileService = mockk<CreateDockerFileService>(relaxUnitFun = true)
     val buildDockerImageService = mockk<BuildDockerImageService>(relaxUnitFun = true)
     val dockerRunService = mockk<DockerRunService>(relaxUnitFun = true)
     val queryApplicationPort = mockk<QueryApplicationPort>(relaxUnitFun = true)
     val validateWorkspaceOwnerService = mockk<ValidateWorkspaceOwnerService>(relaxUnitFun = true)
-    val getExternalPortService = mockk<GetExternalPortService>(relaxed = true)
     val changeApplicationStatusService = mockk<ChangeApplicationStatusService>(relaxUnitFun = true)
     val runApplicationUseCase = RunApplicationUseCase(
-        cloneApplicationByUrlService,
-        modifyGradleService,
-        createDockerFileService,
-        buildDockerImageService,
         dockerRunService,
         queryApplicationPort,
         validateWorkspaceOwnerService,
-        getExternalPortService,
         changeApplicationStatusService
     )
 
@@ -48,16 +39,9 @@ class RunApplicationUseCaseTest : BehaviorSpec({
             every { queryApplicationPort.findById("testId") } returns application
             val result = runApplicationUseCase.execute("testId")
             then("애플리케이션 실행에 관한 service들이 실행되어야함") {
-                verify { cloneApplicationByUrlService.cloneByApplication(application) }
                 verify { validateWorkspaceOwnerService.validateOwner(workspace) }
-                verify { modifyGradleService.modifyGradleByApplication(application) }
-                verify { createDockerFileService.createFileToApplication(application, application.version, 0) }
                 verify { buildDockerImageService.buildImageByApplication(application) }
-                verify { dockerRunService.runApplication(application, getExternalPortService.getExternalPort(application.port)) }
                 verify { changeApplicationStatusService.changeApplicationStatus(application, ApplicationStatus.RUNNING) }
-            }
-            then("반환값은 이용가능한 외부 포트를 담아야함") {
-                result shouldBe RunApplicationResDto(getExternalPortService.getExternalPort(application.port))
             }
         }
 
@@ -88,12 +72,9 @@ class RunApplicationUseCaseTest : BehaviorSpec({
 
             runApplicationUseCase.execute(application.id)
             then("dockerRunService만 실행되어야함") {
-                verify { dockerRunService.runApplication(application, application.version, getExternalPortService.getExternalPort(application.port)) }
+                verify { dockerRunService.runApplication(application) }
                 shouldThrow<AssertionError> {
-                    verify { cloneApplicationByUrlService.cloneByApplication(application) }
                     verify { validateWorkspaceOwnerService.validateOwner(workspace) }
-                    verify { modifyGradleService.modifyGradleByApplication(application) }
-                    verify { createDockerFileService.createFileToApplication(application, application.version, 0) }
                     verify { buildDockerImageService.buildImageByApplication(application) }
                     verify { changeApplicationStatusService.changeApplicationStatus(application, ApplicationStatus.RUNNING) }
                 }
@@ -118,12 +99,9 @@ class RunApplicationUseCaseTest : BehaviorSpec({
 
             runApplicationUseCase.execute(application.id)
             then("dockerRunService만 실행되어야함") {
-                verify { dockerRunService.runApplication(application, application.version, getExternalPortService.getExternalPort(application.port)) }
+                verify { dockerRunService.runApplication(application) }
                 shouldThrow<AssertionError> {
-                    verify { cloneApplicationByUrlService.cloneByApplication(application) }
                     verify { validateWorkspaceOwnerService.validateOwner(workspace) }
-                    verify { modifyGradleService.modifyGradleByApplication(application) }
-                    verify { createDockerFileService.createFileToApplication(application, application.version, 0) }
                     verify { buildDockerImageService.buildImageByApplication(application) }
                     verify { changeApplicationStatusService.changeApplicationStatus(application, ApplicationStatus.RUNNING) }
                 }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCaseTest.kt
@@ -19,7 +19,6 @@ import util.user.UserGenerator
 import util.workspace.WorkspaceGenerator
 
 class RunApplicationUseCaseTest : BehaviorSpec({
-    val buildDockerImageService = mockk<BuildDockerImageService>(relaxUnitFun = true)
     val dockerRunService = mockk<DockerRunService>(relaxUnitFun = true)
     val queryApplicationPort = mockk<QueryApplicationPort>(relaxUnitFun = true)
     val validateWorkspaceOwnerService = mockk<ValidateWorkspaceOwnerService>(relaxUnitFun = true)
@@ -40,7 +39,6 @@ class RunApplicationUseCaseTest : BehaviorSpec({
             val result = runApplicationUseCase.execute("testId")
             then("애플리케이션 실행에 관한 service들이 실행되어야함") {
                 verify { validateWorkspaceOwnerService.validateOwner(workspace) }
-                verify { buildDockerImageService.buildImageByApplication(application) }
                 verify { changeApplicationStatusService.changeApplicationStatus(application, ApplicationStatus.RUNNING) }
             }
         }
@@ -73,11 +71,6 @@ class RunApplicationUseCaseTest : BehaviorSpec({
             runApplicationUseCase.execute(application.id)
             then("dockerRunService만 실행되어야함") {
                 verify { dockerRunService.runApplication(application) }
-                shouldThrow<AssertionError> {
-                    verify { validateWorkspaceOwnerService.validateOwner(workspace) }
-                    verify { buildDockerImageService.buildImageByApplication(application) }
-                    verify { changeApplicationStatusService.changeApplicationStatus(application, ApplicationStatus.RUNNING) }
-                }
             }
         }
 
@@ -100,11 +93,6 @@ class RunApplicationUseCaseTest : BehaviorSpec({
             runApplicationUseCase.execute(application.id)
             then("dockerRunService만 실행되어야함") {
                 verify { dockerRunService.runApplication(application) }
-                shouldThrow<AssertionError> {
-                    verify { validateWorkspaceOwnerService.validateOwner(workspace) }
-                    verify { buildDockerImageService.buildImageByApplication(application) }
-                    verify { changeApplicationStatusService.changeApplicationStatus(application, ApplicationStatus.RUNNING) }
-                }
             }
         }
 

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -21,7 +21,7 @@ import org.springframework.http.HttpStatus
 
 class ApplicationWebAdapterTest : BehaviorSpec({
     val createApplicationUseCase = mockk<CreateApplicationUseCase>()
-    val springRunApplicationUseCase = mockk<RunApplicationUseCase>()
+    val springRunApplicationUseCase = mockk<RunApplicationUseCase>(relaxUnitFun = true)
     val getAllApplicationUseCase = mockk<GetAllApplicationUseCase>()
     val getOneApplicationUseCase = mockk<GetOneApplicationUseCase>()
     val addApplicationEnvUseCase = mockk<AddApplicationEnvUseCase>()
@@ -50,20 +50,6 @@ class ApplicationWebAdapterTest : BehaviorSpec({
             val result = applicationWebAdapter.createApplication("testWorkspaceId", request)
             then("상태코드가 201이여야함") {
                 result.statusCode shouldBe HttpStatus.CREATED
-            }
-        }
-    }
-
-    given("RunApplicationRequest가 주어지고") {
-        val id = "testApplicationId"
-        `when`("runApplication 메서드를 실행할때") {
-            every { springRunApplicationUseCase.execute(id) } returns RunApplicationResDto(externalPort = 8080)
-            val result = applicationWebAdapter.runApplication(id)
-            then("상태코드가 200이여야함") {
-                result.statusCode shouldBe HttpStatus.OK
-            }
-            then("반환값은 RunApplicationResDto의 필드를 가져야함") {
-                result.body shouldBe RunApplicationResponse(8080)
             }
         }
     }
@@ -170,6 +156,13 @@ class ApplicationWebAdapterTest : BehaviorSpec({
             }
             then("응답의 바디는 반환된 로그를 포함해야함") {
                 result.body!!.logs shouldBe logs
+            }
+        }
+
+        `when`("runApplication 메서드를 실행할때") {
+            val result = applicationWebAdapter.runApplication(testId)
+            then("상태코드가 200이여야함") {
+                result.statusCode shouldBe HttpStatus.OK
             }
         }
     }


### PR DESCRIPTION
## 🔖 개요
* 애플리케이션에서 배포와 실행의 개념을 같은 개념으로 사용하고 있었지만, 최적화를 위해 배포와 실행에 관한 개념을 분리하기 위한 작업

## 📜 작업내용
* DockerRunService에서 컨테이너를 실행시키는 역할만 하게끔 수정
* 빌드된 이미지를 컨테이너화 시키는 CreateContainerService 추가
* RunApplicationUseCase에서 DockerRunService를 사용해서 컨테이너를 실행하도록 변경
* 애플리케이션 실행후 반환값 제거
* 애플리케이션을 생성할때 애플리케이션 정보로 컨테이너를 생성하도록 변경
* 컨테이너를 정지시키는 StopContainerService 추가
* 기존에 컨테이너를 삭제하는 로직에서 정지만 시키도록 변경
* 테스트 코드를 변경사항에 맞춰서 수정

## 🎸 기타
* 추후에 애플리케이션 엔티티에 externalPort 필드를 추가
  * ExistsPortService에서 애플리케이션의 필드를 기준으로 판별하는 로직도 추가해야함
* 재배포 API 추가
  * 재배포를 통해서 애플리케이션의 최신 상태를 반영