### PR TITLE
🔀 :: 223 - 애플리케이션 환경변수 수정 API 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
@@ -12,6 +12,7 @@ enum class ErrorCode(
     NOT_SUPPORTED_APPLICATION_TYPE("지원되는 애플리케이션 타입이 아님", 400),
     APPLICATION_ALREADY_RUNNING("해당 애플리케이션은 이미 실행중임", 400),
     APPLICATION_ALREADY_STOPPED("해당 애플리케이션은 이미 정지됨", 400),
+    ALREADY_EXISTS_APPLICATION_ENV("해당 키값을 가지는 환경변수가 이미 존재함", 400),
 
     UNAUTHORIZED("권한이 없음", 401),
     EXPIRED_TOKEN("토큰이 만료됨", 401),

--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/request/UpdateApplicationEnvReqDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/request/UpdateApplicationEnvReqDto.kt
@@ -1,0 +1,5 @@
+package com.dcd.server.core.domain.application.dto.request
+
+data class UpdateApplicationEnvReqDto(
+    val newValue: String
+)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/exception/AlreadyExistsEnvException.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/exception/AlreadyExistsEnvException.kt
@@ -1,0 +1,7 @@
+package com.dcd.server.core.domain.application.exception
+
+import com.dcd.server.core.common.error.BasicException
+import com.dcd.server.core.common.error.ErrorCode
+
+class AlreadyExistsEnvException : BasicException(ErrorCode.ALREADY_EXISTS_APPLICATION_ENV) {
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/AddApplicationEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/AddApplicationEnvUseCase.kt
@@ -3,6 +3,7 @@ package com.dcd.server.core.domain.application.usecase
 import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.common.annotation.ApplicationOwnerVerification
 import com.dcd.server.core.domain.application.dto.request.AddApplicationEnvReqDto
+import com.dcd.server.core.domain.application.exception.AlreadyExistsEnvException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
@@ -18,6 +19,8 @@ class AddApplicationEnvUseCase(
             ?: throw ApplicationNotFoundException())
         val envMutable = application.env.toMutableMap()
         addApplicationEnvReqDto.envList.forEach {
+            if (envMutable.containsKey(it.key)) throw AlreadyExistsEnvException()
+
             envMutable[it.key] = it.value
         }
         commandApplicationPort.save(application.copy(env = envMutable))

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationEnvUseCase.kt
@@ -1,0 +1,32 @@
+package com.dcd.server.core.domain.application.usecase
+
+import com.dcd.server.core.common.annotation.ApplicationOwnerVerification
+import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.domain.application.dto.request.UpdateApplicationEnvReqDto
+import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
+import com.dcd.server.core.domain.application.spi.CommandApplicationPort
+import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+
+@UseCase
+class UpdateApplicationEnvUseCase(
+    private val queryApplicationPort: QueryApplicationPort,
+    private val commandApplicationPort: CommandApplicationPort
+) {
+    @ApplicationOwnerVerification
+    fun execute(applicationId: String, envKey: String, updateApplicationEnvReqDto: UpdateApplicationEnvReqDto) {
+        val application = (queryApplicationPort.findById(applicationId)
+            ?: throw ApplicationNotFoundException())
+
+        val env = application.env
+        if (env.containsKey(envKey).not())
+            throw RuntimeException()//해당 env를 찾을 수 없음
+
+        val mutableEnv = env.toMutableMap()
+        mutableEnv[envKey] = updateApplicationEnvReqDto.newValue
+        commandApplicationPort.save(
+            application.copy(
+                env = mutableEnv
+            )
+        )
+    }
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationEnvUseCase.kt
@@ -3,6 +3,7 @@ package com.dcd.server.core.domain.application.usecase
 import com.dcd.server.core.common.annotation.ApplicationOwnerVerification
 import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.domain.application.dto.request.UpdateApplicationEnvReqDto
+import com.dcd.server.core.domain.application.exception.ApplicationEnvNotFoundException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
@@ -19,7 +20,7 @@ class UpdateApplicationEnvUseCase(
 
         val env = application.env
         if (env.containsKey(envKey).not())
-            throw RuntimeException()//해당 env를 찾을 수 없음
+            throw ApplicationEnvNotFoundException()
 
         val mutableEnv = env.toMutableMap()
         mutableEnv[envKey] = updateApplicationEnvReqDto.newValue

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
@@ -62,6 +62,7 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.POST, "/application/{id}/certificate").authenticated()
                 it.requestMatchers(HttpMethod.POST, "/application/{id}/env").authenticated()
                 it.requestMatchers(HttpMethod.DELETE, "/application/{id}/env").authenticated()
+                it.requestMatchers(HttpMethod.PATCH, "/application/{applicationId}/env/{key}").authenticated()
                 it.requestMatchers(HttpMethod.GET, "/application/version/{applicationType}").authenticated()
 
                 //workspace

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
@@ -4,10 +4,7 @@ import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.usecase.*
 import com.dcd.server.presentation.domain.application.data.exetension.toDto
 import com.dcd.server.presentation.domain.application.data.exetension.toResponse
-import com.dcd.server.presentation.domain.application.data.request.AddApplicationEnvRequest
-import com.dcd.server.presentation.domain.application.data.request.CreateApplicationRequest
-import com.dcd.server.presentation.domain.application.data.request.GenerateSSLCertificateRequest
-import com.dcd.server.presentation.domain.application.data.request.UpdateApplicationRequest
+import com.dcd.server.presentation.domain.application.data.request.*
 import com.dcd.server.presentation.domain.application.data.response.*
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -23,6 +20,7 @@ class ApplicationWebAdapter(
     private val getOneApplicationUseCase: GetOneApplicationUseCase,
     private val addApplicationEnvUseCase: AddApplicationEnvUseCase,
     private val deleteApplicationEnvUseCase: DeleteApplicationEnvUseCase,
+    private val updateApplicationEnvUseCase: UpdateApplicationEnvUseCase,
     private val stopApplicationUseCase: StopApplicationUseCase,
     private val deleteApplicationUseCase: DeleteApplicationUseCase,
     private val updateApplicationUseCase: UpdateApplicationUseCase,
@@ -64,6 +62,11 @@ class ApplicationWebAdapter(
     @DeleteMapping("/{id}/env")
     fun deleteApplicationEnv(@PathVariable id: String, @RequestParam key: String): ResponseEntity<Void> =
         deleteApplicationEnvUseCase.execute(id, key)
+            .run { ResponseEntity.ok().build() }
+
+    @PatchMapping("/{applicationId}/env/{key}")
+    fun updateApplicationEnv(@PathVariable applicationId: String, @PathVariable key: String, @RequestBody updateApplicationEnvRequest: UpdateApplicationEnvRequest): ResponseEntity<Void> =
+        updateApplicationEnvUseCase.execute(applicationId, key, updateApplicationEnvRequest.toDto())
             .run { ResponseEntity.ok().build() }
 
     @PostMapping("/{id}/stop")

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationRequestDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationRequestDataExtension.kt
@@ -1,13 +1,7 @@
 package com.dcd.server.presentation.domain.application.data.exetension
 
-import com.dcd.server.core.domain.application.dto.request.AddApplicationEnvReqDto
-import com.dcd.server.core.domain.application.dto.request.CreateApplicationReqDto
-import com.dcd.server.core.domain.application.dto.request.GenerateSSLCertificateReqDto
-import com.dcd.server.core.domain.application.dto.request.UpdateApplicationReqDto
-import com.dcd.server.presentation.domain.application.data.request.AddApplicationEnvRequest
-import com.dcd.server.presentation.domain.application.data.request.CreateApplicationRequest
-import com.dcd.server.presentation.domain.application.data.request.GenerateSSLCertificateRequest
-import com.dcd.server.presentation.domain.application.data.request.UpdateApplicationRequest
+import com.dcd.server.core.domain.application.dto.request.*
+import com.dcd.server.presentation.domain.application.data.request.*
 
 fun AddApplicationEnvRequest.toDto(): AddApplicationEnvReqDto =
     AddApplicationEnvReqDto(
@@ -38,4 +32,9 @@ fun UpdateApplicationRequest.toDto(): UpdateApplicationReqDto =
 fun GenerateSSLCertificateRequest.toDto(): GenerateSSLCertificateReqDto =
     GenerateSSLCertificateReqDto(
         domain = this.domain
+    )
+
+fun UpdateApplicationEnvRequest.toDto(): UpdateApplicationEnvReqDto =
+    UpdateApplicationEnvReqDto(
+        newValue = this.newValue
     )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/request/UpdateApplicationEnvRequest.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/request/UpdateApplicationEnvRequest.kt
@@ -1,0 +1,5 @@
+package com.dcd.server.presentation.domain.application.data.request
+
+data class UpdateApplicationEnvRequest(
+    val newValue: String
+)

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -26,6 +26,7 @@ class ApplicationWebAdapterTest : BehaviorSpec({
     val getOneApplicationUseCase = mockk<GetOneApplicationUseCase>()
     val addApplicationEnvUseCase = mockk<AddApplicationEnvUseCase>()
     val deleteApplicationEnvUseCase = mockk<DeleteApplicationEnvUseCase>()
+    val updateApplicationEnvUseCase = mockk<UpdateApplicationEnvUseCase>(relaxUnitFun = true)
     val stopApplicationUseCase = mockk<StopApplicationUseCase>()
     val deleteApplicationUseCase = mockk<DeleteApplicationUseCase>()
     val updateApplicationUseCase = mockk<UpdateApplicationUseCase>(relaxUnitFun = true)
@@ -33,7 +34,7 @@ class ApplicationWebAdapterTest : BehaviorSpec({
     val generateSSLCertificateUseCase = mockk<GenerateSSLCertificateUseCase>(relaxUnitFun = true)
     val getApplicationLogUseCase = mockk<GetApplicationLogUseCase>()
     val deployApplicationUseCase = mockk<DeployApplicationUseCase>(relaxUnitFun = true)
-    val applicationWebAdapter = ApplicationWebAdapter(createApplicationUseCase, springRunApplicationUseCase, getAllApplicationUseCase, getOneApplicationUseCase, addApplicationEnvUseCase, deleteApplicationEnvUseCase, stopApplicationUseCase, deleteApplicationUseCase, updateApplicationUseCase, getAvailableVersionUseCase, generateSSLCertificateUseCase, getApplicationLogUseCase, deployApplicationUseCase)
+    val applicationWebAdapter = ApplicationWebAdapter(createApplicationUseCase, springRunApplicationUseCase, getAllApplicationUseCase, getOneApplicationUseCase, addApplicationEnvUseCase, deleteApplicationEnvUseCase, updateApplicationEnvUseCase, stopApplicationUseCase, deleteApplicationUseCase, updateApplicationUseCase, getAvailableVersionUseCase, generateSSLCertificateUseCase, getApplicationLogUseCase, deployApplicationUseCase)
 
     given("CreateApplicationRequest가 주어지고") {
         val request = CreateApplicationRequest(


### PR DESCRIPTION
## 🔖 개요
* 애플리케이션의 환경변수를 수정할 수 있는 API를 추가합니다.

## 📜 작업내용
* 애플리케이션 환경변수 수정 요청 객체 추가
* UpdateApplicationEnvUseCase 추가
* 애플리케이션 환경변수 수정 엔드포인트 추가
* 애플리케이션 환경변수 수정 엔드포인트 권한 설정 추가
* AlreadyExistsEnvException 추가
* ApplicationWebAdapter 테스트 코드에 UpdateApplicationEnvUseCase 모킹 추가

## 🔀 변경사항
* AddApplicationEnvUseCase에서 이미 해당 키값을 가지는 환경변수가 있을때 예외를 발생시키도록 수정