### PR TITLE
🔀 :: [#273] - 전역 환경변수 삭제 API의 테스트 코드 작성

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteGlobalEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteGlobalEnvUseCase.kt
@@ -2,6 +2,7 @@ package com.dcd.server.core.domain.workspace.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.domain.user.service.GetCurrentUserService
+import com.dcd.server.core.domain.workspace.exception.GlobalEnvNotFoundException
 import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
 import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameException
 import com.dcd.server.core.domain.workspace.spi.CommandWorkspacePort
@@ -20,6 +21,9 @@ class DeleteGlobalEnvUseCase(
 
         if (workspace.owner.id != currentUser.id)
             throw WorkspaceOwnerNotSameException()
+
+        if (workspace.globalEnv.contains(key).not())
+            throw GlobalEnvNotFoundException()
 
         val updatedGlobalEnv = workspace.globalEnv.toMutableMap()
         updatedGlobalEnv.remove(key)

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/AddGlobalEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/AddGlobalEnvUseCaseTest.kt
@@ -16,7 +16,7 @@ import io.mockk.verify
 import util.user.UserGenerator
 import util.workspace.WorkspaceGenerator
 
-class AddWorkspaceUseCaseTest : BehaviorSpec({
+class AddGlobalEnvUseCaseTest : BehaviorSpec({
     val queryWorkspacePort = mockk<QueryWorkspacePort>(relaxUnitFun = true)
     val getCurrentUserService = mockk<GetCurrentUserService>()
     val commandWorkspacePort = mockk<CommandWorkspacePort>(relaxUnitFun = true)

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteGlobalEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteGlobalEnvUseCaseTest.kt
@@ -66,5 +66,18 @@ class DeleteGlobalEnvUseCaseTest : BehaviorSpec({
                 }
             }
         }
+
+        `when`("해당 워크스페이스의 유저가 로그인된 유저가 아닐때") {
+            val user = UserGenerator.generateUser()
+            val workspace = spyk(WorkspaceGenerator.generateWorkspace(id = workspaceId))
+            every { getCurrentUserService.getCurrentUser() } returns user
+            every { queryWorkspacePort.findById(workspaceId) } returns workspace
+
+            then("WorkspaceOwnerNotSameException이 발생해야함") {
+                shouldThrow<WorkspaceOwnerNotSameException> {
+                    deleteGlobalEnvUseCase.execute(workspaceId, key)
+                }
+            }
+        }
     }
 })

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteGlobalEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteGlobalEnvUseCaseTest.kt
@@ -54,5 +54,17 @@ class DeleteGlobalEnvUseCaseTest : BehaviorSpec({
                 }
             }
         }
+
+        `when`("해당 워크스페이스가 존재하지 않을때") {
+            val user = UserGenerator.generateUser()
+            every { getCurrentUserService.getCurrentUser() } returns user
+            every { queryWorkspacePort.findById(workspaceId) } returns null
+
+            then("WorkspaceNotFoundException이 발생해야함") {
+                shouldThrow<WorkspaceNotFoundException> {
+                    deleteGlobalEnvUseCase.execute(workspaceId, key)
+                }
+            }
+        }
     }
 })

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteGlobalEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteGlobalEnvUseCaseTest.kt
@@ -41,5 +41,18 @@ class DeleteGlobalEnvUseCaseTest : BehaviorSpec({
                 verify { commandWorkspacePort.save(any() as Workspace) }
             }
         }
