### PR TITLE
🔀 :: 193 - 애플리케이션 엔티티에 외부포트 필드 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/extenstion/ApplicationDtoExtension.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/extenstion/ApplicationDtoExtension.kt
@@ -7,7 +7,7 @@ import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.workspace.model.Workspace
 
-fun CreateApplicationReqDto.toEntity(workspace: Workspace): Application =
+fun CreateApplicationReqDto.toEntity(workspace: Workspace, externalPort: Int): Application =
     Application(
         name = this.name,
         description = this.description,
@@ -16,6 +16,7 @@ fun CreateApplicationReqDto.toEntity(workspace: Workspace): Application =
         env = this.env,
         workspace = workspace,
         port = this.port,
+        externalPort = externalPort,
         version = this.version,
         status = ApplicationStatus.STOPPED
     )

--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/extenstion/ApplicationDtoExtension.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/extenstion/ApplicationDtoExtension.kt
@@ -29,6 +29,7 @@ fun Application.toDto(): ApplicationResDto =
         applicationType = this.applicationType,
         env = this.env,
         port = this.port,
+        externalPort = this.externalPort,
         version = this.version,
         status = this.status
     )

--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/response/ApplicationResDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/response/ApplicationResDto.kt
@@ -11,6 +11,7 @@ data class ApplicationResDto(
     val githubUrl: String?,
     val env: Map<String, String>,
     val port: Int,
+    val externalPort: Int,
     val version: String,
     val status: ApplicationStatus
 )

--- a/src/main/kotlin/com/dcd/server/core/domain/application/model/Application.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/model/Application.kt
@@ -16,5 +16,6 @@ data class Application(
     val version: String,
     val workspace: Workspace,
     val port: Int,
+    val externalPort: Int,
     val status: ApplicationStatus
 )

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExistsPortServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExistsPortServiceImpl.kt
@@ -1,18 +1,21 @@
 package com.dcd.server.core.domain.application.service.impl
 
 import com.dcd.server.core.domain.application.service.ExistsPortService
+import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import org.springframework.stereotype.Service
 import java.io.BufferedReader
 import java.io.InputStreamReader
 
 @Service
