### PR TITLE
🔀 :: 201 - 애플리케이션 삭제시 이미지, 컨테이너 제거하는 로직 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
@@ -30,6 +30,9 @@ enum class ErrorCode(
     APPLICATION_ENV_NOT_FOUND("해당 환경변수를 찾을 수 없음", 404),
     WORKSPACE_NOT_FOUND("해당 워크스페이스를 찾을 수 없음", 404),
 
+    CONFLICT("해당 요청은 서버의 상태와 충돌됩니다.", 409),
+    CAN_NOT_DELETE_APPLICATION("애플리케이션을 삭제할 수 없습니다. 애플리케이션을 정지시킨후 실행해주세요.", 409),
+
     CONTAINER_NOT_RUN("해당 애플리케이션을 실행할 수 없음", 500),
     CONTAINER_NOT_STOPPED("해당 애플리케이션을 정지할 수 없음", 500),
     CONTAINER_NOT_CREATED("해당 애플리케이션의 이미지를 컨테이너로 빌드할 수 없음", 500),

--- a/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
@@ -31,7 +31,8 @@ enum class ErrorCode(
     WORKSPACE_NOT_FOUND("해당 워크스페이스를 찾을 수 없음", 404),
 
     CONFLICT("해당 요청은 서버의 상태와 충돌됩니다.", 409),
-    CAN_NOT_DELETE_APPLICATION("애플리케이션을 삭제할 수 없습니다. 애플리케이션을 정지시킨후 실행해주세요.", 409),
+    CAN_NOT_DEPLOY_APPLICATION("애플리케이션을 배포할 수 없습니다. 애플리케이션을 정지시킨 후 실행해주세요.", 409),
+    CAN_NOT_DELETE_APPLICATION("애플리케이션을 삭제할 수 없습니다. 애플리케이션을 정지시킨 후 실행해주세요.", 409),
 
     CONTAINER_NOT_RUN("해당 애플리케이션을 실행할 수 없음", 500),
     CONTAINER_NOT_STOPPED("해당 애플리케이션을 정지할 수 없음", 500),

--- a/src/main/kotlin/com/dcd/server/core/domain/application/exception/CanNotDeleteApplicationException.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/exception/CanNotDeleteApplicationException.kt
@@ -1,0 +1,7 @@
+package com.dcd.server.core.domain.application.exception
+
+import com.dcd.server.core.common.error.BasicException
+import com.dcd.server.core.common.error.ErrorCode
+
+class CanNotDeleteApplicationException : BasicException(ErrorCode.CAN_NOT_DELETE_APPLICATION) {
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/exception/CanNotDeployApplicationException.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/exception/CanNotDeployApplicationException.kt
@@ -1,0 +1,7 @@
+package com.dcd.server.core.domain.application.exception
+
+import com.dcd.server.core.common.error.BasicException
+import com.dcd.server.core.common.error.ErrorCode
+
+class CanNotDeployApplicationException : BasicException(ErrorCode.CAN_NOT_DEPLOY_APPLICATION) {
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationUseCase.kt
@@ -2,6 +2,8 @@ package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
+import com.dcd.server.core.domain.application.service.DeleteContainerService
+import com.dcd.server.core.domain.application.service.DeleteImageService
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.user.service.GetCurrentUserService
@@ -12,13 +14,19 @@ class DeleteApplicationUseCase(
     private val getCurrentUserService: GetCurrentUserService,
     private val commandApplicationPort: CommandApplicationPort,
     private val queryApplicationPort: QueryApplicationPort,
-    private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService
+    private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService,
+    private val deleteContainerService: DeleteContainerService,
+    private val deleteImageService: DeleteImageService
 ) {
     fun execute(id: String) {
         val user = getCurrentUserService.getCurrentUser()
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
         validateWorkspaceOwnerService.validateOwner(user, application.workspace)
+
+        deleteContainerService.deleteContainer(application)
+        deleteImageService.deleteImage(application)
+
         commandApplicationPort.delete(application)
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationUseCase.kt
@@ -2,6 +2,8 @@ package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
+import com.dcd.server.core.domain.application.exception.CanNotDeleteApplicationException
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.service.DeleteContainerService
 import com.dcd.server.core.domain.application.service.DeleteImageService
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
@@ -23,6 +25,9 @@ class DeleteApplicationUseCase(
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
         validateWorkspaceOwnerService.validateOwner(user, application.workspace)
+
+        if (application.status == ApplicationStatus.RUNNING)
+            throw CanNotDeleteApplicationException()
 
         deleteContainerService.deleteContainer(application)
         deleteImageService.deleteImage(application)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
@@ -2,6 +2,8 @@ package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
+import com.dcd.server.core.domain.application.exception.CanNotDeployApplicationException
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.*
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
@@ -21,6 +23,9 @@ class DeployApplicationUseCase(
     fun execute(id: String) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
+
+        if (application.status == ApplicationStatus.RUNNING)
+            throw CanNotDeployApplicationException()
 
         deleteContainerService.deleteContainer(application)
         deleteImageService.deleteImage(application)

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationUseCaseTest.kt
@@ -4,6 +4,8 @@ import com.dcd.server.core.domain.application.exception.ApplicationNotFoundExcep
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
+import com.dcd.server.core.domain.application.service.DeleteContainerService
+import com.dcd.server.core.domain.application.service.DeleteImageService
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.auth.model.Role
@@ -27,8 +29,10 @@ class DeleteApplicationUseCaseTest : BehaviorSpec({
     val commandApplicationPort = mockk<CommandApplicationPort>()
     val queryApplicationPort = mockk<QueryApplicationPort>()
     val validateWorkspaceOwnerService = mockk<ValidateWorkspaceOwnerService>(relaxUnitFun = true)
+    val deleteContainerService = mockk<DeleteContainerService>(relaxUnitFun = true)
+    val deleteImageService = mockk<DeleteImageService>(relaxUnitFun = true)
     val deleteApplicationUseCase =
-        DeleteApplicationUseCase(getCurrentUserService, commandApplicationPort, queryApplicationPort, validateWorkspaceOwnerService)
+        DeleteApplicationUseCase(getCurrentUserService, commandApplicationPort, queryApplicationPort, validateWorkspaceOwnerService, deleteContainerService, deleteImageService)
     given("애플리케이션 id가 주어지고") {
         val applicationId = "testId"
         val user = UserGenerator.generateUser()
@@ -40,6 +44,8 @@ class DeleteApplicationUseCaseTest : BehaviorSpec({
             deleteApplicationUseCase.execute(applicationId)
             then("commandApplicationPort의 delete메서드가 실행되어야함") {
                 verify { commandApplicationPort.delete(application) }
+                verify { deleteContainerService.deleteContainer(application) }
+                verify { deleteImageService.deleteImage(application) }
             }
         }
         `when`("application을 찾을 수 없을때") {


### PR DESCRIPTION
## 🔖 개요
* 애플리케이션을 삭제할때 애플리케이션의 이미지와 컨테이너를 제거하는 서비스를 호출하도록 변경합니다.

## 📜 작업내용
* DeleteApplicationUseCase에서 컨테이너와 이미지를 제거하도록 수정
* DeleteApplicationUseCase 테스트 코드에서 이미지와 컨테이너를 삭제하는지 검증하는 로직 추가
* 애플리케이션을 삭제할 수 없을때 예외를 던지는 로직 추가
* 애플리케이션을 배포할 수 없을때 예외를 던지는 로직 추가