### PR TITLE
🔀 :: [#250] - ApplicationOwnerVerification 제거

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/aop/OwnerValidateAspect.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/aop/OwnerValidateAspect.kt
@@ -1,7 +1,5 @@
 package com.dcd.server.core.common.aop
 
-import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
-import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.user.service.GetCurrentUserService
 import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
 import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameException
@@ -15,26 +13,10 @@ import org.springframework.stereotype.Component
 @Component
 class OwnerValidateAspect(
     private val getCurrentUserService: GetCurrentUserService,
-    private val queryWorkspacePort: QueryWorkspacePort,
-    private val queryApplicationPort: QueryApplicationPort
+    private val queryWorkspacePort: QueryWorkspacePort
 ) {
-    @Pointcut("@annotation(com.dcd.server.core.common.aop.annotation.ApplicationOwnerVerification)")
-    fun applicationOwnerVerificationPointcut() {}
-
     @Pointcut("@annotation(com.dcd.server.core.common.aop.annotation.WorkspaceOwnerVerification)")
     fun workspaceOwnerVerificationPointcut() {}
-
-    @Before("applicationOwnerVerificationPointcut() && args(id, ..)")
-    fun validApplicationOwner(id: String) {
-        val user = getCurrentUserService.getCurrentUser()
-
-        val application = (queryApplicationPort.findById(id)
-            ?: throw ApplicationNotFoundException())
-
-        val owner = application.workspace.owner
-        if (owner.id != user.id)
-            throw WorkspaceOwnerNotSameException()
-    }
 
     @Before("workspaceOwnerVerificationPointcut() && args(id, ..)")
     fun validWorkspaceOwner(id: String) {

--- a/src/main/kotlin/com/dcd/server/core/common/aop/annotation/ApplicationOwnerVerification.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/aop/annotation/ApplicationOwnerVerification.kt
@@ -1,5 +1,0 @@
-package com.dcd.server.core.common.aop.annotation
-
-@Retention(AnnotationRetention.RUNTIME)
-@Target(AnnotationTarget.FUNCTION)
-annotation class ApplicationOwnerVerification()

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/AddApplicationEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/AddApplicationEnvUseCase.kt
@@ -1,7 +1,6 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
-import com.dcd.server.core.common.aop.annotation.ApplicationOwnerVerification
 import com.dcd.server.core.domain.application.dto.request.AddApplicationEnvReqDto
 import com.dcd.server.core.domain.application.exception.AlreadyExistsEnvException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
@@ -13,7 +12,6 @@ class AddApplicationEnvUseCase(
     private val queryApplicationPort: QueryApplicationPort,
     private val commandApplicationPort: CommandApplicationPort
 ) {
-    @ApplicationOwnerVerification
     fun execute(id: String, addApplicationEnvReqDto: AddApplicationEnvReqDto) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationEnvUseCase.kt
@@ -1,7 +1,6 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
-import com.dcd.server.core.common.aop.annotation.ApplicationOwnerVerification
 import com.dcd.server.core.domain.application.exception.ApplicationEnvNotFoundException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
@@ -12,7 +11,6 @@ class DeleteApplicationEnvUseCase(
     private val queryApplicationPort: QueryApplicationPort,
     private val commandApplicationPort: CommandApplicationPort
 ) {
-    @ApplicationOwnerVerification
     fun execute(id: String, key: String) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationUseCase.kt
@@ -1,7 +1,6 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
-import com.dcd.server.core.common.aop.annotation.ApplicationOwnerVerification
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.exception.CanNotDeleteApplicationException
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
@@ -17,7 +16,6 @@ class DeleteApplicationUseCase(
     private val deleteContainerService: DeleteContainerService,
     private val deleteImageService: DeleteImageService
 ) {
-    @ApplicationOwnerVerification
     fun execute(id: String) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
@@ -1,7 +1,6 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
-import com.dcd.server.core.common.aop.annotation.ApplicationOwnerVerification
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.exception.CanNotDeployApplicationException
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
@@ -21,7 +20,6 @@ class DeployApplicationUseCase(
     private val createContainerService: CreateContainerService,
     private val deleteApplicationDirectoryService: DeleteApplicationDirectoryService
 ) {
-    @ApplicationOwnerVerification
     fun execute(id: String) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GenerateSSLCertificateUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GenerateSSLCertificateUseCase.kt
@@ -1,7 +1,6 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
-import com.dcd.server.core.common.aop.annotation.ApplicationOwnerVerification
 import com.dcd.server.core.domain.application.dto.request.GenerateSSLCertificateReqDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.service.GenerateSSLCertificateService
@@ -19,7 +18,6 @@ class GenerateSSLCertificateUseCase(
     private val putSSLCertificateService: PutSSLCertificateService,
     private val getExternalPortService: GetExternalPortService
 ) {
-    @ApplicationOwnerVerification
     fun execute(id: String, generateSSLCertificateReqDto: GenerateSSLCertificateReqDto) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCase.kt
@@ -1,7 +1,6 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.ReadOnlyUseCase
-import com.dcd.server.core.common.aop.annotation.ApplicationOwnerVerification
 import com.dcd.server.core.domain.application.dto.response.ApplicationLogResDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.service.GetContainerLogService
@@ -12,7 +11,6 @@ class GetApplicationLogUseCase(
     private val getContainerLogService: GetContainerLogService,
     private val queryApplicationPort: QueryApplicationPort
 ) {
-    @ApplicationOwnerVerification
     fun execute(id: String): ApplicationLogResDto {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCase.kt
@@ -1,7 +1,6 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.ReadOnlyUseCase
-import com.dcd.server.core.common.aop.annotation.ApplicationOwnerVerification
 import com.dcd.server.core.domain.application.dto.extenstion.toDto
 import com.dcd.server.core.domain.application.dto.response.ApplicationResDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
@@ -11,7 +10,6 @@ import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 class GetOneApplicationUseCase(
     private val queryApplicationPort: QueryApplicationPort
 ) {
-    @ApplicationOwnerVerification
     fun execute(id: String): ApplicationResDto {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCase.kt
@@ -1,7 +1,6 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
-import com.dcd.server.core.common.aop.annotation.ApplicationOwnerVerification
 import com.dcd.server.core.domain.application.exception.AlreadyRunningException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
@@ -14,7 +13,6 @@ class RunApplicationUseCase(
     private val queryApplicationPort: QueryApplicationPort,
     private val changeApplicationStatusService: ChangeApplicationStatusService
 ) {
-    @ApplicationOwnerVerification
     fun execute(id: String) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCase.kt
@@ -1,7 +1,6 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
-import com.dcd.server.core.common.aop.annotation.ApplicationOwnerVerification
 import com.dcd.server.core.domain.application.exception.AlreadyStoppedException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
@@ -15,7 +14,6 @@ class StopApplicationUseCase(
     private val stopContainerService: StopContainerService,
     private val changeApplicationStatusService: ChangeApplicationStatusService
 ) {
-    @ApplicationOwnerVerification
     fun execute(id: String) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationEnvUseCase.kt
@@ -1,6 +1,5 @@
 package com.dcd.server.core.domain.application.usecase
 
-import com.dcd.server.core.common.aop.annotation.ApplicationOwnerVerification
 import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.domain.application.dto.request.UpdateApplicationEnvReqDto
 import com.dcd.server.core.domain.application.exception.ApplicationEnvNotFoundException
@@ -13,7 +12,6 @@ class UpdateApplicationEnvUseCase(
     private val queryApplicationPort: QueryApplicationPort,
     private val commandApplicationPort: CommandApplicationPort
 ) {
-    @ApplicationOwnerVerification
     fun execute(applicationId: String, envKey: String, updateApplicationEnvReqDto: UpdateApplicationEnvReqDto) {
         val application = (queryApplicationPort.findById(applicationId)
             ?: throw ApplicationNotFoundException())

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCase.kt
@@ -1,7 +1,6 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
-import com.dcd.server.core.common.aop.annotation.ApplicationOwnerVerification
 import com.dcd.server.core.domain.application.dto.request.UpdateApplicationReqDto
 import com.dcd.server.core.domain.application.exception.AlreadyRunningException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
@@ -14,7 +13,6 @@ class UpdateApplicationUseCase(
     private val queryApplicationPort: QueryApplicationPort,
     private val commandApplicationPort: CommandApplicationPort,
 ) {
-    @ApplicationOwnerVerification
     fun execute(id: String, updateApplicationReqDto: UpdateApplicationReqDto) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
@@ -39,16 +39,16 @@ class ApplicationWebAdapter(
         createApplicationUseCase.execute(workspaceId, createApplicationRequest.toDto())
             .run { ResponseEntity(HttpStatus.CREATED) }
 
-    @PostMapping("/{id}/run")
+    @PostMapping("/{applicationId}/run")
     @WorkspaceOwnerVerification
-    fun runApplication(@PathVariable workspaceId: String, @PathVariable id: String): ResponseEntity<Void> =
-        runApplicationUseCase.execute(id)
+    fun runApplication(@PathVariable workspaceId: String, @PathVariable applicationId: String): ResponseEntity<Void> =
+        runApplicationUseCase.execute(applicationId)
             .run { ResponseEntity.ok().build() }
 
-    @PostMapping("/{id}/deploy")
+    @PostMapping("/{applicationId}/deploy")
     @WorkspaceOwnerVerification
-    fun deployApplication(@PathVariable workspaceId: String, @PathVariable id: String): ResponseEntity<Void> =
-        deployApplicationUseCase.execute(id)
+    fun deployApplication(@PathVariable workspaceId: String, @PathVariable applicationId: String): ResponseEntity<Void> =
+        deployApplicationUseCase.execute(applicationId)
             .run { ResponseEntity.ok().build() }
 
     @GetMapping
@@ -57,30 +57,30 @@ class ApplicationWebAdapter(
         getAllApplicationUseCase.execute(workspaceId)
             .let { ResponseEntity.ok(it.toResponse()) }
 
-    @GetMapping("/{id}")
+    @GetMapping("/{applicationId}")
     @WorkspaceOwnerVerification
-    fun getOneApplication(@PathVariable workspaceId: String, @PathVariable id: String): ResponseEntity<ApplicationResponse> =
-        getOneApplicationUseCase.execute(id)
+    fun getOneApplication(@PathVariable workspaceId: String, @PathVariable applicationId: String): ResponseEntity<ApplicationResponse> =
+        getOneApplicationUseCase.execute(applicationId)
             .let { ResponseEntity.ok(it.toResponse()) }
 
-    @PostMapping("/{id}/env")
+    @PostMapping("/{applicationId}/env")
     @WorkspaceOwnerVerification
     fun addApplicationEnv(
         @PathVariable workspaceId: String,
-        @PathVariable id: String,
+        @PathVariable applicationId: String,
         @RequestBody addApplicationEnvRequest: AddApplicationEnvRequest
     ): ResponseEntity<Void> =
-        addApplicationEnvUseCase.execute(id, addApplicationEnvRequest.toDto())
+        addApplicationEnvUseCase.execute(applicationId, addApplicationEnvRequest.toDto())
             .run { ResponseEntity.ok().build() }
 
-    @DeleteMapping("/{id}/env")
+    @DeleteMapping("/{applicationId}/env")
     @WorkspaceOwnerVerification
     fun deleteApplicationEnv(
         @PathVariable workspaceId: String,
-        @PathVariable id: String,
+        @PathVariable applicationId: String,
         @RequestParam key: String
     ): ResponseEntity<Void> =
-        deleteApplicationEnvUseCase.execute(id, key)
+        deleteApplicationEnvUseCase.execute(applicationId, key)
             .run { ResponseEntity.ok().build() }
 
     @PatchMapping("/{applicationId}/env/{key}")
@@ -94,26 +94,26 @@ class ApplicationWebAdapter(
         updateApplicationEnvUseCase.execute(applicationId, key, updateApplicationEnvRequest.toDto())
             .run { ResponseEntity.ok().build() }
 
-    @PostMapping("/{id}/stop")
+    @PostMapping("/{applicationId}/stop")
     @WorkspaceOwnerVerification
-    fun stopApplication(@PathVariable workspaceId: String, @PathVariable id: String): ResponseEntity<Void> =
-        stopApplicationUseCase.execute(id)
+    fun stopApplication(@PathVariable workspaceId: String, @PathVariable applicationId: String): ResponseEntity<Void> =
+        stopApplicationUseCase.execute(applicationId)
             .run { ResponseEntity.ok().build() }
 
-    @DeleteMapping("/{id}")
+    @DeleteMapping("/{applicationId}")
     @WorkspaceOwnerVerification
-    fun deleteApplication(@PathVariable workspaceId: String, @PathVariable id: String): ResponseEntity<Void> =
-        deleteApplicationUseCase.execute(id)
+    fun deleteApplication(@PathVariable workspaceId: String, @PathVariable applicationId: String): ResponseEntity<Void> =
+        deleteApplicationUseCase.execute(applicationId)
             .run { ResponseEntity.ok().build() }
 
-    @PatchMapping("/{id}")
+    @PatchMapping("/{applicationId}")
     @WorkspaceOwnerVerification
     fun updateApplication(
         @PathVariable workspaceId: String,
-        @PathVariable id: String,
+        @PathVariable applicationId: String,
         @RequestBody updateApplicationRequest: UpdateApplicationRequest
     ): ResponseEntity<Void> =
-        updateApplicationUseCase.execute(id, updateApplicationRequest.toDto())
+        updateApplicationUseCase.execute(applicationId, updateApplicationRequest.toDto())
             .run { ResponseEntity.ok().build() }
 
     @GetMapping("/version/{applicationType}")
@@ -122,19 +122,19 @@ class ApplicationWebAdapter(
         getAvailableVersionUseCase.execute(applicationType)
             .let { ResponseEntity.ok(it.toResponse()) }
 
-    @PostMapping("/{id}/certificate")
+    @PostMapping("/{applicationId}/certificate")
     @WorkspaceOwnerVerification
     fun generateSSLCertificate(
         @PathVariable workspaceId: String,
-        @PathVariable id: String,
+        @PathVariable applicationId: String,
         @RequestBody generateSSLCertificateRequest: GenerateSSLCertificateRequest
     ): ResponseEntity<Void> =
-        generateSSLCertificateUseCase.execute(id, generateSSLCertificateRequest.toDto())
+        generateSSLCertificateUseCase.execute(applicationId, generateSSLCertificateRequest.toDto())
             .run { ResponseEntity.ok().build() }
 
-    @GetMapping("/{id}/logs")
+    @GetMapping("/{applicationId}/logs")
     @WorkspaceOwnerVerification
-    fun getApplicationLog(@PathVariable workspaceId: String, @PathVariable id: String): ResponseEntity<ApplicationLogResponse> =
-        getApplicationLogUseCase.execute(id)
+    fun getApplicationLog(@PathVariable workspaceId: String, @PathVariable applicationId: String): ResponseEntity<ApplicationLogResponse> =
+        getApplicationLogUseCase.execute(applicationId)
             .let { ResponseEntity.ok(it.toResponse()) }
 }


### PR DESCRIPTION
## 🔖 개요
* 워크스페이스 아이디를 받아서 소유자 검증하므로, 굳이 애플리케이션 소유자를 검증할 필요가 없음

## 📜 작업내용
* UseCase에 달려있는 ApplicationOwnerVerification 어노테이션 제거
* ApplicationWebAdapter의 path value중 id의 네이밍을 applicationId로 수정
* application 소유자 검증 로직 제거
* ApplicationOwnerVerification 어노테이션 제거