### PR TITLE
🔀 :: 213 - 컨테이너 정지 서비스의 테스트 코드 작성

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/StopContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/StopContainerServiceImpl.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.core.domain.application.service.impl
 
 import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.domain.application.exception.ContainerNotStoppedException
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.service.StopContainerService
 import org.springframework.stereotype.Service
@@ -11,6 +12,6 @@ class StopContainerServiceImpl(
 ) : StopContainerService {
     override fun stopContainer(application: Application) {
         val exitValue = commandPort.executeShellCommand("docker stop ${application.name.lowercase()}")
-        if (exitValue != 0) throw RuntimeException()
+        if (exitValue != 0) throw ContainerNotStoppedException()
     }
 }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/StopContainerServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/StopContainerServiceImplTest.kt
@@ -1,0 +1,25 @@
+package com.dcd.server.core.domain.application.service
+
+import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.domain.application.service.impl.StopContainerServiceImpl
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.mockk
+import io.mockk.verify
+import util.application.ApplicationGenerator
+
+class StopContainerServiceImplTest : BehaviorSpec({
+    val commandPort = mockk<CommandPort>(relaxed = true)
+    val stopContainerService = StopContainerServiceImpl(commandPort)
+
+    given("애플리케이션이 주어지고") {
+        val application = ApplicationGenerator.generateApplication()
+
+        `when`("컨테이너 정지 명령이 성공했을때") {
+            stopContainerService.stopContainer(application)
+
+            then("컨테이너 정지 명령이 실행되야함") {
+                verify { commandPort.executeShellCommand("docker stop ${application.name.lowercase()}") }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/StopContainerServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/StopContainerServiceImplTest.kt
@@ -1,8 +1,11 @@
 package com.dcd.server.core.domain.application.service
 
 import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.domain.application.exception.ContainerNotStoppedException
 import com.dcd.server.core.domain.application.service.impl.StopContainerServiceImpl
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import util.application.ApplicationGenerator
@@ -19,6 +22,16 @@ class StopContainerServiceImplTest : BehaviorSpec({
 
             then("컨테이너 정지 명령이 실행되야함") {
                 verify { commandPort.executeShellCommand("docker stop ${application.name.lowercase()}") }
+            }
+        }
+
+        `when`("컨테이너 정지 명령이 실패했을때") {
+            every { commandPort.executeShellCommand("docker stop ${application.name.lowercase()}") } returns 125
+
+            then("ContainerNotStoppedException이 발생해야함") {
+                shouldThrow<ContainerNotStoppedException> {
+                    stopContainerService.stopContainer(application)
+                }
             }
         }
     }


### PR DESCRIPTION
## 🔖 개요
* StopContainerService의 테스트 코드를 작성합니다.

## 📜 작업내용
* StopContainerService를 실행할때 컨테이너 정지 명령이 성공하는 테스트 케이스 추가
* StopContainerService를 실행할때 컨테이너 정지 명령이 실패하는 테스트 케이스 추가

## 🔀 변경사항
* StopContainerService에서 컨테이너 정지 명령이 실패했을때 커스텀 예외를 반환하는 로직 추가