### PR TITLE
🔀 :: [#256] - 워크스페이스에 적용되는 전역 환경변수 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/model/Workspace.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/model/Workspace.kt
@@ -7,5 +7,6 @@ data class Workspace(
     val id: String = UUID.randomUUID().toString(),
     val title: String,
     val description: String,
+    val globalEnv: Map<String, String>,
     val owner: User
 )

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/model/Workspace.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/model/Workspace.kt
@@ -7,6 +7,6 @@ data class Workspace(
     val id: String = UUID.randomUUID().toString(),
     val title: String,
     val description: String,
-    val globalEnv: Map<String, String>,
+    val globalEnv: Map<String, String> = mapOf(),
     val owner: User
 )

--- a/src/main/kotlin/com/dcd/server/persistence/workspace/adapter/WorkspaceAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/workspace/adapter/WorkspaceAdapter.kt
@@ -10,6 +10,7 @@ fun Workspace.toEntity(): WorkspaceJpaEntity =
         id = this.id,
         title = this.title,
         description = this.description,
+        globalEnv = this.globalEnv,
         owner = this.owner.toEntity()
     )
 
@@ -18,5 +19,6 @@ fun WorkspaceJpaEntity.toDomain(): Workspace =
         id = this.id,
         title = this.title,
         description = this.description,
+        globalEnv = this.globalEnv,
         owner = this.owner.toDomain()
     )

--- a/src/main/kotlin/com/dcd/server/persistence/workspace/entity/WorkspaceJpaEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/workspace/entity/WorkspaceJpaEntity.kt
@@ -1,11 +1,7 @@
 package com.dcd.server.persistence.workspace.entity
 
 import com.dcd.server.persistence.user.entity.UserJpaEntity
-import jakarta.persistence.Entity
-import jakarta.persistence.Id
-import jakarta.persistence.JoinColumn
-import jakarta.persistence.ManyToOne
-import jakarta.persistence.Table
+import jakarta.persistence.*
 import java.util.UUID
 
 @Entity
@@ -15,6 +11,12 @@ class WorkspaceJpaEntity(
     val id: String = UUID.randomUUID().toString(),
     val title: String,
     val description: String,
+    @ElementCollection
+    @CollectionTable(name = "global_env_table",
+        joinColumns = [JoinColumn(name = "workspace_id", referencedColumnName = "id")])
+    @MapKeyColumn(name = "env_key")
+    @Column(name = "env_value")
+    val globalEnv: Map<String, String>,
     @ManyToOne
     @JoinColumn(name = "owner_id")
     val owner: UserJpaEntity


### PR DESCRIPTION
## 개요
* workspace에 있는 모든 애플리케이션에 적용되는 전역 환경변수를 추가합니다.
## 작업내용
* workspace 도메인에 globalEnv 필드 추가
* workspace 엔티티에 globalEnv 필드 추가
* workspaceAdapter에서 globalEnv 필드를 초기화하게 수정