### PR TITLE
🔀 :: 203 - 애플리케이션 배포 API 테스트 코드

### DIFF
--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCaseTest.kt
@@ -1,8 +1,11 @@
 package com.dcd.server.core.domain.application.usecase
 
+import com.dcd.server.core.domain.application.exception.CanNotDeployApplicationException
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.*
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.every
 import io.mockk.mockk
@@ -104,6 +107,20 @@ class DeployApplicationUseCaseTest : BehaviorSpec({
             }
             then("생성된 애플리케이션 디렉토리를 제거해야함") {
                 verify { deleteApplicationDirectoryService.deleteApplicationDirectory(application) }
+            }
+        }
+
+        `when`("주어진 id의 애플리케이션이 실행중인 애플리케이션일때") {
+            val application = ApplicationGenerator.generateApplication(
+                id = applicationId,
+                status = ApplicationStatus.RUNNING
+            )
+            every { queryApplicationPort.findById(applicationId) } returns application
+
+            then("CanNotDeployApplicationException이 발생해야함") {
+                shouldThrow<CanNotDeployApplicationException> {
+                    deployApplicationUseCase.execute(applicationId)
+                }
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCaseTest.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.core.domain.application.usecase
 
+import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.exception.CanNotDeployApplicationException
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
@@ -119,6 +120,16 @@ class DeployApplicationUseCaseTest : BehaviorSpec({
 
             then("CanNotDeployApplicationException이 발생해야함") {
                 shouldThrow<CanNotDeployApplicationException> {
+                    deployApplicationUseCase.execute(applicationId)
+                }
+            }
+        }
+
+        `when`("주어진 id를 가진 애플리케이션이 존재하지 않을때") {
+            every { queryApplicationPort.findById(applicationId) } returns null
+
+            then("ApplicationNotFoundException이 발생해야함") {
+                shouldThrow<ApplicationNotFoundException> {
                     deployApplicationUseCase.execute(applicationId)
                 }
             }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCaseTest.kt
@@ -1,0 +1,64 @@
+package com.dcd.server.core.domain.application.usecase
+
+import com.dcd.server.core.domain.application.model.enums.ApplicationType
+import com.dcd.server.core.domain.application.service.*
+import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import util.application.ApplicationGenerator
+
+class DeployApplicationUseCaseTest : BehaviorSpec({
+    val queryApplicationPort = mockk<QueryApplicationPort>()
+    val deleteContainerService = mockk<DeleteContainerService>(relaxUnitFun = true)
+    val deleteImageService = mockk<DeleteImageService>(relaxUnitFun = true)
+    val cloneApplicationByUrlService = mockk<CloneApplicationByUrlService>(relaxUnitFun = true)
+    val modifyGradleService = mockk<ModifyGradleService>(relaxUnitFun = true)
+    val createDockerFileService = mockk<CreateDockerFileService>(relaxUnitFun = true)
+    val buildDockerImageService = mockk<BuildDockerImageService>(relaxUnitFun = true)
+    val createContainerService = mockk<CreateContainerService>(relaxUnitFun = true)
+    val deleteApplicationDirectoryService = mockk<DeleteApplicationDirectoryService>(relaxUnitFun = true)
+    val deployApplicationUseCase = DeployApplicationUseCase(
+        queryApplicationPort,
+        deleteContainerService,
+        deleteImageService,
+        cloneApplicationByUrlService,
+        modifyGradleService,
+        createDockerFileService,
+        buildDockerImageService,
+        createContainerService,
+        deleteApplicationDirectoryService
+    )
+
+    given("애플리케이션 id가 주어지고") {
+        val applicationId = "testApplicationId"
+
+        `when`("주어진 id의 애플리케이션이 spring boot 타입의 애플리케이션일때") {
+            val application = ApplicationGenerator.generateApplication(
+                id = applicationId,
+                applicationType = ApplicationType.SPRING_BOOT
+            )
+            every { queryApplicationPort.findById(applicationId) } returns application
+
+            deployApplicationUseCase.execute(applicationId)
+
+            then("이미지와 컨테이너를 삭제하는 서비스를 실행해야함") {
+                verify { deleteContainerService.deleteContainer(application) }
+                verify { deleteImageService.deleteImage(application) }
+            }
+            then("애플리케이션을 클론하고, 그래들 파일을 수정해야함") {
+                verify { cloneApplicationByUrlService.cloneByApplication(application) }
+                verify { modifyGradleService.modifyGradleByApplication(application) }
+            }
+            then("도커파일을 생성하고, 이미지를 빌드하고, 컨테이너를 생성해야함") {
+                verify { createDockerFileService.createFileToApplication(application, application.version) }
+                verify { buildDockerImageService.buildImageByApplication(application) }
+                verify { createContainerService.createContainer(application, application.externalPort) }
+            }
+            then("생성된 애플리케이션 디렉토리를 제거해야함") {
+                verify { deleteApplicationDirectoryService.deleteApplicationDirectory(application) }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCaseTest.kt
@@ -83,5 +83,28 @@ class DeployApplicationUseCaseTest : BehaviorSpec({
                 verify { deleteApplicationDirectoryService.deleteApplicationDirectory(application) }
             }
         }
+
+        `when`("주어진 id의 애플리케이션이 REDIS 타입의 애플리케이션일때") {
+            val application = ApplicationGenerator.generateApplication(
+                id = applicationId,
+                applicationType = ApplicationType.REDIS
+            )
+            every { queryApplicationPort.findById(applicationId) } returns application
+
+            deployApplicationUseCase.execute(applicationId)
+
+            then("이미지와 컨테이너를 삭제하는 서비스를 실행해야함") {
+                verify { deleteContainerService.deleteContainer(application) }
+                verify { deleteImageService.deleteImage(application) }
+            }
+            then("도커파일을 생성하고, 이미지를 빌드하고, 컨테이너를 생성해야함") {
+                verify { createDockerFileService.createFileToApplication(application, application.version) }
+                verify { buildDockerImageService.buildImageByApplication(application) }
+                verify { createContainerService.createContainer(application, application.externalPort) }
+            }
+            then("생성된 애플리케이션 디렉토리를 제거해야함") {
+                verify { deleteApplicationDirectoryService.deleteApplicationDirectory(application) }
+            }
+        }
     }
 })

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -32,7 +32,7 @@ class ApplicationWebAdapterTest : BehaviorSpec({
     val getAvailableVersionUseCase = mockk<GetAvailableVersionUseCase>()
     val generateSSLCertificateUseCase = mockk<GenerateSSLCertificateUseCase>(relaxUnitFun = true)
     val getApplicationLogUseCase = mockk<GetApplicationLogUseCase>()
-    val deployApplicationUseCase = mockk<DeployApplicationUseCase>()
+    val deployApplicationUseCase = mockk<DeployApplicationUseCase>(relaxUnitFun = true)
     val applicationWebAdapter = ApplicationWebAdapter(createApplicationUseCase, springRunApplicationUseCase, getAllApplicationUseCase, getOneApplicationUseCase, addApplicationEnvUseCase, deleteApplicationEnvUseCase, stopApplicationUseCase, deleteApplicationUseCase, updateApplicationUseCase, getAvailableVersionUseCase, generateSSLCertificateUseCase, getApplicationLogUseCase, deployApplicationUseCase)
 
     given("CreateApplicationRequest가 주어지고") {
@@ -164,6 +164,13 @@ class ApplicationWebAdapterTest : BehaviorSpec({
 
         `when`("runApplication 메서드를 실행할때") {
             val result = applicationWebAdapter.runApplication(testId)
+            then("상태코드가 200이여야함") {
+                result.statusCode shouldBe HttpStatus.OK
+            }
+        }
+
+        `when`("deployApplication 메서드를 실행할때") {
+            val result = applicationWebAdapter.deployApplication(testId)
             then("상태코드가 200이여야함") {
                 result.statusCode shouldBe HttpStatus.OK
             }


### PR DESCRIPTION
## 🔖 개요
* 애플리케이션 배포 API의 테스트를 작성합니다.

## 📜 작업내용
* Spring 타입의 애플리케이션을 배포하는 테스트 케이스 추가
* My sql 타입의 애플리케이션을 배포하는 테스트 케이스 추가
* redis 타입의 애플리케이션을 배포하는 테스트 케이스 추가
* 실행중인 애플리케이션을 배포하는 테스트 케이스 추가
* 주어진 애플리케이션 id를 가진 애플리케이션이 없는 테스트 케이스 추가
* ApplicationWebAdapter 테스트 코드에 deployApplication 메서드의 결과값을 검증하는 테스트 케이스 추가