### PR TITLE
🔀 :: [#269] - 워크스페이스  조회시 전역 환경변수도 조회되도록 수정

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/dto/extension/WorkspaceDtoExtension.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/dto/extension/WorkspaceDtoExtension.kt
@@ -18,7 +18,8 @@ fun Workspace.toDto(applicationList: List<Application>): WorkspaceResDto =
         title = this.title,
         description = this.description,
         owner = this.owner.toDto(),
-        applicationList = applicationList.map { it.toWorkspaceDto() }
+        applicationList = applicationList.map { it.toWorkspaceDto() },
+        globalEnv = this.globalEnv
     )
 
 fun CreateWorkspaceReqDto.toEntity(user: User): Workspace =

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/dto/extension/WorkspaceDtoExtension.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/dto/extension/WorkspaceDtoExtension.kt
@@ -9,6 +9,7 @@ import com.dcd.server.core.domain.user.model.User
 import com.dcd.server.core.domain.workspace.dto.request.CreateWorkspaceReqDto
 import com.dcd.server.core.domain.workspace.dto.response.WorkspaceProfileResDto
 import com.dcd.server.core.domain.workspace.dto.response.WorkspaceResDto
+import com.dcd.server.core.domain.workspace.dto.response.WorkspaceSimpleResDto
 import com.dcd.server.core.domain.workspace.model.Workspace
 
 fun Workspace.toDto(applicationList: List<Application>): WorkspaceResDto =
@@ -32,4 +33,11 @@ fun Workspace.toProfileDto(applicationList: List<ApplicationProfileResDto>): Wor
         id = this.id,
         title = this.title,
         applicationList = applicationList
+    )
+
+fun Workspace.toSimpleDto(): WorkspaceSimpleResDto =
+    WorkspaceSimpleResDto(
+        id = this.id,
+        title = this.title,
+        description = this.description
     )

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/dto/extension/WorkspaceDtoExtension.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/dto/extension/WorkspaceDtoExtension.kt
@@ -35,9 +35,10 @@ fun Workspace.toProfileDto(applicationList: List<ApplicationProfileResDto>): Wor
         applicationList = applicationList
     )
 
-fun Workspace.toSimpleDto(): WorkspaceSimpleResDto =
+fun Workspace.toSimpleDto(applicationList: List<Application>): WorkspaceSimpleResDto =
     WorkspaceSimpleResDto(
         id = this.id,
         title = this.title,
-        description = this.description
+        description = this.description,
+        applicationList = applicationList.map { it.toWorkspaceDto() }
     )

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/dto/response/WorkspaceListResDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/dto/response/WorkspaceListResDto.kt
@@ -1,5 +1,5 @@
 package com.dcd.server.core.domain.workspace.dto.response
 
 data class WorkspaceListResDto(
-    val list: List<WorkspaceResDto>
+    val list: List<WorkspaceSimpleResDto>
 )

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/dto/response/WorkspaceResDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/dto/response/WorkspaceResDto.kt
@@ -7,5 +7,6 @@ data class WorkspaceResDto(
     val title: String,
     val description: String,
     val applicationList: List<WorkspaceApplicationResDto>,
+    val globalEnv: Map<String, String>,
     val owner: UserResDto
 )

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/dto/response/WorkspaceSimpleResDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/dto/response/WorkspaceSimpleResDto.kt
@@ -3,5 +3,6 @@ package com.dcd.server.core.domain.workspace.dto.response
 data class WorkspaceSimpleResDto(
     val id: String,
     val title: String,
-    val description: String
+    val description: String,
+    val applicationList: List<WorkspaceApplicationResDto>
 )

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/dto/response/WorkspaceSimpleResDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/dto/response/WorkspaceSimpleResDto.kt
@@ -1,0 +1,7 @@
+package com.dcd.server.core.domain.workspace.dto.response
+
+data class WorkspaceSimpleResDto(
+    val id: String,
+    val title: String,
+    val description: String
+)

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/GetAllWorkspaceUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/GetAllWorkspaceUseCase.kt
@@ -4,6 +4,7 @@ import com.dcd.server.core.common.annotation.ReadOnlyUseCase
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.user.service.GetCurrentUserService
 import com.dcd.server.core.domain.workspace.dto.extension.toDto
