### PR TITLE
🔀 :: [#281] - 유저 승인 API 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/user/usecase/ChangeUserStatusUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/user/usecase/ChangeUserStatusUseCase.kt
@@ -1,0 +1,21 @@
+package com.dcd.server.core.domain.user.usecase
+
+import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.domain.auth.exception.UserNotFoundException
+import com.dcd.server.core.domain.user.model.Status
+import com.dcd.server.core.domain.user.spi.CommandUserPort
+import com.dcd.server.core.domain.user.spi.QueryUserPort
+
+@UseCase
+class ChangeUserStatusUseCase(
+    private val queryUserPort: QueryUserPort,
+    private val commandUserPort: CommandUserPort,
+) {
+    fun execute(userId: String, status: Status) {
+        val user = (queryUserPort.findById(userId)
+            ?: throw UserNotFoundException())
+
+        val updatedUser = user.copy(status = status)
+        commandUserPort.save(updatedUser)
+    }
+}

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
@@ -77,6 +77,7 @@ class SecurityConfig(
                 //user
                 it.requestMatchers(HttpMethod.GET, "/user/profile").authenticated()
                 it.requestMatchers(HttpMethod.PATCH, "/user/password").authenticated()
+                it.requestMatchers(HttpMethod.PATCH, "/user/{userId}/status").hasRole("ADMIN")
 
                 //when url not set
                 it.anyRequest().denyAll()

--- a/src/main/kotlin/com/dcd/server/presentation/domain/user/UserWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/user/UserWebAdapter.kt
@@ -1,6 +1,8 @@
 package com.dcd.server.presentation.domain.user
 
+import com.dcd.server.core.domain.user.model.Status
 import com.dcd.server.core.domain.user.usecase.ChangePasswordUseCase
+import com.dcd.server.core.domain.user.usecase.ChangeUserStatusUseCase
 import com.dcd.server.core.domain.user.usecase.GetUserProfileUseCase
 import com.dcd.server.presentation.domain.user.data.exetension.toDto
 import com.dcd.server.presentation.domain.user.data.exetension.toResponse
@@ -9,15 +11,18 @@ import com.dcd.server.presentation.domain.user.data.response.UserProfileResponse
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/user")
 class UserWebAdapter(
     private val getUserProfileUseCase: GetUserProfileUseCase,
-    private val changePasswordUseCase: ChangePasswordUseCase
+    private val changePasswordUseCase: ChangePasswordUseCase,
+    private val changeUserStatusUseCase: ChangeUserStatusUseCase
 ) {
     @GetMapping("/profile")
     fun getUserProfile(): ResponseEntity<UserProfileResponse> =
@@ -27,5 +32,10 @@ class UserWebAdapter(
     @PatchMapping("/password")
     fun changePassword(@RequestBody passwordChangeRequest: PasswordChangeRequest): ResponseEntity<Void> =
         changePasswordUseCase.execute(passwordChangeRequest.toDto())
+            .run { ResponseEntity.ok().build() }
+
+    @PatchMapping("/{userId}/status")
+    fun updateStatus(@PathVariable userId: String, @RequestParam status: Status): ResponseEntity<Void> =
+        changeUserStatusUseCase.execute(userId, status)
             .run { ResponseEntity.ok().build() }
 }

--- a/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangeUserStatusUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangeUserStatusUseCaseTest.kt
@@ -32,5 +32,15 @@ class ChangeUserStatusUseCaseTest : BehaviorSpec({
                 verify { commandUserPort.save(user.copy(status = status)) }
             }
         }
+
+        `when`("해당 userId를 가진 유저가 없을때") {
+            every { queryUserPort.findById(userId) } returns null
+
+            then("UserNotFoundException이 발생해야함") {
+                shouldThrow<UserNotFoundException> {
+                    changeUserStatusUseCase.execute(userId, status)
+                }
+            }
+        }
     }
 })

