### PR TITLE
🔀 :: 217 - 워크스페이스 소유자 검증 어노테이션 적용

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/aop/WorkspaceValidateAspect.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/aop/WorkspaceValidateAspect.kt
@@ -15,17 +15,18 @@ class WorkspaceValidateAspect(
     private val getCurrentUserService: GetCurrentUserService,
     private val queryApplicationPort: QueryApplicationPort
 ) {
-    @Pointcut("@annotation(com.dcd.server.core.annotation.WorkspaceOwnerVerification)")
+    @Pointcut("@annotation(com.dcd.server.core.common.annotation.WorkspaceOwnerVerification)")
     fun verificationPointcut() {}
 
-    @Before("verificationPointcut() && args(id, ..)")
-    fun validWorkspaceOwner(id: String) {
+    @Before("verificationPointcut() && args(applicationId, ..)")
+    fun validWorkspaceOwner(applicationId: String) {
+        println("testsesteststtstetetst")
         val user = getCurrentUserService.getCurrentUser()
 
-        val application = queryApplicationPort.findById(id)
+        val application = queryApplicationPort.findById(applicationId)
             ?: throw ApplicationNotFoundException()
 
-        if (application.workspace.owner.equals(user))
+        if (!application.workspace.owner.equals(user))
             throw WorkspaceOwnerNotSameException()
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/common/aop/WorkspaceValidateAspect.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/aop/WorkspaceValidateAspect.kt
@@ -18,12 +18,11 @@ class WorkspaceValidateAspect(
     @Pointcut("@annotation(com.dcd.server.core.common.annotation.WorkspaceOwnerVerification)")
     fun verificationPointcut() {}
 
-    @Before("verificationPointcut() && args(applicationId, ..)")
-    fun validWorkspaceOwner(applicationId: String) {
-        println("testsesteststtstetetst")
+    @Before("verificationPointcut() && args(id, ..)")
+    fun validWorkspaceOwner(id: String) {
         val user = getCurrentUserService.getCurrentUser()
 
-        val application = queryApplicationPort.findById(applicationId)
+        val application = queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException()
 
         if (!application.workspace.owner.equals(user))

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/AddApplicationEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/AddApplicationEnvUseCase.kt
@@ -1,22 +1,21 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.common.annotation.WorkspaceOwnerVerification
 import com.dcd.server.core.domain.application.dto.request.AddApplicationEnvReqDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
-import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 
 @UseCase
 class AddApplicationEnvUseCase(
     private val queryApplicationPort: QueryApplicationPort,
-    private val commandApplicationPort: CommandApplicationPort,
-    private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService
+    private val commandApplicationPort: CommandApplicationPort
 ) {
+    @WorkspaceOwnerVerification
     fun execute(id: String, addApplicationEnvReqDto: AddApplicationEnvReqDto) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
-        validateWorkspaceOwnerService.validateOwner(application.workspace)
         val envMutable = application.env.toMutableMap()
         addApplicationEnvReqDto.envList.forEach {
             envMutable[it.key] = it.value

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationEnvUseCase.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.common.annotation.WorkspaceOwnerVerification
 import com.dcd.server.core.domain.application.exception.ApplicationEnvNotFoundException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
@@ -10,13 +11,12 @@ import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerServic
 @UseCase
 class DeleteApplicationEnvUseCase(
     private val queryApplicationPort: QueryApplicationPort,
-    private val commandApplicationPort: CommandApplicationPort,
-    private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService
+    private val commandApplicationPort: CommandApplicationPort
 ) {
+    @WorkspaceOwnerVerification
     fun execute(id: String, key: String) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
-        validateWorkspaceOwnerService.validateOwner(application.workspace)
         val updatedEnv = application.env.toMutableMap()
         updatedEnv.remove(key)
             ?: throw ApplicationEnvNotFoundException()

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationUseCase.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.common.annotation.WorkspaceOwnerVerification
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.exception.CanNotDeleteApplicationException
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
@@ -13,18 +14,15 @@ import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerServic
 
 @UseCase
 class DeleteApplicationUseCase(
-    private val getCurrentUserService: GetCurrentUserService,
     private val commandApplicationPort: CommandApplicationPort,
     private val queryApplicationPort: QueryApplicationPort,
-    private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService,
     private val deleteContainerService: DeleteContainerService,
     private val deleteImageService: DeleteImageService
 ) {
+    @WorkspaceOwnerVerification
     fun execute(id: String) {
-        val user = getCurrentUserService.getCurrentUser()
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
-        validateWorkspaceOwnerService.validateOwner(user, application.workspace)
 
         if (application.status == ApplicationStatus.RUNNING)
             throw CanNotDeleteApplicationException()

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.common.annotation.WorkspaceOwnerVerification
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.exception.CanNotDeployApplicationException
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
@@ -20,6 +21,7 @@ class DeployApplicationUseCase(
     private val createContainerService: CreateContainerService,
     private val deleteApplicationDirectoryService: DeleteApplicationDirectoryService
 ) {
+    @WorkspaceOwnerVerification
     fun execute(id: String) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GenerateSSLCertificateUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GenerateSSLCertificateUseCase.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.common.annotation.WorkspaceOwnerVerification
 import com.dcd.server.core.domain.application.dto.request.GenerateSSLCertificateReqDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.service.GenerateSSLCertificateService
@@ -18,6 +19,7 @@ class GenerateSSLCertificateUseCase(
     private val putSSLCertificateService: PutSSLCertificateService,
     private val getExternalPortService: GetExternalPortService
 ) {
+    @WorkspaceOwnerVerification
     fun execute(id: String, generateSSLCertificateReqDto: GenerateSSLCertificateReqDto) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCase.kt
@@ -1,25 +1,21 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.ReadOnlyUseCase
+import com.dcd.server.core.common.annotation.WorkspaceOwnerVerification
 import com.dcd.server.core.domain.application.dto.response.ApplicationLogResDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.service.GetContainerLogService
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
-import com.dcd.server.core.domain.user.service.GetCurrentUserService
-import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 
 @ReadOnlyUseCase
 class GetApplicationLogUseCase(
     private val getContainerLogService: GetContainerLogService,
-    private val queryApplicationPort: QueryApplicationPort,
-    private val getCurrentUserService: GetCurrentUserService,
-    private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService
+    private val queryApplicationPort: QueryApplicationPort
 ) {
+    @WorkspaceOwnerVerification
     fun execute(id: String): ApplicationLogResDto {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
-        val user = getCurrentUserService.getCurrentUser()
-        validateWorkspaceOwnerService.validateOwner(user, application.workspace)
 
         val logs = getContainerLogService.getLogs(application)
         return ApplicationLogResDto(logs)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCase.kt
@@ -1,24 +1,20 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.ReadOnlyUseCase
+import com.dcd.server.core.common.annotation.WorkspaceOwnerVerification
 import com.dcd.server.core.domain.application.dto.extenstion.toDto
 import com.dcd.server.core.domain.application.dto.response.ApplicationResDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
-import com.dcd.server.core.domain.user.service.GetCurrentUserService
-import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameException
 
 @ReadOnlyUseCase
 class GetOneApplicationUseCase(
-    private val queryApplicationPort: QueryApplicationPort,
-    private val getCurrentUserService: GetCurrentUserService
+    private val queryApplicationPort: QueryApplicationPort
 ) {
+    @WorkspaceOwnerVerification
     fun execute(id: String): ApplicationResDto {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
-        val currentUser = getCurrentUserService.getCurrentUser()
-        if (application.workspace.owner.equals(currentUser).not())
-            throw WorkspaceOwnerNotSameException()
         return application.toDto()
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCase.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.common.annotation.WorkspaceOwnerVerification
 import com.dcd.server.core.domain.application.exception.AlreadyRunningException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
@@ -12,17 +13,15 @@ import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerServic
 class RunApplicationUseCase(
     private val dockerRunService: DockerRunService,
     private val queryApplicationPort: QueryApplicationPort,
-    private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService,
     private val changeApplicationStatusService: ChangeApplicationStatusService
 ) {
+    @WorkspaceOwnerVerification
     fun execute(id: String) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
 
         if (application.status == ApplicationStatus.RUNNING)
             throw AlreadyRunningException()
-
-        validateWorkspaceOwnerService.validateOwner(application.workspace)
 
         dockerRunService.runApplication(application)
 

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCase.kt
@@ -1,29 +1,27 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.common.annotation.WorkspaceOwnerVerification
 import com.dcd.server.core.domain.application.exception.AlreadyStoppedException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.service.ChangeApplicationStatusService
 import com.dcd.server.core.domain.application.service.StopContainerService
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
-import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 
 @UseCase
 class StopApplicationUseCase(
     private val queryApplicationPort: QueryApplicationPort,
     private val stopContainerService: StopContainerService,
-    private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService,
     private val changeApplicationStatusService: ChangeApplicationStatusService
 ) {
+    @WorkspaceOwnerVerification
     fun execute(id: String) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
 
         if (application.status == ApplicationStatus.STOPPED)
             throw AlreadyStoppedException()
-
-        validateWorkspaceOwnerService.validateOwner(application.workspace)
 
         stopContainerService.stopContainer(application)
 

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCase.kt
@@ -1,28 +1,23 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.common.annotation.WorkspaceOwnerVerification
 import com.dcd.server.core.domain.application.dto.request.UpdateApplicationReqDto
 import com.dcd.server.core.domain.application.exception.AlreadyRunningException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
-import com.dcd.server.core.domain.user.service.GetCurrentUserService
-import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameException
 
 @UseCase
 class UpdateApplicationUseCase(
     private val queryApplicationPort: QueryApplicationPort,
     private val commandApplicationPort: CommandApplicationPort,
-    private val getCurrentUserService: GetCurrentUserService
 ) {
+    @WorkspaceOwnerVerification
     fun execute(id: String, updateApplicationReqDto: UpdateApplicationReqDto) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
-        val owner = application.workspace.owner
-
-        if (owner.equals(getCurrentUserService.getCurrentUser()).not())
-            throw WorkspaceOwnerNotSameException()
 
         if (application.status == ApplicationStatus.RUNNING)
             throw AlreadyRunningException()

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/AddApplicationEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/AddApplicationEnvUseCaseTest.kt
@@ -22,8 +22,7 @@ import java.util.*
 class AddApplicationEnvUseCaseTest : BehaviorSpec({
     val queryApplicationPort = mockk<QueryApplicationPort>()
     val commandApplicationPort = mockk<CommandApplicationPort>()
-    val validateWorkspaceOwnerService = mockk<ValidateWorkspaceOwnerService>(relaxUnitFun = true)
-    val addApplicationEnvUseCase = AddApplicationEnvUseCase(queryApplicationPort, commandApplicationPort, validateWorkspaceOwnerService)
+    val addApplicationEnvUseCase = AddApplicationEnvUseCase(queryApplicationPort, commandApplicationPort)
 
     given("request가 주어지고") {
         val request = AddApplicationEnvReqDto(

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationEnvUseCaseTest.kt
@@ -22,8 +22,7 @@ import java.util.*
 class DeleteApplicationEnvUseCaseTest : BehaviorSpec({
     val queryApplicationPort = mockk<QueryApplicationPort>()
     val commandApplicationPort = mockk<CommandApplicationPort>()
-    val validateWorkspaceOwnerService = mockk<ValidateWorkspaceOwnerService>(relaxUnitFun = true)
-    val deleteApplicationEnvUseCase = DeleteApplicationEnvUseCase(queryApplicationPort, commandApplicationPort, validateWorkspaceOwnerService)
+    val deleteApplicationEnvUseCase = DeleteApplicationEnvUseCase(queryApplicationPort, commandApplicationPort)
 
     given("애플리케이션 Id와 삭제할 key가 주어지고") {
         val applicationId = "testId"

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationUseCaseTest.kt
@@ -26,19 +26,16 @@ import java.lang.RuntimeException
 import java.util.*
 
 class DeleteApplicationUseCaseTest : BehaviorSpec({
-    val getCurrentUserService = mockk<GetCurrentUserService>()
     val commandApplicationPort = mockk<CommandApplicationPort>()
     val queryApplicationPort = mockk<QueryApplicationPort>()
-    val validateWorkspaceOwnerService = mockk<ValidateWorkspaceOwnerService>(relaxUnitFun = true)
     val deleteContainerService = mockk<DeleteContainerService>(relaxUnitFun = true)
     val deleteImageService = mockk<DeleteImageService>(relaxUnitFun = true)
     val deleteApplicationUseCase =
-        DeleteApplicationUseCase(getCurrentUserService, commandApplicationPort, queryApplicationPort, validateWorkspaceOwnerService, deleteContainerService, deleteImageService)
+        DeleteApplicationUseCase(commandApplicationPort, queryApplicationPort, deleteContainerService, deleteImageService)
     given("애플리케이션 id가 주어지고") {
         val applicationId = "testId"
         val user = UserGenerator.generateUser()
         val application = ApplicationGenerator.generateApplication(workspace = WorkspaceGenerator.generateWorkspace(user = user))
-        every { getCurrentUserService.getCurrentUser() } returns user
         `when`("usecase를 실행할때") {
             every { commandApplicationPort.delete(application) } returns Unit
             every { queryApplicationPort.findById(applicationId) } returns application
@@ -58,7 +55,6 @@ class DeleteApplicationUseCaseTest : BehaviorSpec({
             }
         }
         `when`("현재 유저가 소유자가 아닐때") {
-            every { getCurrentUserService.getCurrentUser() } returns user.copy(id = "otherUser")
             then("RuntimeException이 발생해야함") {
                 shouldThrow<RuntimeException> {
                     deleteApplicationUseCase.execute(applicationId)
@@ -71,7 +67,6 @@ class DeleteApplicationUseCaseTest : BehaviorSpec({
         val applicationId = "testId"
         val user = UserGenerator.generateUser()
         val application = ApplicationGenerator.generateApplication(workspace = WorkspaceGenerator.generateWorkspace(user = user), status = ApplicationStatus.RUNNING)
-        every { getCurrentUserService.getCurrentUser() } returns user
         `when`("usecase를 실행할때") {
             every { commandApplicationPort.delete(application) } returns Unit
             every { queryApplicationPort.findById(applicationId) } returns application

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCaseTest.kt
@@ -40,18 +40,6 @@ class GetApplicationLogUseCaseTest : BehaviorSpec({
             }
         }
 
-        `when`("해당 애플리케이션이 존재하지만, 로그인된 유저가 워크스페이스의 권한을 가지고 있지 않을때") {
-            val user = UserGenerator.generateUser(email = "thief")
-
-            every { queryApplicationPort.findById(appId) } returns application
-
-            then("유스케이스 실행시 WorkspaceOwnerNotSameException이 발생해야함") {
-                shouldThrow<WorkspaceOwnerNotSameException> {
-                    getApplicationLogUseCase.execute(appId)
-                }
-            }
-        }
-
         `when`("해당 애플리케이션이 존재하고, 로그인된 유저가 워크스페이스의 권한을 가지고 있을때") {
             val logs = listOf("testLogs")
 

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCaseTest.kt
@@ -19,13 +19,9 @@ import util.workspace.WorkspaceGenerator
 class GetApplicationLogUseCaseTest : BehaviorSpec({
     val getContainerLogService = mockk<GetContainerLogService>()
     val queryApplicationPort = mockk<QueryApplicationPort>()
-    val getCurrentUserService = mockk<GetCurrentUserService>()
-    val validateWorkspaceOwnerService = mockk<ValidateWorkspaceOwnerService>(relaxUnitFun = true)
     val getApplicationLogUseCase = GetApplicationLogUseCase(
         getContainerLogService,
-        queryApplicationPort,
-        getCurrentUserService,
-        validateWorkspaceOwnerService
+        queryApplicationPort
     )
 
     given("애플리케이션 id가 주어지고") {
@@ -48,8 +44,6 @@ class GetApplicationLogUseCaseTest : BehaviorSpec({
             val user = UserGenerator.generateUser(email = "thief")
 
             every { queryApplicationPort.findById(appId) } returns application
-            every { getCurrentUserService.getCurrentUser() } returns user
-            every { validateWorkspaceOwnerService.validateOwner(user, workspace) } throws WorkspaceOwnerNotSameException()
 
             then("유스케이스 실행시 WorkspaceOwnerNotSameException이 발생해야함") {
                 shouldThrow<WorkspaceOwnerNotSameException> {
@@ -62,7 +56,6 @@ class GetApplicationLogUseCaseTest : BehaviorSpec({
             val logs = listOf("testLogs")
 
             every { queryApplicationPort.findById(appId) } returns application
-            every { getCurrentUserService.getCurrentUser() } returns owner
             every { getContainerLogService.getLogs(application) } returns logs
 
             val response = getApplicationLogUseCase.execute(appId)

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCaseTest.kt
@@ -23,15 +23,13 @@ import java.util.*
 
 class GetOneApplicationUseCaseTest : BehaviorSpec({
     val queryApplicationPort = mockk<QueryApplicationPort>()
-    val getCurrentUserService = mockk<GetCurrentUserService>()
-    val getOneApplicationUseCase = GetOneApplicationUseCase(queryApplicationPort, getCurrentUserService)
+    val getOneApplicationUseCase = GetOneApplicationUseCase(queryApplicationPort)
 
     given("애플리케이션이 주어지고") {
         val user = UserGenerator.generateUser()
         val application = ApplicationGenerator.generateApplication(workspace = WorkspaceGenerator.generateWorkspace(user = user))
         `when`("해당 애플리케이션이 있을때") {
             every { queryApplicationPort.findById(application.id) } returns application
-            every { getCurrentUserService.getCurrentUser() } returns user
             val result = getOneApplicationUseCase.execute(application.id)
             then("result는 application의 내용이랑 같아야함") {
                 result shouldBe application.toDto()
@@ -47,10 +45,7 @@ class GetOneApplicationUseCaseTest : BehaviorSpec({
             }
         }
         `when`("현재 유저가 해당 애플리케이션의 워크스페이스 주인이 아닐때") {
-            val another = UserGenerator.generateUser(email = "another")
-
             every { queryApplicationPort.findById(application.id) } returns application
-            every { getCurrentUserService.getCurrentUser() } returns another
 
             then("WorkspaceOwnerNotSameException이 발생해야함") {
                 shouldThrow<WorkspaceOwnerNotSameException> {

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCaseTest.kt
@@ -44,14 +44,5 @@ class GetOneApplicationUseCaseTest : BehaviorSpec({
                 }
             }
         }
-        `when`("현재 유저가 해당 애플리케이션의 워크스페이스 주인이 아닐때") {
-            every { queryApplicationPort.findById(application.id) } returns application
-
-            then("WorkspaceOwnerNotSameException이 발생해야함") {
-                shouldThrow<WorkspaceOwnerNotSameException> {
-                    getOneApplicationUseCase.execute(application.id)
-                }
-            }
-        }
     }
 })

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCaseTest.kt
@@ -34,7 +34,7 @@ class RunApplicationUseCaseTest : BehaviorSpec({
         val application = ApplicationGenerator.generateApplication(workspace = workspace)
         `when`("usecase를 실행할때") {
             every { queryApplicationPort.findById("testId") } returns application
-            val result = runApplicationUseCase.execute("testId")
+            runApplicationUseCase.execute("testId")
             then("애플리케이션 실행에 관한 service들이 실행되어야함") {
                 verify { changeApplicationStatusService.changeApplicationStatus(application, ApplicationStatus.RUNNING) }
             }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCaseTest.kt
@@ -21,12 +21,10 @@ import util.workspace.WorkspaceGenerator
 class RunApplicationUseCaseTest : BehaviorSpec({
     val dockerRunService = mockk<DockerRunService>(relaxUnitFun = true)
     val queryApplicationPort = mockk<QueryApplicationPort>(relaxUnitFun = true)
-    val validateWorkspaceOwnerService = mockk<ValidateWorkspaceOwnerService>(relaxUnitFun = true)
     val changeApplicationStatusService = mockk<ChangeApplicationStatusService>(relaxUnitFun = true)
     val runApplicationUseCase = RunApplicationUseCase(
         dockerRunService,
         queryApplicationPort,
-        validateWorkspaceOwnerService,
         changeApplicationStatusService
     )
 
@@ -38,7 +36,6 @@ class RunApplicationUseCaseTest : BehaviorSpec({
             every { queryApplicationPort.findById("testId") } returns application
             val result = runApplicationUseCase.execute("testId")
             then("애플리케이션 실행에 관한 service들이 실행되어야함") {
-                verify { validateWorkspaceOwnerService.validateOwner(workspace) }
                 verify { changeApplicationStatusService.changeApplicationStatus(application, ApplicationStatus.RUNNING) }
             }
         }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
@@ -21,10 +21,9 @@ import util.workspace.WorkspaceGenerator
 class StopApplicationUseCaseTest : BehaviorSpec({
     val queryApplicationPort = mockk<QueryApplicationPort>()
     val stopContainerService = mockk<StopContainerService>(relaxUnitFun = true)
-    val validateWorkspaceOwnerService = mockk<ValidateWorkspaceOwnerService>(relaxUnitFun = true)
     val changeApplicationStatusService = mockk<ChangeApplicationStatusService>(relaxUnitFun = true)
     val stopApplicationUseCase =
-        StopApplicationUseCase(queryApplicationPort, stopContainerService, validateWorkspaceOwnerService, changeApplicationStatusService)
+        StopApplicationUseCase(queryApplicationPort, stopContainerService, changeApplicationStatusService)
 
     given("애플리케이션 Id가 주어지고") {
         val applicationId = "testApplicationId"

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCaseTest.kt
@@ -48,15 +48,6 @@ class UpdateApplicationUseCaseTest : BehaviorSpec({
                 verify { commandApplicationPort.save(updatedApplication) }
             }
         }
-
-        `when`("로그인된 유저가 workspace 주인이 아닐때") {
-
-            then("WorkspaceOwnerNotSameException이 발생해야함") {
-                shouldThrow<WorkspaceOwnerNotSameException> {
-                    updateApplicationUseCase.execute(applicationId, updateReqDto)
-                }
-            }
-        }
     }
 
     given("애플리케이션이 주어지지 않고") {

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCaseTest.kt
@@ -26,10 +26,9 @@ import java.util.*
 class UpdateApplicationUseCaseTest : BehaviorSpec({
     val queryApplicationPort = mockk<QueryApplicationPort>()
     val commandApplicationPort = mockk<CommandApplicationPort>(relaxUnitFun = true)
-    val getCurrentUserService = mockk<GetCurrentUserService>()
 
     val updateApplicationUseCase =
-        UpdateApplicationUseCase(queryApplicationPort, commandApplicationPort, getCurrentUserService)
+        UpdateApplicationUseCase(queryApplicationPort, commandApplicationPort)
 
     val user = UserGenerator.generateUser()
     val workspace = WorkspaceGenerator.generateWorkspace(user = user)
@@ -40,7 +39,6 @@ class UpdateApplicationUseCaseTest : BehaviorSpec({
         val application = ApplicationGenerator.generateApplication(id = applicationId, workspace = workspace)
 
         `when`("usecase를 실행할때") {
-            every { getCurrentUserService.getCurrentUser() } returns user
             every { queryApplicationPort.findById(applicationId) } returns application
 
             updateApplicationUseCase.execute(applicationId, updateReqDto)
@@ -52,7 +50,6 @@ class UpdateApplicationUseCaseTest : BehaviorSpec({
         }
 
         `when`("로그인된 유저가 workspace 주인이 아닐때") {
-            every { getCurrentUserService.getCurrentUser() } returns user.copy(id = "another", name = "another", email = "another")
 
             then("WorkspaceOwnerNotSameException이 발생해야함") {
                 shouldThrow<WorkspaceOwnerNotSameException> {
@@ -79,7 +76,6 @@ class UpdateApplicationUseCaseTest : BehaviorSpec({
         val application = ApplicationGenerator.generateApplication(id = applicationId, workspace = workspace, status = ApplicationStatus.RUNNING)
 
         `when`("usecase를 실행할때") {
-            every { getCurrentUserService.getCurrentUser() } returns user
             every { queryApplicationPort.findById(applicationId) } returns application
 
             then("ReqDto의 내용이 반영된 애플리케이션을 저장해야함") {


### PR DESCRIPTION
## 🔖 개요
* 애플리케이션 소유자를 검증하는 로직 대신에 어노테이션을 통해 검증하도록 합니다.

## 📜 작업내용
* WorkspaceValidateAspect 수정
  * 포인트컷에서 사용하던 어노테이션 경로 수정
  * if문 조건 수정
* 워크스페이스 소유자를 검증할 필요가 있는 usecase에서 어노테이션을 통해서 검증하도록 수정