+import com.dcd.server.core.domain.workspace.dto.extension.toSimpleDto
 import com.dcd.server.core.domain.workspace.dto.response.WorkspaceListResDto
 import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
 
@@ -17,7 +18,7 @@ class GetAllWorkspaceUseCase(
         val user = getCurrentUserService.getCurrentUser()
         val workspaceDtoList = queryWorkspacePort.findByUser(user).map {
             val applicationList = queryApplicationPort.findAllByWorkspace(it)
-            it.toDto(applicationList)
+            it.toSimpleDto(applicationList)
         }
         return WorkspaceListResDto(workspaceDtoList)
     }

--- a/src/main/kotlin/com/dcd/server/presentation/domain/workspace/data/exetension/WorkspaceResponseDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/workspace/data/exetension/WorkspaceResponseDataExtension.kt
@@ -3,11 +3,13 @@ package com.dcd.server.presentation.domain.workspace.data.exetension
 import com.dcd.server.core.domain.workspace.dto.response.WorkspaceListResDto
 import com.dcd.server.core.domain.workspace.dto.response.WorkspaceProfileResDto
 import com.dcd.server.core.domain.workspace.dto.response.WorkspaceResDto
+import com.dcd.server.core.domain.workspace.dto.response.WorkspaceSimpleResDto
 import com.dcd.server.presentation.domain.application.data.exetension.toResponse
 import com.dcd.server.presentation.domain.user.data.exetension.toResponse
 import com.dcd.server.presentation.domain.workspace.data.response.WorkspaceListResponse
 import com.dcd.server.presentation.domain.workspace.data.response.WorkspaceProfileResponse
 import com.dcd.server.presentation.domain.workspace.data.response.WorkspaceResponse
+import com.dcd.server.presentation.domain.workspace.data.response.WorkspaceSimpleResponse
 
 fun WorkspaceResDto.toResponse(): WorkspaceResponse =
     WorkspaceResponse(
@@ -16,6 +18,13 @@ fun WorkspaceResDto.toResponse(): WorkspaceResponse =
         description = this.description,
         applicationList = this.applicationList.map { it.toResponse() },
         owner = this.owner.toResponse()
+    )
+
+fun WorkspaceSimpleResDto.toResponse(): WorkspaceSimpleResponse =
+    WorkspaceSimpleResponse(
+        id = this.id,
+        title = this.title,
+        description = this.description
     )
 
 fun WorkspaceListResDto.toResponse(): WorkspaceListResponse =

--- a/src/main/kotlin/com/dcd/server/presentation/domain/workspace/data/exetension/WorkspaceResponseDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/workspace/data/exetension/WorkspaceResponseDataExtension.kt
@@ -17,6 +17,7 @@ fun WorkspaceResDto.toResponse(): WorkspaceResponse =
         title = this.title,
         description = this.description,
         applicationList = this.applicationList.map { it.toResponse() },
+        globalEnv = this.globalEnv,
         owner = this.owner.toResponse()
     )
 

--- a/src/main/kotlin/com/dcd/server/presentation/domain/workspace/data/exetension/WorkspaceResponseDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/workspace/data/exetension/WorkspaceResponseDataExtension.kt
@@ -24,7 +24,8 @@ fun WorkspaceSimpleResDto.toResponse(): WorkspaceSimpleResponse =
     WorkspaceSimpleResponse(
         id = this.id,
         title = this.title,
-        description = this.description
+        description = this.description,
+        applicationList = this.applicationList.map { it.toResponse() }
     )
 
 fun WorkspaceListResDto.toResponse(): WorkspaceListResponse =

