### PR TITLE
🔀 :: 236 - AOP 어노테이션 분리

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/aop/OwnerValidateAspect.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/aop/OwnerValidateAspect.kt
@@ -21,7 +21,7 @@ class OwnerValidateAspect(
     @Pointcut("@annotation(com.dcd.server.core.common.annotation.ApplicationOwnerVerification)")
     fun applicationOwnerVerificationPointcut() {}
 
-    @Pointcut("@annotation(com.dcd.server.core.common.annotation.WorkspaceOwnerVerification)")
+    @Pointcut("@annotation(com.dcd.server.core.common.aop.annotation.WorkspaceOwnerVerification)")
     fun workspaceOwnerVerificationPointcut() {}
 
     @Before("applicationOwnerVerificationPointcut() && args(id, ..)")

--- a/src/main/kotlin/com/dcd/server/core/common/aop/OwnerValidateAspect.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/aop/OwnerValidateAspect.kt
@@ -18,7 +18,7 @@ class OwnerValidateAspect(
     private val queryWorkspacePort: QueryWorkspacePort,
     private val queryApplicationPort: QueryApplicationPort
 ) {
-    @Pointcut("@annotation(com.dcd.server.core.common.annotation.ApplicationOwnerVerification)")
+    @Pointcut("@annotation(com.dcd.server.core.common.aop.annotation.ApplicationOwnerVerification)")
     fun applicationOwnerVerificationPointcut() {}
 
     @Pointcut("@annotation(com.dcd.server.core.common.aop.annotation.WorkspaceOwnerVerification)")

--- a/src/main/kotlin/com/dcd/server/core/common/aop/annotation/ApplicationOwnerVerification.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/aop/annotation/ApplicationOwnerVerification.kt
@@ -1,4 +1,4 @@
-package com.dcd.server.core.common.annotation
+package com.dcd.server.core.common.aop.annotation
 
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.FUNCTION)

--- a/src/main/kotlin/com/dcd/server/core/common/aop/annotation/WorkspaceOwnerVerification.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/aop/annotation/WorkspaceOwnerVerification.kt
@@ -1,4 +1,4 @@
-package com.dcd.server.core.common.annotation
+package com.dcd.server.core.common.aop.annotation
 
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.FUNCTION)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/AddApplicationEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/AddApplicationEnvUseCase.kt
@@ -1,7 +1,7 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
-import com.dcd.server.core.common.annotation.ApplicationOwnerVerification
+import com.dcd.server.core.common.aop.annotation.ApplicationOwnerVerification
 import com.dcd.server.core.domain.application.dto.request.AddApplicationEnvReqDto
 import com.dcd.server.core.domain.application.exception.AlreadyExistsEnvException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCase.kt
@@ -1,7 +1,7 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
-import com.dcd.server.core.common.annotation.WorkspaceOwnerVerification
+import com.dcd.server.core.common.aop.annotation.WorkspaceOwnerVerification
 import com.dcd.server.core.domain.application.dto.extenstion.toEntity
 import com.dcd.server.core.domain.application.dto.request.CreateApplicationReqDto
 import com.dcd.server.core.domain.application.model.enums.ApplicationType

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationEnvUseCase.kt
@@ -1,7 +1,7 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
-import com.dcd.server.core.common.annotation.ApplicationOwnerVerification
+import com.dcd.server.core.common.aop.annotation.ApplicationOwnerVerification
 import com.dcd.server.core.domain.application.exception.ApplicationEnvNotFoundException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationUseCase.kt
@@ -1,7 +1,7 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
-import com.dcd.server.core.common.annotation.ApplicationOwnerVerification
+import com.dcd.server.core.common.aop.annotation.ApplicationOwnerVerification
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.exception.CanNotDeleteApplicationException
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
@@ -1,7 +1,7 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
-import com.dcd.server.core.common.annotation.ApplicationOwnerVerification
+import com.dcd.server.core.common.aop.annotation.ApplicationOwnerVerification
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.exception.CanNotDeployApplicationException
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GenerateSSLCertificateUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GenerateSSLCertificateUseCase.kt
@@ -1,7 +1,7 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
-import com.dcd.server.core.common.annotation.ApplicationOwnerVerification
+import com.dcd.server.core.common.aop.annotation.ApplicationOwnerVerification
 import com.dcd.server.core.domain.application.dto.request.GenerateSSLCertificateReqDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.service.GenerateSSLCertificateService

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCase.kt
@@ -1,7 +1,7 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.ReadOnlyUseCase
-import com.dcd.server.core.common.annotation.WorkspaceOwnerVerification
+import com.dcd.server.core.common.aop.annotation.WorkspaceOwnerVerification
 import com.dcd.server.core.domain.application.dto.extenstion.toDto
 import com.dcd.server.core.domain.application.dto.response.ApplicationListResDto
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCase.kt
@@ -1,7 +1,7 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.ReadOnlyUseCase
-import com.dcd.server.core.common.annotation.ApplicationOwnerVerification
+import com.dcd.server.core.common.aop.annotation.ApplicationOwnerVerification
 import com.dcd.server.core.domain.application.dto.response.ApplicationLogResDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.service.GetContainerLogService

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCase.kt
@@ -1,7 +1,7 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.ReadOnlyUseCase
-import com.dcd.server.core.common.annotation.ApplicationOwnerVerification
+import com.dcd.server.core.common.aop.annotation.ApplicationOwnerVerification
 import com.dcd.server.core.domain.application.dto.extenstion.toDto
 import com.dcd.server.core.domain.application.dto.response.ApplicationResDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCase.kt
@@ -1,7 +1,7 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
-import com.dcd.server.core.common.annotation.ApplicationOwnerVerification
+import com.dcd.server.core.common.aop.annotation.ApplicationOwnerVerification
 import com.dcd.server.core.domain.application.exception.AlreadyRunningException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCase.kt
@@ -1,7 +1,7 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
-import com.dcd.server.core.common.annotation.ApplicationOwnerVerification
+import com.dcd.server.core.common.aop.annotation.ApplicationOwnerVerification
 import com.dcd.server.core.domain.application.exception.AlreadyStoppedException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationEnvUseCase.kt
@@ -1,6 +1,6 @@
 package com.dcd.server.core.domain.application.usecase
 
-import com.dcd.server.core.common.annotation.ApplicationOwnerVerification
+import com.dcd.server.core.common.aop.annotation.ApplicationOwnerVerification
 import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.domain.application.dto.request.UpdateApplicationEnvReqDto
 import com.dcd.server.core.domain.application.exception.ApplicationEnvNotFoundException

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCase.kt
@@ -1,7 +1,7 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
-import com.dcd.server.core.common.annotation.ApplicationOwnerVerification
+import com.dcd.server.core.common.aop.annotation.ApplicationOwnerVerification
 import com.dcd.server.core.domain.application.dto.request.UpdateApplicationReqDto
 import com.dcd.server.core.domain.application.exception.AlreadyRunningException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException


### PR DESCRIPTION
## 🔖 개요
* 일반 어노테이션과 AOP 어노테이션을 분리합니다.

## 📜 작업내용
* aop 디렉토리 하위에 anntation 디렉토리 추가
* WorkspaceOwnerVerification 어노테이션을 aop/anntation 디렉토리로 이동
* WorkspaceOwnerVerification 어노테이션이 이동된 경로를 import에 반영
* ApplicationOwnerVerification 어노테이션을 aop/annotation 디렉토리로 이동
* ApplicationOwnerVerficiation 어노테이션이 이동된 경로를 import에 반영