### PR TITLE
🔀 :: 199 - 애플리케이션 배포후 생성된 디렉토리를 삭제하는 로직 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCase.kt
@@ -20,7 +20,8 @@ class CreateApplicationUseCase(
     private val createDockerFileService: CreateDockerFileService,
     private val getExternalPortService: GetExternalPortService,
     private val buildDockerImageService: BuildDockerImageService,
-    private val createContainerService: CreateContainerService
+    private val createContainerService: CreateContainerService,
+    private val deleteApplicationDirectoryService: DeleteApplicationDirectoryService
 ) {
     fun execute(workspaceId: String, createApplicationReqDto: CreateApplicationReqDto) {
         val workspace = queryWorkspacePort.findById(workspaceId)
@@ -42,5 +43,7 @@ class CreateApplicationUseCase(
         createDockerFileService.createFileToApplication(application, version)
         buildDockerImageService.buildImageByApplication(application)
         createContainerService.createContainer(application, externalPort)
+
+        deleteApplicationDirectoryService.deleteApplicationDirectory(application)
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
@@ -15,7 +15,8 @@ class DeployApplicationUseCase(
     private val modifyGradleService: ModifyGradleService,
     private val createDockerFileService: CreateDockerFileService,
     private val buildDockerImageService: BuildDockerImageService,
-    private val createContainerService: CreateContainerService
+    private val createContainerService: CreateContainerService,
+    private val deleteApplicationDirectoryService: DeleteApplicationDirectoryService
 ) {
     fun execute(id: String) {
         val application = (queryApplicationPort.findById(id)
@@ -35,5 +36,7 @@ class DeployApplicationUseCase(
         createDockerFileService.createFileToApplication(application, version)
         buildDockerImageService.buildImageByApplication(application)
         createContainerService.createContainer(application, externalPort)
+
+        deleteApplicationDirectoryService.deleteApplicationDirectory(application)
     }
 }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
@@ -34,6 +34,7 @@ class CreateApplicationUseCaseTest : BehaviorSpec({
     val getExternalPortService = mockk<GetExternalPortService>(relaxed = true)
     val buildDockerImageService = mockk<BuildDockerImageService>(relaxUnitFun = true)
     val createContainerService = mockk<CreateContainerService>(relaxUnitFun = true)
+    val deleteApplicationDirectoryService = mockk<DeleteApplicationDirectoryService>(relaxUnitFun = true)
     val createApplicationUseCase = CreateApplicationUseCase(
         commandApplicationPort,
         queryWorkspacePort,
@@ -43,7 +44,8 @@ class CreateApplicationUseCaseTest : BehaviorSpec({
         createDockerFileService,
         getExternalPortService,
         buildDockerImageService,
-        createContainerService
+        createContainerService,
+        deleteApplicationDirectoryService
     )
 
     given("CreateApplicationReqDto와 유저가 주어지고") {
@@ -73,6 +75,7 @@ class CreateApplicationUseCaseTest : BehaviorSpec({
                 verify { createDockerFileService.createFileToApplication(any() as Application, request.version) }
                 verify { buildDockerImageService.buildImageByApplication(any() as Application) }
                 verify { getExternalPortService.getExternalPort(request.port) }
+                verify { deleteApplicationDirectoryService.deleteApplicationDirectory(any() as Application) }
             }
         }
     }


### PR DESCRIPTION
## 🔖 개요
* 애플리케이션 배포후 생성된 디렉토리를 삭제하는 로직 추가

## 📜 작업내용
* CreateApplicationUseCase에서 생성된 애플리케이션의 DockerFile이 담긴 디렉토리를 제거하는 로직 추가
* DeployApplicationUseCase에서 애플리케이션의 DockerFile이 담긴 디렉토리를 제거하는 로직 추가
* CreateApplicationUseCase 테스트 코드에서 생성된 애플리케이션의 DockerFile이 담긴 디렉토리를 제거하는 서비스를 실행하는지 검증하는 테스트 케이스 추가

## 🎸 기타
* 애플리케이션의 이미지, 컨테이너를 생성후 해당 애플리케이션을 클론받은 디렉토리를 제거하는 로직 추가