### PR TITLE
🔀 :: 209 - 잘못된 시큐리티 설정 리펙토링

### DIFF
--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
@@ -55,7 +55,7 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.POST, "/application/{id}/deploy").authenticated()
                 it.requestMatchers(HttpMethod.GET, "/application").authenticated()
                 it.requestMatchers(HttpMethod.GET, "/application/{id}").authenticated()
-                it.requestMatchers(HttpMethod.PATCH, "/application/{id}/env").authenticated()
+                it.requestMatchers(HttpMethod.POST, "/application/{id}/env").authenticated()
                 it.requestMatchers(HttpMethod.DELETE, "/application/{id}/env").authenticated()
                 it.requestMatchers(HttpMethod.POST, "/application/{id}/stop").authenticated()
                 it.requestMatchers(HttpMethod.DELETE, "/application/{id}").authenticated()

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
@@ -52,17 +52,17 @@ class SecurityConfig(
                 //application
                 it.requestMatchers(HttpMethod.POST, "/application/{workspaceId}").authenticated()
                 it.requestMatchers(HttpMethod.POST, "/application/{id}/run").authenticated()
+                it.requestMatchers(HttpMethod.POST, "/application/{id}/stop").authenticated()
                 it.requestMatchers(HttpMethod.POST, "/application/{id}/deploy").authenticated()
                 it.requestMatchers(HttpMethod.GET, "/application").authenticated()
                 it.requestMatchers(HttpMethod.GET, "/application/{id}").authenticated()
-                it.requestMatchers(HttpMethod.POST, "/application/{id}/env").authenticated()
-                it.requestMatchers(HttpMethod.DELETE, "/application/{id}/env").authenticated()
-                it.requestMatchers(HttpMethod.POST, "/application/{id}/stop").authenticated()
                 it.requestMatchers(HttpMethod.DELETE, "/application/{id}").authenticated()
                 it.requestMatchers(HttpMethod.PATCH, "/application/{id}").authenticated()
-                it.requestMatchers(HttpMethod.GET, "/application/version/{applicationType}").authenticated()
-                it.requestMatchers(HttpMethod.POST, "/application/{id}/certificate").authenticated()
                 it.requestMatchers(HttpMethod.GET, "/application/{id}/logs").authenticated()
+                it.requestMatchers(HttpMethod.POST, "/application/{id}/certificate").authenticated()
+                it.requestMatchers(HttpMethod.POST, "/application/{id}/env").authenticated()
+                it.requestMatchers(HttpMethod.DELETE, "/application/{id}/env").authenticated()
+                it.requestMatchers(HttpMethod.GET, "/application/version/{applicationType}").authenticated()
 
                 //workspace
                 it.requestMatchers(HttpMethod.POST, "/workspace").authenticated()


### PR DESCRIPTION
## 🔖 개요
* 잘못된 시큐리티 설정을 리펙토링합니다.

## 📜 작업내용
* 환경변수 추가 엔드포인트의 시큐리티 설정이 HTTP 메서드 PATCH로 되어있던 코드를 POST로 수정
* 시큐리티 설정에서 유사한 엔드포인트끼리 붙여서 가독성 높이기
* ExceptionFilter에서 Exception에 관한 정보를 로깅하도록 수정