### PR TITLE
🔀 :: 219 - 워크스페이스 소유자 검증 어노테이션 리펙토링

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/aop/WorkspaceValidateAspect.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/aop/WorkspaceValidateAspect.kt
@@ -1,10 +1,10 @@
 package com.dcd.server.core.common.aop
 
-import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.user.service.GetCurrentUserService
 import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
 import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameException
+import com.dcd.server.core.domain.workspace.model.Workspace
 import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
 import org.aspectj.lang.annotation.Aspect
 import org.aspectj.lang.annotation.Before
@@ -25,18 +25,14 @@ class WorkspaceValidateAspect(
     fun validWorkspaceOwner(id: String) {
         val user = getCurrentUserService.getCurrentUser()
 
-        try {
-            val workspace = queryWorkspacePort.findById(id)
-                ?: throw WorkspaceNotFoundException()
+        val workspace = (findWorkspace(id)
+            ?: throw WorkspaceNotFoundException())
 
-            if (!workspace.owner.equals(user))
-                throw WorkspaceOwnerNotSameException()
-        } catch (e: WorkspaceNotFoundException) {
-            val application = queryApplicationPort.findById(id)
-                ?: throw ApplicationNotFoundException()
-
-            if (!application.workspace.owner.equals(user))
-                throw WorkspaceOwnerNotSameException()
-        }
+        if (!workspace.owner.equals(user))
+            throw WorkspaceOwnerNotSameException()
     }
+
+    private fun findWorkspace(id: String): Workspace? =
+        queryWorkspacePort.findById(id)
+            ?: queryApplicationPort.findById(id)?.workspace
 }

--- a/src/main/kotlin/com/dcd/server/core/common/aop/WorkspaceValidateAspect.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/aop/WorkspaceValidateAspect.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.core.common.aop
 
+import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.user.service.GetCurrentUserService
 import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
@@ -34,5 +35,7 @@ class WorkspaceValidateAspect(
 
     private fun findWorkspace(id: String): Workspace? =
         queryWorkspacePort.findById(id)
-            ?: queryApplicationPort.findById(id)?.workspace
+            ?: (queryApplicationPort.findById(id)
+                ?: throw ApplicationNotFoundException())
+                .workspace
 }


### PR DESCRIPTION
## 🔖 개요
* 워크스페이스 소유자 검증 어노테이션을 리펙토링합니다.

## 📜 작업내용
* 메서드에서 받은 id로 워크스페이스를 조회후 워크스페이스가 없다면 애플리케이션을 조회해서 워크스페이스의 소유자를 검증하게끔 수정
* 워크스페이스 조회하는 부분을 메서드로 분리
* 조회된 워크스페이스가 null이라 애플리케이션을 조회할때도 애플리케이션이 null이라면 ApplicationNotFoundException이 발생하도록 수정
