### PR TITLE
🔀 :: 238 - CustomEntryPoint, CustomAccessDeniedHandler 리펙토링

### DIFF
--- a/src/main/kotlin/com/dcd/server/infrastructure/global/security/CustomAccessDeniedHandler.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/security/CustomAccessDeniedHandler.kt
@@ -1,19 +1,29 @@
 package com.dcd.server.infrastructure.global.security
 
-import com.dcd.server.infrastructure.global.security.exception.InvalidRoleException
+import com.dcd.server.core.common.error.ErrorCode
+import com.dcd.server.infrastructure.global.error.response.ErrorResponse
+import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.MediaType
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.web.access.AccessDeniedHandler
 import org.springframework.stereotype.Component
 
 @Component
-class CustomAccessDeniedHandler : AccessDeniedHandler {
+class CustomAccessDeniedHandler(
+    private val objectMapper: ObjectMapper
+) : AccessDeniedHandler {
     override fun handle(
-        request: HttpServletRequest?,
-        response: HttpServletResponse?,
+        request: HttpServletRequest,
+        response: HttpServletResponse,
         accessDeniedException: AccessDeniedException?
     ) {
-        throw InvalidRoleException()
+        val errorCode = ErrorCode.INVALID_ROLE
+        val result = objectMapper.writeValueAsString(ErrorResponse(errorCode))
+        response.characterEncoding = Charsets.UTF_8.name()
+        response.status = errorCode.code
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        response.writer.write(result)
     }
 }

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/security/CustomAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/security/CustomAuthenticationEntryPoint.kt
@@ -23,12 +23,11 @@ class CustomAuthenticationEntryPoint(
         response: HttpServletResponse,
         authException: AuthenticationException
     ) {
-        log.error("==========Access Denied==========")
         val errorCode = ErrorCode.FORBIDDEN
-        val responseString = objectMapper.writeValueAsString(ErrorResponse(errorCode.code, errorCode.msg))
-        response.characterEncoding = "UTF-8"
+        val result = objectMapper.writeValueAsString(ErrorResponse(errorCode))
+        response.characterEncoding = Charsets.UTF_8.name()
         response.status = errorCode.code
         response.contentType = MediaType.APPLICATION_JSON_VALUE
-        response.writer.write(responseString)
+        response.writer.write(result)
     }
 }


### PR DESCRIPTION
## 🔖 개요
* 리펙토링해서 예외처리에서 휴먼에러를 없애고 핸들러에서 직접 응답을 작성하도록 수정

## 📜 작업내용
* CustomAccessDeniedHandler에서 예외를 발생시키지 않고, 핸들러에서 응답을 작성하도록 수정
* CustomAuthenticationEntryPoint에서 Charsets를 사용해서 인코딩 설정할때 휴먼에러가 발생하지 않도록 수정