### PR TITLE
🔀 :: [#252] - 리소스 수정에 관련된 API의 메서드 통일

### DIFF
--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
@@ -57,7 +57,7 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.GET, "/{workspaceId}/application").authenticated()
                 it.requestMatchers(HttpMethod.GET, "/{workspaceId}/application/{id}").authenticated()
                 it.requestMatchers(HttpMethod.DELETE, "/{workspaceId}/application/{id}").authenticated()
-                it.requestMatchers(HttpMethod.PATCH, "/{workspaceId}/application/{id}").authenticated()
+                it.requestMatchers(HttpMethod.PUT, "/{workspaceId}/application/{id}").authenticated()
                 it.requestMatchers(HttpMethod.GET, "/{workspaceId}/application/{id}/logs").authenticated()
                 it.requestMatchers(HttpMethod.POST, "/{workspaceId}/application/{id}/certificate").authenticated()
                 it.requestMatchers(HttpMethod.POST, "/{workspaceId}/application/{id}/env").authenticated()

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
@@ -106,7 +106,7 @@ class ApplicationWebAdapter(
         deleteApplicationUseCase.execute(applicationId)
             .run { ResponseEntity.ok().build() }
 
-    @PatchMapping("/{applicationId}")
+    @PutMapping("/{applicationId}")
     @WorkspaceOwnerVerification
     fun updateApplication(
         @PathVariable workspaceId: String,


### PR DESCRIPTION
## 🔖 개요
* 애플리케이션 수정 API의 메서드를 PUT으로 변경합니다.

## 📜 작업내용
* 애플리케이션 수정 API의 메서드 PUT으로 변경
* SecurityConfig의 애플리케이션 수정 API의 메서드를 PUT으로 변경