### PR TITLE
🔀 :: [#248] - 컨테이너에서 로그를 가져오지 못하는 버그 수정

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetContainerLogServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetContainerLogServiceImpl.kt
@@ -9,7 +9,7 @@ import java.io.InputStreamReader
 @Service
 class GetContainerLogServiceImpl : GetContainerLogService {
     override fun getLogs(application: Application): List<String> {
-        val cmd = arrayOf("/bin/sh", "-c", "docker logs ${application.name}")
+        val cmd = arrayOf("/bin/sh", "-c", "docker logs ${application.name.lowercase()}")
         val p = Runtime.getRuntime().exec(cmd)
         val br = BufferedReader(InputStreamReader(p.inputStream))
         val result = br.readLines()


### PR DESCRIPTION
## 🔖 개요
* 컨테이너에서 로그를 가져올 수 있게 수정

## 📜 작업내용
* 로그를 가져오는 애플리케이션 이름을 컨테이너 이름으로 수정해서 명령을 실행하도록 수정