### PR TITLE
🔀 :: 225 - 애플리케이션 환경변수 수정 API 테스트 코드

### DIFF
--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationEnvUseCaseTest.kt
@@ -1,0 +1,46 @@
+package com.dcd.server.core.domain.application.usecase
+
+import com.dcd.server.core.domain.application.dto.request.UpdateApplicationEnvReqDto
+import com.dcd.server.core.domain.application.exception.ApplicationEnvNotFoundException
+import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
+import com.dcd.server.core.domain.application.spi.CommandApplicationPort
+import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import util.application.ApplicationGenerator
+
+class UpdateApplicationEnvUseCaseTest : BehaviorSpec({
+    val queryApplicationPort = mockk<QueryApplicationPort>()
+    val commandApplicationPort = mockk<CommandApplicationPort>(relaxUnitFun = true)
+    val updateApplicationEnvUseCase = UpdateApplicationEnvUseCase(queryApplicationPort, commandApplicationPort)
+
+    given("애플리케이션 아이디와 수정할 환경변수값이 주어지고") {
+        val applicationId = "testId"
+        val envKey = "testKey"
+        val request = UpdateApplicationEnvReqDto(newValue = "newValue")
+
+        `when`("해당 애플리케이션이 존재할때") {
+            val env = mapOf(Pair(envKey, "testValue"))
+            val application = ApplicationGenerator.generateApplication(
+                id = applicationId,
+                env = env
+            )
+            every { queryApplicationPort.findById(applicationId) } returns application
+
+            updateApplicationEnvUseCase.execute(applicationId, envKey, request)
+
+            then("애플리케이션의 env를 변경해서 저장해야함") {
+                val updatedEnv = env.toMutableMap()
+                updatedEnv[envKey] = request.newValue
+                val updatedApplication = application.copy(env = updatedEnv)
+
+                updatedApplication.env[envKey] shouldBe request.newValue
+                verify { commandApplicationPort.save(updatedApplication) }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationEnvUseCaseTest.kt
@@ -42,5 +42,15 @@ class UpdateApplicationEnvUseCaseTest : BehaviorSpec({
                 verify { commandApplicationPort.save(updatedApplication) }
             }
         }
+
+        `when`("해당 애플리케이션이 존재하지 않을때") {
+            every { queryApplicationPort.findById(applicationId) } returns null
+
+            then("ApplicationNotFoundException이 발생해야함") {
+                shouldThrow<ApplicationNotFoundException> {
+                    updateApplicationEnvUseCase.execute(applicationId, envKey, request)
+                }
+            }
+        }
     }
 })

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationEnvUseCaseTest.kt
@@ -52,5 +52,20 @@ class UpdateApplicationEnvUseCaseTest : BehaviorSpec({
                 }
             }
         }
+
+        `when`("해당 키를 가지는 환경변수가 존재하지 않을때") {
+            val env = mapOf(Pair("NotTestKey", "value"))
+            val application = ApplicationGenerator.generateApplication(
+                id = applicationId,
+                env = env
+            )
+            every { queryApplicationPort.findById(applicationId) } returns application
+
+            then("ApplicationEnvNotFoundException가 발생해야함") {
+                shouldThrow<ApplicationEnvNotFoundException> {
+                    updateApplicationEnvUseCase.execute(applicationId, envKey, request)
+                }
+            }
+        }
     }
 })

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -7,10 +7,7 @@ import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.usecase.*
 import com.dcd.server.presentation.domain.application.data.exetension.toResponse
-import com.dcd.server.presentation.domain.application.data.request.AddApplicationEnvRequest
-import com.dcd.server.presentation.domain.application.data.request.CreateApplicationRequest
-import com.dcd.server.presentation.domain.application.data.request.GenerateSSLCertificateRequest
-import com.dcd.server.presentation.domain.application.data.request.UpdateApplicationRequest
+import com.dcd.server.presentation.domain.application.data.request.*
 import com.dcd.server.presentation.domain.application.data.response.RunApplicationResponse
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -222,6 +219,20 @@ class ApplicationWebAdapterTest : BehaviorSpec({
                 verify { generateSSLCertificateUseCase.execute(testId, any() as GenerateSSLCertificateReqDto) }
             }
             then("result는 200 상태코드를 가져야함") {
+                result.statusCode shouldBe HttpStatus.OK
+            }
+        }
+    }
+
+    given("애플리케이션 id와 UpdateApplicationEnvRequest가 주어지고") {
+        val testId = "testId"
+        val envKey = "testKey"
+        val request = UpdateApplicationEnvRequest(newValue = "newValue")
+
+        `when`("updateApplicationEnv 메서드를 실행할때") {
+            val result = applicationWebAdapter.updateApplicationEnv(testId, envKey, request)
+
+            then("상태코드는 200이여야함") {
                 result.statusCode shouldBe HttpStatus.OK
             }
         }


### PR DESCRIPTION
## 🔖 개요
* 애플리케이션을 환경변수를 수정하는 API의 테스트 코드를 작성합니다.

## 📜 작업내용
* UpdateApplicationEnvUseCase를 정상적으로 실행되는 테스트 케이스 추가
* UpdateApplicationEnvUseCase에 주어진 id를 가진 애플리케이션이 없는 테스트 케이스 추가
* UpdateApplicationEnvUseCase에 주어진 애플리케이션이 주어진 key값의 환경변수를 가지고 있지 않은 테스트 케이스 추가
* ApplicationWebAdapter에서 updateApplicationEnv메서드를 실행하는 테스트 케이스 추가