### PR TITLE
🔀 :: [#258] - 애플리케이션 배포시 전역변수 적용

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateDockerFileServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateDockerFileServiceImpl.kt
@@ -37,19 +37,19 @@ class CreateDockerFileServiceImpl(
         val file = File("./$name/Dockerfile")
         val fileContent = when (application.applicationType) {
             ApplicationType.SPRING_BOOT ->
-                FileContent.getSpringBootDockerFileContent(name, version, application.port, application.env)
+                FileContent.getSpringBootDockerFileContent(name, version, application.port, mutableEnv)
 
             ApplicationType.MYSQL ->
-                FileContent.getMYSQLDockerFileContent(version, application.port, application.env)
+                FileContent.getMYSQLDockerFileContent(version, application.port, mutableEnv)
 
             ApplicationType.MARIA_DB ->
-                FileContent.getMARIADBDockerFileContent(version, application.port, application.env)
+                FileContent.getMARIADBDockerFileContent(version, application.port, mutableEnv)
 
             ApplicationType.REDIS ->
-                FileContent.getRedisDockerFileContent(version, application.port, application.env)
+                FileContent.getRedisDockerFileContent(version, application.port, mutableEnv)
 
             ApplicationType.NEST_JS ->
-                FileContent.getNestJsDockerFileContent(version, application.port, application.env)
+                FileContent.getNestJsDockerFileContent(version, application.port, mutableEnv)
         }
         file.writeText(fileContent)
         try {

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateDockerFileServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateDockerFileServiceImpl.kt
@@ -29,6 +29,8 @@ class CreateDockerFileServiceImpl(
 
     private fun createFile(application: Application, version: String) {
         val name = application.name
+        val mutableEnv = application.env.toMutableMap()
+        mutableEnv.putAll(application.workspace.globalEnv)
 
         commandPort.executeShellCommand("mkdir $name")
 


### PR DESCRIPTION
## 개요
* 애플리케이션을 배포할때 전역변수를 적용해서 배포하도록 수정합니다.
## 작업내용
* CreateDockerFileServiceImpl의 create 메서드에서 애플리케이션 환경변수에 전역 환경변수를 추가하는 변수 추가
* 각 도커파일을 생성할때 mutableEnv로 호출하도록 변경