### PR TITLE
🔀 :: [#279] - 유저 상태 필드 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/auth/dto/extension/AuthDtoExtension.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/dto/extension/AuthDtoExtension.kt
@@ -2,6 +2,7 @@ package com.dcd.server.core.domain.auth.dto.extension
 
 import com.dcd.server.core.domain.auth.dto.request.SignUpReqDto
 import com.dcd.server.core.domain.auth.model.Role
+import com.dcd.server.core.domain.user.model.Status
 import com.dcd.server.core.domain.user.model.User
 
 fun SignUpReqDto.toEntity(encodedPassword: String): User =
@@ -9,5 +10,6 @@ fun SignUpReqDto.toEntity(encodedPassword: String): User =
         email = this.email,
         password = encodedPassword,
         name = this.name,
-        roles = mutableListOf(Role.ROLE_USER)
+        roles = mutableListOf(Role.ROLE_USER),
+        status = Status.PENDING
     )

--- a/src/main/kotlin/com/dcd/server/core/domain/user/model/Status.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/user/model/Status.kt
@@ -1,0 +1,6 @@
+package com.dcd.server.core.domain.user.model
+
+enum class Status {
+    PENDING,
+    CREATED
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/user/model/User.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/user/model/User.kt
@@ -8,5 +8,6 @@ data class User(
     val email: String,
     val password: String,
     val name: String,
-    val roles: MutableList<Role>
+    val roles: MutableList<Role>,
+    val status: Status
 )

--- a/src/main/kotlin/com/dcd/server/persistence/user/adapter/UserAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/user/adapter/UserAdapter.kt
@@ -9,7 +9,8 @@ fun User.toEntity(): UserJpaEntity =
         email = this.email,
         name = this.name,
         password = this.password,
-        roles = this.roles
+        roles = this.roles,
+        status = this.status
     )
 
 fun UserJpaEntity.toDomain(): User =
@@ -18,5 +19,6 @@ fun UserJpaEntity.toDomain(): User =
         email = this.email,
         name = this.name,
         password = this.password,
-        roles = this.roles
+        roles = this.roles,
+        status = this.status
     )

--- a/src/main/kotlin/com/dcd/server/persistence/user/entity/UserJpaEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/user/entity/UserJpaEntity.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.persistence.user.entity
 
 import com.dcd.server.core.domain.auth.model.Role
+import com.dcd.server.core.domain.user.model.Status
 import jakarta.persistence.*
 import java.util.*
 
@@ -15,5 +16,6 @@ class UserJpaEntity(
     @Enumerated(EnumType.STRING)
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "Role", joinColumns = [JoinColumn(name = "user_id")])
-    val roles: MutableList<Role>
+    val roles: MutableList<Role>,
+    val status: Status,
 )

--- a/src/main/kotlin/com/dcd/server/persistence/user/entity/UserJpaEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/user/entity/UserJpaEntity.kt
@@ -17,5 +17,6 @@ class UserJpaEntity(
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "Role", joinColumns = [JoinColumn(name = "user_id")])
     val roles: MutableList<Role>,
+    @Enumerated(EnumType.STRING)
     val status: Status,
 )

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/service/ValidateWorkspaceOwnerServiceTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/service/ValidateWorkspaceOwnerServiceTest.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.core.domain.workspace.service
 
 import com.dcd.server.core.domain.auth.model.Role
+import com.dcd.server.core.domain.user.model.Status
 import com.dcd.server.core.domain.user.model.User
 import com.dcd.server.core.domain.user.service.GetCurrentUserService
 import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameException
