### PR TITLE
🔀 :: 231 - DockerRunService의 네이밍 변경

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/RunContainerService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/RunContainerService.kt
@@ -6,6 +6,4 @@ interface RunContainerService {
     fun runApplication(id: String)
 
     fun runApplication(application: Application)
-
-
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/RunContainerService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/RunContainerService.kt
@@ -2,7 +2,7 @@ package com.dcd.server.core.domain.application.service
 
 import com.dcd.server.core.domain.application.model.Application
 
-interface DockerRunService {
+interface RunContainerService {
     fun runApplication(id: String)
 
     fun runApplication(application: Application)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/RunContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/RunContainerServiceImpl.kt
@@ -1,9 +1,7 @@
 package com.dcd.server.core.domain.application.service.impl
 
 import com.dcd.server.core.common.command.CommandPort
-import com.dcd.server.core.domain.application.exception.ApplicationEnvNotFoundException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
-import com.dcd.server.core.domain.application.exception.ContainerNotCreatedException
 import com.dcd.server.core.domain.application.exception.ContainerNotRunException
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.service.RunContainerService

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/RunContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/RunContainerServiceImpl.kt
@@ -6,16 +6,15 @@ import com.dcd.server.core.domain.application.exception.ApplicationNotFoundExcep
 import com.dcd.server.core.domain.application.exception.ContainerNotCreatedException
 import com.dcd.server.core.domain.application.exception.ContainerNotRunException
 import com.dcd.server.core.domain.application.model.Application
-import com.dcd.server.core.domain.application.model.enums.ApplicationType
-import com.dcd.server.core.domain.application.service.DockerRunService
+import com.dcd.server.core.domain.application.service.RunContainerService
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import org.springframework.stereotype.Service
 
 @Service
-class DockerRunServiceImpl(
+class RunContainerServiceImpl(
     private val queryApplicationPort: QueryApplicationPort,
     private val commandPort: CommandPort
-) : DockerRunService {
+) : RunContainerService {
     override fun runApplication(id: String) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCase.kt
@@ -10,7 +10,7 @@ import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 
 @UseCase
 class RunApplicationUseCase(
-    private val dockerRunService: DockerRunService,
+    private val runContainerService: RunContainerService,
     private val queryApplicationPort: QueryApplicationPort,
     private val changeApplicationStatusService: ChangeApplicationStatusService
 ) {
@@ -22,7 +22,7 @@ class RunApplicationUseCase(
         if (application.status == ApplicationStatus.RUNNING)
             throw AlreadyRunningException()
 
-        dockerRunService.runApplication(application)
+        runContainerService.runApplication(application)
 
         changeApplicationStatusService.changeApplicationStatus(application, ApplicationStatus.RUNNING)
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/DockerRunServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/DockerRunServiceImplTest.kt
@@ -1,10 +1,7 @@
 package com.dcd.server.core.domain.application.service
 
 import com.dcd.server.core.common.command.CommandPort
-import com.dcd.server.core.domain.application.model.Application
-import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
-import com.dcd.server.core.domain.application.model.enums.ApplicationType
-import com.dcd.server.core.domain.application.service.impl.DockerRunServiceImpl
+import com.dcd.server.core.domain.application.service.impl.RunContainerServiceImpl
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.every
@@ -16,7 +13,7 @@ import java.util.*
 class DockerRunServiceImplTest : BehaviorSpec({
     val commandPort = mockk<CommandPort>(relaxed = true)
     val queryApplicationPort = mockk<QueryApplicationPort>()
-    val service = DockerRunServiceImpl(queryApplicationPort, commandPort)
+    val service = RunContainerServiceImpl(queryApplicationPort, commandPort)
 
     given("애플리케이션id가 주어지고") {
         val appId = UUID.randomUUID().toString()

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCaseTest.kt
@@ -1,16 +1,13 @@
 package com.dcd.server.core.domain.application.usecase
 
-import com.dcd.server.core.domain.application.dto.response.RunApplicationResDto
 import com.dcd.server.core.domain.application.exception.AlreadyRunningException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.*
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
-import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
-import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -19,11 +16,11 @@ import util.user.UserGenerator
 import util.workspace.WorkspaceGenerator
 
 class RunApplicationUseCaseTest : BehaviorSpec({
-    val dockerRunService = mockk<DockerRunService>(relaxUnitFun = true)
+    val runContainerService = mockk<RunContainerService>(relaxUnitFun = true)
     val queryApplicationPort = mockk<QueryApplicationPort>(relaxUnitFun = true)
     val changeApplicationStatusService = mockk<ChangeApplicationStatusService>(relaxUnitFun = true)
     val runApplicationUseCase = RunApplicationUseCase(
-        dockerRunService,
+        runContainerService,
         queryApplicationPort,
         changeApplicationStatusService
     )
@@ -67,7 +64,7 @@ class RunApplicationUseCaseTest : BehaviorSpec({
 
             runApplicationUseCase.execute(application.id)
             then("dockerRunService만 실행되어야함") {
-                verify { dockerRunService.runApplication(application) }
+                verify { runContainerService.runApplication(application) }
             }
         }
 
@@ -89,7 +86,7 @@ class RunApplicationUseCaseTest : BehaviorSpec({
 
             runApplicationUseCase.execute(application.id)
             then("dockerRunService만 실행되어야함") {
-                verify { dockerRunService.runApplication(application) }
+                verify { runContainerService.runApplication(application) }
             }
         }
 


### PR DESCRIPTION
## 🔖 개요
* 코드의 일관성을 위해 DockerRunService의 네이밍을 변경합니다.

## 📜 작업내용
* DockerRunService의 네이밍을 RunContainerService로 수정
* DockerRunService의 interface 메서드 아래 공백 제거
* DokcerRunServiceImpl의 네이밍을 RunContainerServiceImpl로 수정
* DockerRunSerivceImpl에서 사용되지 않는 임포트 제거
* DockerRunService 타입의 변수 네이밍 변경