--- a/src/main/kotlin/com/dcd/server/presentation/domain/workspace/data/response/WorkspaceListResponse.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/workspace/data/response/WorkspaceListResponse.kt
@@ -1,5 +1,5 @@
 package com.dcd.server.presentation.domain.workspace.data.response
 
 data class WorkspaceListResponse(
-    val list: List<WorkspaceResponse>
+    val list: List<WorkspaceSimpleResponse>
 )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/workspace/data/response/WorkspaceResponse.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/workspace/data/response/WorkspaceResponse.kt
@@ -8,5 +8,6 @@ data class WorkspaceResponse(
     val title: String,
     val description: String,
     val applicationList: List<WorkspaceApplicationResponse>,
+    val globalEnv: Map<String, String>,
     val owner: UserResponse
 )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/workspace/data/response/WorkspaceSimpleResponse.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/workspace/data/response/WorkspaceSimpleResponse.kt
@@ -1,0 +1,7 @@
+package com.dcd.server.presentation.domain.workspace.data.response
+
+data class WorkspaceSimpleResponse(
+    val id: String,
+    val title: String,
+    val description: String
+)

--- a/src/main/kotlin/com/dcd/server/presentation/domain/workspace/data/response/WorkspaceSimpleResponse.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/workspace/data/response/WorkspaceSimpleResponse.kt
@@ -3,5 +3,6 @@ package com.dcd.server.presentation.domain.workspace.data.response
 data class WorkspaceSimpleResponse(
     val id: String,
     val title: String,
-    val description: String
+    val description: String,
+    val applicationList: List<WorkspaceApplicationResponse>
 )

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/GetAllWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/GetAllWorkspaceUseCaseTest.kt
@@ -41,13 +41,11 @@ class GetAllWorkspaceUseCaseTest : BehaviorSpec({
                 firstWorkspaceResult.id shouldBe firstWorkspaceId
                 firstWorkspaceResult.title shouldBe firstWorkspace.title
                 firstWorkspaceResult.description shouldBe firstWorkspace.description
-                firstWorkspaceResult.owner shouldBe firstWorkspace.owner.toDto()
                 firstWorkspaceResult.applicationList.isEmpty() shouldBe true
                 val secondWorkspaceResult = result.list[1]
                 secondWorkspaceResult.id shouldBe secondWorkspaceId
                 secondWorkspaceResult.title shouldBe secondWorkspace.title
                 secondWorkspaceResult.description shouldBe secondWorkspace.description
-                secondWorkspaceResult.owner shouldBe secondWorkspace.owner.toDto()
                 secondWorkspaceResult.applicationList.isEmpty() shouldBe true
             }
         }

--- a/src/test/kotlin/com/dcd/server/presentation/domain/workspace/WorkspaceWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/workspace/WorkspaceWebAdapterTest.kt
@@ -62,7 +62,8 @@ class WorkspaceWebAdapterTest : BehaviorSpec({
             title = "testTitle",
             description = "testDescription",
             owner = userResponse,
-            applicationList = listOf()
+            applicationList = listOf(),
+            globalEnv = mapOf()
         )
         `when`("getOneWorkspace 메서드를 실행할때") {
             every { getWorkspaceUseCase.execute(workspaceResDto.id) } returns workspaceResDto


### PR DESCRIPTION
## 개요
* 워크스페이스를 조회시 해당 워크스페이스의 환경변수도 조회되도록 수정합니다.
## 작업내용
* WorkspaceSimpleResDto 추가
* WorkspaceSimpleResponse 추가
* WorkspaceList 응답객체가 WorkspaceSimpleResponse에 의존하도록 수정
* WorkspaceSimple 응답 객체에 applicationList 필드 추가
* 워크스페이스 전체 조회 테스트 코드 수정
* 워크스페이스 응답 객체에 globalEnv필드 추가