### PR TITLE
🔀 :: 233 - 워크스페이스를 조회할때 애플리케이션 정보의 일부만 제공하도록 리펙토링

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/extenstion/ApplicationDtoExtension.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/extenstion/ApplicationDtoExtension.kt
@@ -5,6 +5,7 @@ import com.dcd.server.core.domain.application.dto.response.ApplicationProfileRes
 import com.dcd.server.core.domain.application.dto.response.ApplicationResDto
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
+import com.dcd.server.core.domain.workspace.dto.response.WorkspaceApplicationResDto
 import com.dcd.server.core.domain.workspace.model.Workspace
 
 fun CreateApplicationReqDto.toEntity(workspace: Workspace, externalPort: Int): Application =
@@ -40,4 +41,15 @@ fun Application.toProfileDto(): ApplicationProfileResDto =
         id = this.id,
         name = this.name,
         description = this.description
+    )
+
+fun Application.toWorkspaceDto(): WorkspaceApplicationResDto =
+    WorkspaceApplicationResDto(
+        id = this.id,
+        name = this.name,
+        description = this.description,
+        applicationType = this.applicationType,
+        port = this.port,
+        externalPort = this.externalPort,
+        status = this.status
     )

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/dto/extension/WorkspaceDtoExtension.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/dto/extension/WorkspaceDtoExtension.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.core.domain.workspace.dto.extension
 
 import com.dcd.server.core.domain.application.dto.extenstion.toDto
+import com.dcd.server.core.domain.application.dto.extenstion.toWorkspaceDto
 import com.dcd.server.core.domain.application.dto.response.ApplicationProfileResDto
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.user.dto.extension.toDto
@@ -16,7 +17,7 @@ fun Workspace.toDto(applicationList: List<Application>): WorkspaceResDto =
         title = this.title,
         description = this.description,
         owner = this.owner.toDto(),
-        applicationList = applicationList.map { it.toDto() }
+        applicationList = applicationList.map { it.toWorkspaceDto() }
     )
 
 fun CreateWorkspaceReqDto.toEntity(user: User): Workspace =

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/dto/response/WorkspaceApplicationResDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/dto/response/WorkspaceApplicationResDto.kt
@@ -1,0 +1,14 @@
+package com.dcd.server.core.domain.workspace.dto.response
+
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
+import com.dcd.server.core.domain.application.model.enums.ApplicationType
+
+data class WorkspaceApplicationResDto(
+    val id: String,
+    val name: String,
+    val description: String?,
+    val applicationType: ApplicationType,
+    val port: Int,
+    val externalPort: Int,
+    val status: ApplicationStatus
+)

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/dto/response/WorkspaceResDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/dto/response/WorkspaceResDto.kt
@@ -1,12 +1,11 @@
 package com.dcd.server.core.domain.workspace.dto.response
 
-import com.dcd.server.core.domain.application.dto.response.ApplicationResDto
 import com.dcd.server.core.domain.user.dto.response.UserResDto
 
 data class WorkspaceResDto(
     val id: String,
     val title: String,
     val description: String,
-    val applicationList: List<ApplicationResDto>,
+    val applicationList: List<WorkspaceApplicationResDto>,
     val owner: UserResDto
 )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationResponseDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationResponseDataExtension.kt
@@ -1,7 +1,10 @@
 package com.dcd.server.presentation.domain.application.data.exetension
 
+import com.dcd.server.core.domain.application.dto.extenstion.toWorkspaceDto
 import com.dcd.server.core.domain.application.dto.response.*
+import com.dcd.server.core.domain.workspace.dto.response.WorkspaceApplicationResDto
 import com.dcd.server.presentation.domain.application.data.response.*
+import com.dcd.server.presentation.domain.workspace.data.response.WorkspaceApplicationResponse
 
 fun ApplicationResDto.toResponse(): ApplicationResponse =
     ApplicationResponse(
@@ -37,4 +40,15 @@ fun AvailableVersionResDto.toResponse(): AvailableVersionResponse =
 fun ApplicationLogResDto.toResponse(): ApplicationLogResponse =
     ApplicationLogResponse(
         logs = this.logs
+    )
+
+fun WorkspaceApplicationResDto.toResponse(): WorkspaceApplicationResponse =
+    WorkspaceApplicationResponse(
+        id = this.id,
+        name = this.name,
+        description = this.description,
+        applicationType = this.applicationType,
+        port = this.port,
+        externalPort = this.externalPort,
+        status = this.status
     )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/workspace/data/response/WorkspaceApplicationResponse.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/workspace/data/response/WorkspaceApplicationResponse.kt
@@ -1,0 +1,14 @@
+package com.dcd.server.presentation.domain.workspace.data.response
+
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
+import com.dcd.server.core.domain.application.model.enums.ApplicationType
+
+data class WorkspaceApplicationResponse(
+    val id: String,
+    val name: String,
+    val description: String?,
+    val applicationType: ApplicationType,
+    val port: Int,
+    val externalPort: Int,
+    val status: ApplicationStatus
+)

--- a/src/main/kotlin/com/dcd/server/presentation/domain/workspace/data/response/WorkspaceResponse.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/workspace/data/response/WorkspaceResponse.kt
@@ -7,6 +7,6 @@ data class WorkspaceResponse(
     val id: String,
     val title: String,
     val description: String,
-    val applicationList: List<ApplicationResponse>,
+    val applicationList: List<WorkspaceApplicationResponse>,
     val owner: UserResponse
 )


### PR DESCRIPTION
## 🔖 개요
* 워크스페이스를 조회할때 애플리케이션 정보의 일부만 제공하도록 리펙토링

## 📜 작업내용
* WorkspaceApplicationResDto 추가
* Application 도메인에 toWorkspaceDto 확장 함수 추가
* WorkspaceResDto에서 WorkspaceApplicationResDto를 사용하도록 수정
* Workspace 도메인의 toDto 메서드에서 toWorkspaceDto를 호출하도록 변경