### PR TITLE
🔀 :: 229 - Nest 애플리케이션 타입 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
@@ -10,6 +10,12 @@ object FileContent {
         getEnvString(env) +
         "CMD [\"java\",\"-jar\",\"build/libs/app.jar\"]"
 
+    fun getNestJsDockerFileContent(version: String, port: Int, env: Map<String, String>): String =
+        "FROM node:${version}\n" +
+        "EXPOSE ${port}\n" +
+        getEnvString(env) +
+        "CMD [\"npm\",\"run\",\"start\"]"
+
     fun getMYSQLDockerFileContent(version: String, port: Int, env: Map<String, String>): String =
         "FROM mysql:${version}\n" +
         "EXPOSE ${port}\n" +

--- a/src/main/kotlin/com/dcd/server/core/domain/application/model/enums/ApplicationType.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/model/enums/ApplicationType.kt
@@ -2,6 +2,7 @@ package com.dcd.server.core.domain.application.model.enums
 
 enum class ApplicationType {
     SPRING_BOOT,
+    NEST_JS,
     MYSQL,
     MARIA_DB,
     REDIS

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateDockerFileServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateDockerFileServiceImpl.kt
@@ -45,6 +45,9 @@ class CreateDockerFileServiceImpl(
 
             ApplicationType.REDIS ->
                 FileContent.getRedisDockerFileContent(version, application.port, application.env)
+
+            ApplicationType.NEST_JS ->
+                FileContent.getNestJsDockerFileContent(version, application.port, application.env)
         }
         file.writeText(fileContent)
         try {

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCase.kt
@@ -34,9 +34,13 @@ class CreateApplicationUseCase(
 
         val version = application.version
 
-        if (application.applicationType == ApplicationType.SPRING_BOOT) {
+        val applicationType = application.applicationType
+        if (applicationType == ApplicationType.SPRING_BOOT) {
             cloneApplicationByUrlService.cloneByApplication(application)
             modifyGradleService.modifyGradleByApplication(application)
+        }
+        else if (applicationType == ApplicationType.NEST_JS) {
+            cloneApplicationByUrlService.cloneByApplication(application)
         }
 
         createDockerFileService.createFileToApplication(application, version)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
@@ -35,9 +35,13 @@ class DeployApplicationUseCase(
         val version = application.version
         val externalPort = application.externalPort
 
-        if (application.applicationType == ApplicationType.SPRING_BOOT) {
+        val applicationType = application.applicationType
+        if (applicationType == ApplicationType.SPRING_BOOT) {
             cloneApplicationByUrlService.cloneByApplication(application)
             modifyGradleService.modifyGradleByApplication(application)
+        }
+        else if (applicationType == ApplicationType.NEST_JS) {
+            cloneApplicationByUrlService.cloneByApplication(application)
         }
 
         createDockerFileService.createFileToApplication(application, version)


### PR DESCRIPTION
## 🔖 개요
* nest 애플리케이션 타입을 추가합니다.

## 📜 작업내용
* Nest 애플리케이션 Enum 타입 추가
* Nest 도커파일 내용 추가
* CreateDockerFileService에서 Nest 도커파일을 생성하는 로직 추가
* Nest 애플리케이션을 배포할때 clone 하도록 수정 

## 🎸 기타
* 일단 이번 pr에선 타입 추가에 관련된 부분만 추가하고, 배포가 가능한지 확인후 로직 수정