-class ExistsPortServiceImpl
+class ExistsPortServiceImpl (
+    private val queryApplicationPort: QueryApplicationPort
+)
     : ExistsPortService {
     override fun existsPort(port: Int): Boolean {
         val cmd = arrayOf("/bin/sh", "-c", "lsof -i :${port}")
         val p = Runtime.getRuntime().exec(cmd)
         val br = BufferedReader(InputStreamReader(p.inputStream))
-        val result = br.readLine() != null
+        val result = br.readLine() != null && queryApplicationPort.existsByExternalPort(port)
         p.waitFor()
         p.destroy()
         return result

--- a/src/main/kotlin/com/dcd/server/core/domain/application/spi/QueryApplicationPort.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/spi/QueryApplicationPort.kt
@@ -7,4 +7,5 @@ import com.dcd.server.core.domain.workspace.model.Workspace
 interface QueryApplicationPort {
     fun findAllByWorkspace(workspace: Workspace): List<Application>
     fun findById(id: String): Application?
+    fun existsByExternalPort(externalPort: Int): Boolean
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCase.kt
@@ -26,11 +26,13 @@ class CreateApplicationUseCase(
         val workspace = queryWorkspacePort.findById(workspaceId)
             ?: throw WorkspaceNotFoundException()
         validateWorkspaceOwnerService.validateOwner(workspace)
-        val application = createApplicationReqDto.toEntity(workspace)
+
+        val externalPort = getExternalPortService.getExternalPort(createApplicationReqDto.port)
+
+        val application = createApplicationReqDto.toEntity(workspace, externalPort)
         commandApplicationPort.save(application)
 
         val version = application.version
-        val externalPort = getExternalPortService.getExternalPort(application.port)
         when(application.applicationType){
             ApplicationType.SPRING_BOOT -> {
                 cloneApplicationByUrlService.cloneByApplication(application)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCase.kt
@@ -1,6 +1,6 @@
 package com.dcd.server.core.domain.application.usecase
 
-import com.dcd.server.core.common.annotation.ReadOnlyUseCase
+import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.domain.application.exception.AlreadyRunningException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
@@ -8,7 +8,7 @@ import com.dcd.server.core.domain.application.service.*
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 
-@ReadOnlyUseCase
+@UseCase
 class RunApplicationUseCase(
     private val dockerRunService: DockerRunService,
     private val queryApplicationPort: QueryApplicationPort,

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCase.kt
@@ -1,18 +1,15 @@
 package com.dcd.server.core.domain.application.usecase
 
-import com.dcd.server.core.common.annotation.ReadOnlyUseCase
+import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.domain.application.exception.AlreadyStoppedException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.service.ChangeApplicationStatusService
-import com.dcd.server.core.domain.application.service.DeleteApplicationDirectoryService
-import com.dcd.server.core.domain.application.service.DeleteContainerService
 import com.dcd.server.core.domain.application.service.StopContainerService
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
-import com.dcd.server.core.domain.user.service.GetCurrentUserService
 import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 
-@ReadOnlyUseCase
+@UseCase
 class StopApplicationUseCase(
     private val queryApplicationPort: QueryApplicationPort,
     private val stopContainerService: StopContainerService,

--- a/src/main/kotlin/com/dcd/server/persistence/application/ApplicationPersistenceAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/application/ApplicationPersistenceAdapter.kt
@@ -31,4 +31,7 @@ class ApplicationPersistenceAdapter(
     override fun findById(id: String): Application? =
         applicationRepository.findByIdOrNull(id)
             ?.toDomain()
+
+    override fun existsByExternalPort(externalPort: Int): Boolean =
+        applicationRepository.existsByExternalPort(externalPort)
 }

--- a/src/main/kotlin/com/dcd/server/persistence/application/adapter/ApplicationAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/application/adapter/ApplicationAdapter.kt
@@ -17,6 +17,7 @@ fun Application.toEntity(): ApplicationJpaEntity =
         env = this.env,
         workspace = this.workspace.toEntity(),
         port = this.port,
+        externalPort = this.externalPort,
         version = this.version,
         status = this.status
     )
@@ -31,6 +32,7 @@ fun ApplicationJpaEntity.toDomain(): Application =
         env = this.env,
         workspace = this.workspace.toDomain(),
         port = this.port,
+        externalPort = this.externalPort,
         version = this.version,
         status = this.status
     )

--- a/src/main/kotlin/com/dcd/server/persistence/application/entity/ApplicationJpaEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/application/entity/ApplicationJpaEntity.kt
@@ -26,6 +26,7 @@ class ApplicationJpaEntity(
     @JoinColumn(name = "workspace_id")
     val workspace: WorkspaceJpaEntity,
     val port: Int,
+    val externalPort: Int,
     val version: String,
     @Enumerated(EnumType.STRING)
     val status: ApplicationStatus

--- a/src/main/kotlin/com/dcd/server/persistence/application/repository/ApplicationRepository.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/application/repository/ApplicationRepository.kt
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface ApplicationRepository : JpaRepository<ApplicationJpaEntity, String> {
     fun findAllByWorkspace(workspace: WorkspaceJpaEntity): List<ApplicationJpaEntity>
+    fun existsByExternalPort(externalPort: Int): Boolean
 }

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationResponseDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationResponseDataExtension.kt
@@ -12,6 +12,7 @@ fun ApplicationResDto.toResponse(): ApplicationResponse =
         applicationType = this.applicationType,
         env = this.env,
         port = this.port,
+        externalPort = this.externalPort,
         version = this.version,
         status = this.status
     )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/response/ApplicationResponse.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/response/ApplicationResponse.kt
@@ -11,6 +11,7 @@ data class ApplicationResponse(
     val githubUrl: String?,
     val env: Map<String, String>,
     val port: Int,
+    val externalPort: Int,
     val version: String,
     val status: ApplicationStatus
 )

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/ExistsPortServiceTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/ExistsPortServiceTest.kt
@@ -1,12 +1,18 @@
 package com.dcd.server.core.domain.application.service
 
 import com.dcd.server.core.domain.application.service.impl.ExistsPortServiceImpl
+import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
 
 class ExistsPortServiceTest : BehaviorSpec({
     given("service 구현체가 주어지고") {
-        val service = ExistsPortServiceImpl()
+        val queryApplicationPort = mockk<QueryApplicationPort>()
+        every { queryApplicationPort.existsByExternalPort(9999) } returns false
+
+        val service = ExistsPortServiceImpl(queryApplicationPort)
 
         `when`("9999 포트가 사용중인지 검증할때") {
             val result = service.existsPort(9999)

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
@@ -72,6 +72,7 @@ class CreateApplicationUseCaseTest : BehaviorSpec({
                 verify { modifyGradleService.modifyGradleByApplication(any() as Application) }
                 verify { createDockerFileService.createFileToApplication(any() as Application, request.version, 0) }
                 verify { buildDockerImageService.buildImageByApplication(any() as Application) }
+                verify { getExternalPortService.getExternalPort(request.port) }
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/persistence/application/ApplicationPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/persistence/application/ApplicationPersistenceAdapterTest.kt
@@ -42,6 +42,7 @@ class ApplicationPersistenceAdapterTest : BehaviorSpec({
             version = "17",
             workspace = workspace,
             port = 8080,
+            externalPort = 8080,
             status = ApplicationStatus.STOPPED
         )
         val id = application.id

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -63,6 +63,7 @@ class ApplicationWebAdapterTest : BehaviorSpec({
             env = mapOf(),
             githubUrl = "testUrl",
             port = 8080,
+            externalPort = 8080,
             version = "latest",
             status = ApplicationStatus.STOPPED
         )
@@ -89,6 +90,7 @@ class ApplicationWebAdapterTest : BehaviorSpec({
             env = mapOf(),
             githubUrl = "testUrl",
             port = 8080,
+            externalPort = 8080,
             version = "latest",
             status = ApplicationStatus.STOPPED
         )

--- a/src/test/kotlin/util/application/ApplicationGenerator.kt
+++ b/src/test/kotlin/util/application/ApplicationGenerator.kt
@@ -29,6 +29,7 @@ object ApplicationGenerator {
             version = version,
             workspace = workspace,
             port = port,
+            externalPort = port,
             status = status
         )
 }


### PR DESCRIPTION
## 🔖 개요
* 애플리케이션 엔티티에 외부포트 추가

## 📜 작업내용
* 애플리케이션 엔티티에 외부포트를 저장하는 필드 추가
* 애플리케이션 조회 응답에 외부포트를 나타내는 필드 추가
* 애플리케이션을 생성할때 비어있는 외부포트를 찾아서 저장하는 로직 추가
* 테스트 모듈에서 사용되는 애플리케이션 엔티티에 외부포트 추가
* ExistsPortService에서 application 엔티티의 외부포트도 검증하도록 수정

## 🔀 변경사항
* 애플리케이션 실행/정지 유스케이스에서 ReadOnly 옵션 제거