### PR TITLE
🔀 :: [#275] - 전역 환경변수 수정 API 테스트 코드 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/UpdateGlobalEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/UpdateGlobalEnvUseCase.kt
@@ -1,20 +1,27 @@
 package com.dcd.server.core.domain.workspace.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.domain.user.service.GetCurrentUserService
 import com.dcd.server.core.domain.workspace.dto.request.UpdateGlobalEnvReqDto
 import com.dcd.server.core.domain.workspace.exception.GlobalEnvNotFoundException
 import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
+import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameException
 import com.dcd.server.core.domain.workspace.spi.CommandWorkspacePort
 import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
 
 @UseCase
 class UpdateGlobalEnvUseCase(
     private val queryWorkspacePort: QueryWorkspacePort,
+    private val getCurrentUserService: GetCurrentUserService,
     private val commandWorkspacePort: CommandWorkspacePort
 ) {
     fun execute(workspaceId: String, envKey: String, updateGlobalEnvReqDto: UpdateGlobalEnvReqDto) {
         val workspace = (queryWorkspacePort.findById(workspaceId)
             ?: throw WorkspaceNotFoundException())
+        val currentUser = getCurrentUserService.getCurrentUser()
+
+        if (workspace.owner.id != currentUser.id)
+            throw WorkspaceOwnerNotSameException()
 
         val mutableEnv = workspace.globalEnv.toMutableMap()
         if (mutableEnv.containsKey(envKey).not())

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/UpdateGlobalEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/UpdateGlobalEnvUseCaseTest.kt
@@ -3,6 +3,7 @@ package com.dcd.server.core.domain.workspace.usecase
 import com.dcd.server.core.domain.user.service.GetCurrentUserService
 import com.dcd.server.core.domain.workspace.dto.request.UpdateGlobalEnvReqDto
 import com.dcd.server.core.domain.workspace.exception.GlobalEnvNotFoundException
+import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameException
 import com.dcd.server.core.domain.workspace.model.Workspace
 import com.dcd.server.core.domain.workspace.spi.CommandWorkspacePort
 import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
@@ -46,8 +47,21 @@ class UpdateGlobalEnvUseCaseTest : BehaviorSpec({
             val workspace = spyk(WorkspaceGenerator.generateWorkspace(id = testWorkspaceId, user = user))
             every { queryWorkspacePort.findById(testWorkspaceId) } returns workspace
 
-            then("해당 env를 수정후 저장해야함") {
+            then("GlobalEnvNotFoundException이 발생해야함") {
                 shouldThrow<GlobalEnvNotFoundException> {
+                    updateGlobalEnvUseCase.execute(testWorkspaceId, envKey, updateGlobalEnvReqDto)
+                }
+            }
+        }
+
+        `when`("워크스페이스 소유자가 일치하지 않을때") {
+            val user = UserGenerator.generateUser()
+            every { getCurrentUserService.getCurrentUser() } returns user
+            val workspace = spyk(WorkspaceGenerator.generateWorkspace(id = testWorkspaceId))
+            every { queryWorkspacePort.findById(testWorkspaceId) } returns workspace
+
+            then("WorkspaceOwnerNotSameException이 발생해야함") {
+                shouldThrow<WorkspaceOwnerNotSameException> {
                     updateGlobalEnvUseCase.execute(testWorkspaceId, envKey, updateGlobalEnvReqDto)
                 }
             }

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/UpdateGlobalEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/UpdateGlobalEnvUseCaseTest.kt
@@ -1,0 +1,41 @@
+package com.dcd.server.core.domain.workspace.usecase
+
+import com.dcd.server.core.domain.user.service.GetCurrentUserService
+import com.dcd.server.core.domain.workspace.dto.request.UpdateGlobalEnvReqDto
+import com.dcd.server.core.domain.workspace.model.Workspace
+import com.dcd.server.core.domain.workspace.spi.CommandWorkspacePort
+import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import util.user.UserGenerator
+import util.workspace.WorkspaceGenerator
+
+class UpdateGlobalEnvUseCaseTest : BehaviorSpec({
+    val queryWorkspacePort = mockk<QueryWorkspacePort>()
+    val getCurrentUserService = mockk<GetCurrentUserService>()
+    val commandWorkspacePort = mockk<CommandWorkspacePort>(relaxUnitFun = true)
+    val updateGlobalEnvUseCase = UpdateGlobalEnvUseCase(queryWorkspacePort, getCurrentUserService, commandWorkspacePort)
+
+    given("workspaceId, envKey, updateGlobalEnvReqDto가 주어지고") {
+        val testWorkspaceId = "testWorkspaceId"
+        val envKey = "testEnvKey"
+        val updateGlobalEnvReqDto = UpdateGlobalEnvReqDto(newValue = "updatedValue")
+
+        `when`("유스케이스가 예외없이 실행할때") {
+            val user = UserGenerator.generateUser()
+            every { getCurrentUserService.getCurrentUser() } returns user
+            val workspace = spyk(WorkspaceGenerator.generateWorkspace(id = testWorkspaceId, user = user, globalEnv = mapOf("testEnvKey" to "dcd")))
+            every { queryWorkspacePort.findById(testWorkspaceId) } returns workspace
+
+            updateGlobalEnvUseCase.execute(testWorkspaceId, envKey, updateGlobalEnvReqDto)
+
+            then("해당 env를 수정후 저장해야함") {
+                verify { workspace.copy(globalEnv = mapOf(envKey to updateGlobalEnvReqDto.newValue)) }
+                verify { commandWorkspacePort.save(any() as Workspace) }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/UpdateGlobalEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/UpdateGlobalEnvUseCaseTest.kt
@@ -3,6 +3,7 @@ package com.dcd.server.core.domain.workspace.usecase
 import com.dcd.server.core.domain.user.service.GetCurrentUserService
 import com.dcd.server.core.domain.workspace.dto.request.UpdateGlobalEnvReqDto
 import com.dcd.server.core.domain.workspace.exception.GlobalEnvNotFoundException
+import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
 import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameException
 import com.dcd.server.core.domain.workspace.model.Workspace
 import com.dcd.server.core.domain.workspace.spi.CommandWorkspacePort
@@ -62,6 +63,16 @@ class UpdateGlobalEnvUseCaseTest : BehaviorSpec({
 
             then("WorkspaceOwnerNotSameException이 발생해야함") {
                 shouldThrow<WorkspaceOwnerNotSameException> {
+                    updateGlobalEnvUseCase.execute(testWorkspaceId, envKey, updateGlobalEnvReqDto)
+                }
+            }
+        }
+
+        `when`("워크스페이스가 존재하지 않을때") {
+            every { queryWorkspacePort.findById(testWorkspaceId) } returns null
+
+            then("WorkspaceOwnerNotSameException이 발생해야함") {
+                shouldThrow<WorkspaceNotFoundException> {
                     updateGlobalEnvUseCase.execute(testWorkspaceId, envKey, updateGlobalEnvReqDto)
                 }
             }

--- a/src/test/kotlin/com/dcd/server/presentation/domain/workspace/WorkspaceWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/workspace/WorkspaceWebAdapterTest.kt
@@ -3,18 +3,22 @@ package com.dcd.server.presentation.domain.workspace
 import com.dcd.server.core.domain.user.dto.response.UserResDto
 import com.dcd.server.core.domain.workspace.dto.request.AddGlobalEnvReqDto
 import com.dcd.server.core.domain.workspace.dto.request.CreateWorkspaceReqDto
+import com.dcd.server.core.domain.workspace.dto.request.UpdateGlobalEnvReqDto
 import com.dcd.server.core.domain.workspace.dto.request.UpdateWorkspaceReqDto
 import com.dcd.server.core.domain.workspace.dto.response.WorkspaceListResDto
 import com.dcd.server.core.domain.workspace.dto.response.WorkspaceResDto
 import com.dcd.server.core.domain.workspace.usecase.*
+import com.dcd.server.presentation.domain.workspace.data.exetension.toDto
 import com.dcd.server.presentation.domain.workspace.data.exetension.toResponse
 import com.dcd.server.presentation.domain.workspace.data.request.AddGlobalEnvRequest
 import com.dcd.server.presentation.domain.workspace.data.request.CreateWorkspaceRequest
+import com.dcd.server.presentation.domain.workspace.data.request.UpdateGlobalEnvRequest
 import com.dcd.server.presentation.domain.workspace.data.request.UpdateWorkspaceRequest
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.spyk
 import io.mockk.verify
 import org.springframework.http.HttpStatus
 import java.util.*
@@ -126,6 +130,22 @@ class WorkspaceWebAdapterTest : BehaviorSpec({
             then("200 코드가 반환되고, deleteGlobalEnvUseCase를 실행해야함") {
                 result.statusCode shouldBe HttpStatus.OK
                 verify { deleteGlobalEnvUseCase.execute(workspaceId, key) }
+            }
+        }
+    }
+
+    given("envKey, UpdateGlobalEnvRequest가 주어지고") {
+        val workspaceId = UUID.randomUUID().toString()
+        val key = "testKey"
+        val updateGlobalEnvRequest = spyk(UpdateGlobalEnvRequest("testValue"))
+
+        `when`("updateGlobalEnv 메서드를 실행할때") {
+            val result = workspaceWebAdapter.updateGlobalEnv(workspaceId, key, updateGlobalEnvRequest)
+
+            then("200이 반환되고, updateGlobalEnvUseCase를 실행해야함") {
+                result.statusCode shouldBe HttpStatus.OK
+                verify { updateGlobalEnvRequest.toDto() }
+                verify { updateGlobalEnvUseCase.execute(workspaceId, key, any() as UpdateGlobalEnvReqDto) }
             }
         }
     }


### PR DESCRIPTION
## 개요
* 전역 환경변수 수정 API 테스트 코드 추가
## 작업내용
* 전역변수 수정 webAdapter 테스트 코드 추가
* 전역 환경변수 수정시 유저를 검증하는 로직 추가
* 예외없이 useCase가 실행되는 테스트 코드 추가
* 해당 env가 존재하지 않는 테스트 코드 추가
* 워크스페이스 소유자가 일치하지 않는 테스트 코드 추가
* 워크스페이스가 존재하지 않는 테스트 코드 추가