--- a/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangeUserStatusUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangeUserStatusUseCaseTest.kt
@@ -1,0 +1,36 @@
+package com.dcd.server.core.domain.user.usecase
+
+import com.dcd.server.core.domain.auth.exception.UserNotFoundException
+import com.dcd.server.core.domain.user.model.Status
+import com.dcd.server.core.domain.user.spi.CommandUserPort
+import com.dcd.server.core.domain.user.spi.QueryUserPort
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import util.user.UserGenerator
+
+class ChangeUserStatusUseCaseTest : BehaviorSpec({
+    val queryUserPort = mockk<QueryUserPort>()
+    val commandUserPort = mockk<CommandUserPort>(relaxUnitFun = true)
+    val changeUserStatusUseCase = ChangeUserStatusUseCase(queryUserPort, commandUserPort)
+
+    given("userId, 변경할 status가 주어지고") {
+        val userId = "testUserId"
+        val status = Status.CREATED
+
+        `when`("해당 유저가 존재할때") {
+            val user = UserGenerator.generateUser()
+
+            every { queryUserPort.findById(userId) } returns user
+
+            changeUserStatusUseCase.execute(userId, status)
+
+            then("user가 수정되고 저장됐는지 검사") {
+                verify { queryUserPort.findById(userId) }
+                verify { commandUserPort.save(user.copy(status = status)) }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/dcd/server/presentation/domain/user/UserWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/user/UserWebAdapterTest.kt
@@ -6,6 +6,7 @@ import com.dcd.server.core.domain.user.dto.response.UserProfileResDto
 import com.dcd.server.core.domain.user.model.Status
 import com.dcd.server.core.domain.user.model.User
 import com.dcd.server.core.domain.user.usecase.ChangePasswordUseCase
+import com.dcd.server.core.domain.user.usecase.ChangeUserStatusUseCase
 import com.dcd.server.core.domain.user.usecase.GetUserProfileUseCase
 import com.dcd.server.presentation.domain.user.data.exetension.toResponse
 import com.dcd.server.presentation.domain.user.data.request.PasswordChangeRequest
@@ -18,8 +19,9 @@ import org.springframework.http.HttpStatus
 class UserWebAdapterTest : BehaviorSpec({
     val getUserProfileUseCase = mockk<GetUserProfileUseCase>()
     val changePasswordUseCase = mockk<ChangePasswordUseCase>(relaxUnitFun = true)
+    val changeUserStatusUseCase = mockk<ChangeUserStatusUseCase>(relaxUnitFun = true)
 
-    val userWebAdapter = UserWebAdapter(getUserProfileUseCase, changePasswordUseCase)
+    val userWebAdapter = UserWebAdapter(getUserProfileUseCase, changePasswordUseCase, changeUserStatusUseCase)
 
     given("UserProfileResDto가 주어지고") {
         val user =

--- a/src/test/kotlin/com/dcd/server/presentation/domain/user/UserWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/user/UserWebAdapterTest.kt
@@ -55,4 +55,17 @@ class UserWebAdapterTest : BehaviorSpec({
             }
         }
     }
+
+    given("UserId, Status가 주어지고") {
+        val userId = "testUserId"
+        val status = Status.CREATED
+
+        `when`("updateStatus 메서드를 실행할때") {
+            val response = userWebAdapter.updateStatus(userId, status)
+
+            then("응답코드는 200이여야함") {
+                response.statusCode shouldBe HttpStatus.OK
+            }
+        }
+    }
 })


### PR DESCRIPTION
## 개요
* 유저 승인 API를 추가합니다.
## 작업내용
* ChangeUserStatusUseCase 추가
* 유저 상태 수정 엔드포인트 추가
* 유저 상태 수정 엔드포인트에 권한 설정 추가
* 유저 웹어뎁터 테스트 코드에 updateStatus 메서드 테스트 코드 추가
* 유저 상태 수정 테스트 케이스 추가
* 유저가 존재하지 않는 테스트 케이스 추가