### PR TITLE
🔀 :: 215 - 워크스페이스의 소유자를 검증하는 aop 로직 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/annotation/WorkspaceOwnerVerification.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/annotation/WorkspaceOwnerVerification.kt
@@ -1,0 +1,5 @@
+package com.dcd.server.core.common.annotation
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION)
+annotation class WorkspaceOwnerVerification()

--- a/src/main/kotlin/com/dcd/server/core/common/aop/EmailCertificateAspect.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/aop/EmailCertificateAspect.kt
@@ -20,8 +20,7 @@ class EmailCertificateAspect(
     private val queryUserPort: QueryUserPort
 ) {
     @Pointcut("execution(* com.dcd.server.core.domain.auth.usecase.SignUpUseCase.execute(..)) " + "&& args(signUpReqDto)")
-    fun signupUseCasePointcut(signUpReqDto: SignUpReqDto) {
-    }
+    fun signupUseCasePointcut(signUpReqDto: SignUpReqDto) {}
 
     @Pointcut("execution(* com.dcd.server.core.domain.auth.usecase.NonAuthChangePasswordUseCase.execute(..))" + "&& args(nonAuthChangePasswordReqDto)")
     fun changePasswordUseCasePointcut(nonAuthChangePasswordReqDto: NonAuthChangePasswordReqDto) {}

--- a/src/main/kotlin/com/dcd/server/core/common/aop/WorkspaceValidateAspect.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/aop/WorkspaceValidateAspect.kt
@@ -1,0 +1,13 @@
+package com.dcd.server.core.common.aop
+
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.annotation.Pointcut
+import org.springframework.stereotype.Component
+
+@Aspect
+@Component
+class WorkspaceValidateAspect {
+    @Pointcut("@annotation(com.dcd.server.core.annotation.WorkspaceOwnerVerification)")
+    fun verificationPointcut() {}
+
+}

--- a/src/main/kotlin/com/dcd/server/core/common/aop/WorkspaceValidateAspect.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/aop/WorkspaceValidateAspect.kt
@@ -1,13 +1,31 @@
 package com.dcd.server.core.common.aop
 
+import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
+import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import com.dcd.server.core.domain.user.service.GetCurrentUserService
+import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameException
 import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.annotation.Before
 import org.aspectj.lang.annotation.Pointcut
 import org.springframework.stereotype.Component
 
 @Aspect
 @Component
-class WorkspaceValidateAspect {
+class WorkspaceValidateAspect(
+    private val getCurrentUserService: GetCurrentUserService,
+    private val queryApplicationPort: QueryApplicationPort
+) {
     @Pointcut("@annotation(com.dcd.server.core.annotation.WorkspaceOwnerVerification)")
     fun verificationPointcut() {}
 
+    @Before("verificationPointcut() && args(id, ..)")
+    fun validWorkspaceOwner(id: String) {
+        val user = getCurrentUserService.getCurrentUser()
+
+        val application = queryApplicationPort.findById(id)
+            ?: throw ApplicationNotFoundException()
+
+        if (application.workspace.owner.equals(user))
+            throw WorkspaceOwnerNotSameException()
+    }
 }


### PR DESCRIPTION
## 🔖 개요
* 워크스페이스의 소유자를 검증하는 포인트 컷 및 어드바이스 추가

## 📜 작업내용
* 이메일 인증 검증 포인트컷의 공백 제거
* WorkspaceOwnerVerification 어노테이션 추가
* WorkspaceOwnerVerification 어노테이션의 포인트컷 추가
* 추가된 포인트컷의 어드바이스 추가

## 🎸 기타
* 해당 어노테이션의 적용은 다음에 진행합니다.