+
+        `when`("해당 워크스페이스가 존재하고, 해당 환경변수가 존재하지 않을때") {
+            val user = UserGenerator.generateUser()
+            val workspace = spyk(WorkspaceGenerator.generateWorkspace(id = workspaceId, user = user))
+            every { getCurrentUserService.getCurrentUser() } returns user
+            every { queryWorkspacePort.findById(workspaceId) } returns workspace
+
+            then("GlobalEnvNotFoundException이 발생해야함") {
+                shouldThrow<GlobalEnvNotFoundException> {
+                    deleteGlobalEnvUseCase.execute(workspaceId, key)
+                }
+            }
+        }
     }
 })

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteGlobalEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteGlobalEnvUseCaseTest.kt
@@ -1,0 +1,45 @@
+package com.dcd.server.core.domain.workspace.usecase
+
+import com.dcd.server.core.domain.user.service.GetCurrentUserService
+import com.dcd.server.core.domain.workspace.exception.GlobalEnvNotFoundException
+import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
+import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameException
+import com.dcd.server.core.domain.workspace.model.Workspace
+import com.dcd.server.core.domain.workspace.spi.CommandWorkspacePort
+import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import util.user.UserGenerator
+import util.workspace.WorkspaceGenerator
+import java.util.*
+
+class DeleteGlobalEnvUseCaseTest : BehaviorSpec({
+    val queryWorkspacePort = mockk<QueryWorkspacePort>(relaxUnitFun = true)
+    val getCurrentUserService = mockk<GetCurrentUserService>()
+    val commandWorkspacePort = mockk<CommandWorkspacePort>(relaxUnitFun = true)
+    val deleteGlobalEnvUseCase = DeleteGlobalEnvUseCase(queryWorkspacePort, getCurrentUserService, commandWorkspacePort)
+
+    given("workspaceId, 삭제할 환경변수의 키값이 주어지고") {
+        val workspaceId = UUID.randomUUID().toString()
+        val key = "testEnvKey"
+
+        `when`("해당 워크스페이스가 존재하고, 해당 환경변수가 존재할때") {
+            val env = mapOf(key to "testValue")
+            val user = UserGenerator.generateUser()
+            val workspace = spyk(WorkspaceGenerator.generateWorkspace(id = workspaceId, globalEnv = env, user = user))
+            every { getCurrentUserService.getCurrentUser() } returns user
+            every { queryWorkspacePort.findById(workspaceId) } returns workspace
+
+            deleteGlobalEnvUseCase.execute(workspaceId, key)
+
+            then("해당 키가 삭제된 워크스페이스를 저장해야함") {
+                verify { workspace.copy(globalEnv = mapOf()) }
+                verify { commandWorkspacePort.save(any() as Workspace) }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/dcd/server/presentation/domain/workspace/WorkspaceWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/workspace/WorkspaceWebAdapterTest.kt
@@ -116,7 +116,7 @@ class WorkspaceWebAdapterTest : BehaviorSpec({
         }
     }
 
-    given("deleteGlobalEnvRequest가 주어지고") {
+    given("envKey가 주어지고") {
         val workspaceId = UUID.randomUUID().toString()
         val key = "testKey"
 

--- a/src/test/kotlin/com/dcd/server/presentation/domain/workspace/WorkspaceWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/workspace/WorkspaceWebAdapterTest.kt
@@ -115,4 +115,18 @@ class WorkspaceWebAdapterTest : BehaviorSpec({
             }
         }
     }
+
+    given("deleteGlobalEnvRequest가 주어지고") {
+        val workspaceId = UUID.randomUUID().toString()
+        val key = "testKey"
+
+        `when`("deleteGlobalEnv 메서드를 실행할때") {
+            val result = workspaceWebAdapter.deleteGlobalEnv(workspaceId, key)
+
+            then("200 코드가 반환되고, deleteGlobalEnvUseCase를 실행해야함") {
+                result.statusCode shouldBe HttpStatus.OK
+                verify { deleteGlobalEnvUseCase.execute(workspaceId, key) }
+            }
+        }
+    }
 })

--- a/src/test/kotlin/util/workspace/WorkspaceGenerator.kt
+++ b/src/test/kotlin/util/workspace/WorkspaceGenerator.kt
@@ -10,12 +10,14 @@ object WorkspaceGenerator {
         id: String = UUID.randomUUID().toString(),
         title: String = "testTitle",
         description: String = "testDescription",
-        user: User = UserGenerator.generateUser()
+        user: User = UserGenerator.generateUser(),
+        globalEnv: Map<String, String> = mapOf()
     ): Workspace =
         Workspace(
             id = id,
             title = title,
             description = description,
-            owner = user
+            owner = user,
+            globalEnv = globalEnv
         )
 }


### PR DESCRIPTION
## 개요
* 전역 환경변수 삭제 API의 테스트 코드를 작성합니다.
## 작업내용
* deleteGlobalEnv 메서드 테스트 코드 추가
* DeleteGlobalEnvUseCase의 전역 환경변수 삭제 로직 수정
* 전역 환경변수 추가 useCase 테스트 코드 네이밍 수정
* WorkspaceGenerator에서 globalEnv를 받을 수 있도록 수정
* DeleteGlobalEnvUseCase 테스트 코드 추가