@@ -29,7 +30,7 @@ class ValidateWorkspaceOwnerServiceTest : BehaviorSpec({
         }
         `when`("현재 인증된 유저가 workspace의 주인이 아닐때") {
             val another =
-                User(email = "another", password = "password", name = "another user", roles = mutableListOf(Role.ROLE_USER))
+                User(email = "another", password = "password", name = "another user", roles = mutableListOf(Role.ROLE_USER), status = Status.CREATED)
             then("WorkspaceOwnerNotSameException이 발생해야함") {
                 shouldThrow<WorkspaceOwnerNotSameException> {
                     service.validateOwner(another, workspace)

--- a/src/test/kotlin/com/dcd/server/persistence/application/ApplicationPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/persistence/application/ApplicationPersistenceAdapterTest.kt
@@ -4,6 +4,7 @@ import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.auth.model.Role
+import com.dcd.server.core.domain.user.model.Status
 import com.dcd.server.core.domain.user.model.User
 import com.dcd.server.core.domain.workspace.model.Workspace
 import com.dcd.server.persistence.application.adapter.toEntity
@@ -25,7 +26,8 @@ class ApplicationPersistenceAdapterTest : BehaviorSpec({
             email = "testEmail",
             password = "testPassword",
             name = "testName",
-            roles = mutableListOf(Role.ROLE_USER)
+            roles = mutableListOf(Role.ROLE_USER),
+            status = Status.CREATED
         )
         val workspace = Workspace(
             UUID.randomUUID().toString(),

--- a/src/test/kotlin/com/dcd/server/persistence/user/UserPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/persistence/user/UserPersistenceAdapterTest.kt
@@ -1,5 +1,7 @@
 package com.dcd.server.persistence.user
 
+import com.dcd.server.core.domain.auth.model.Role
+import com.dcd.server.core.domain.user.model.Status
 import com.dcd.server.core.domain.user.model.User
 import com.dcd.server.persistence.user.adapter.toEntity
 import com.dcd.server.persistence.user.repository.UserRepository
@@ -19,7 +21,7 @@ class UserPersistenceAdapterTest : BehaviorSpec({
         val testEmail = "test"
         val testPassword = "test123!@#"
         val testName = "test"
-        val user = User(id = testUserId, email = testEmail, password = testPassword, name = testName, roles = mutableListOf())
+        val user = User(email = "another", password = "password", name = "another user", roles = mutableListOf(Role.ROLE_USER), status = Status.CREATED)
 
         `when`("save 메서드를 사용할때") {
             every { userRepository.save(any()) } answers { callOriginal() }

--- a/src/test/kotlin/com/dcd/server/persistence/workspace/WorkspacePersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/persistence/workspace/WorkspacePersistenceAdapterTest.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.persistence.workspace
 
 import com.dcd.server.core.domain.auth.model.Role
+import com.dcd.server.core.domain.user.model.Status
 import com.dcd.server.core.domain.user.model.User
 import com.dcd.server.core.domain.workspace.model.Workspace
 import com.dcd.server.persistence.user.adapter.toEntity
@@ -25,7 +26,8 @@ class WorkspacePersistenceAdapterTest : BehaviorSpec({
             email = "testEmail",
             password = "testPassword",
             name = "testName",
-            roles = mutableListOf(Role.ROLE_USER)
+            roles = mutableListOf(Role.ROLE_USER),
+            status = Status.CREATED
         )
 
         val workspace = Workspace(

--- a/src/test/kotlin/com/dcd/server/presentation/domain/user/UserWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/user/UserWebAdapterTest.kt
@@ -3,6 +3,7 @@ package com.dcd.server.presentation.domain.user
 import com.dcd.server.core.domain.auth.model.Role
 import com.dcd.server.core.domain.user.dto.extension.toDto
 import com.dcd.server.core.domain.user.dto.response.UserProfileResDto
+import com.dcd.server.core.domain.user.model.Status
 import com.dcd.server.core.domain.user.model.User
 import com.dcd.server.core.domain.user.usecase.ChangePasswordUseCase
 import com.dcd.server.core.domain.user.usecase.GetUserProfileUseCase
@@ -22,7 +23,7 @@ class UserWebAdapterTest : BehaviorSpec({
 
     given("UserProfileResDto가 주어지고") {
         val user =
-            User(email = "email", password = "password", name = "testName", roles = mutableListOf(Role.ROLE_USER))
+            User(email = "another", password = "password", name = "another user", roles = mutableListOf(Role.ROLE_USER), status = Status.CREATED)
         val userProfileResDto = UserProfileResDto(user = user.toDto(), workspaces = listOf())
 
         `when`("getProfile 메서드를 실행할때") {

--- a/src/test/kotlin/util/user/UserGenerator.kt
+++ b/src/test/kotlin/util/user/UserGenerator.kt
@@ -1,6 +1,7 @@
 package util.user
 
 import com.dcd.server.core.domain.auth.model.Role
+import com.dcd.server.core.domain.user.model.Status
 import com.dcd.server.core.domain.user.model.User
 
 object UserGenerator {
@@ -14,6 +15,7 @@ object UserGenerator {
             email = email,
             password = password,
             name = name,
-            roles = roles
+            roles = roles,
+            status = Status.CREATED
         )
 }


### PR DESCRIPTION
## 개요
* 유저 엔티티에 상태 필드 추가
## 작업내용
* Status enum 클래스 추가
* User 도매인에 status 필드 추가
* User 엔티티에 status 필드 추가
* UserAdapter에서 status 필드를 초기화하는 부분 추가
* User 엔티티의 status 필드에 Enumerated 어노테이션 추가