### PR TITLE
🔀 :: [#283] - 유저 조회시 유저 상태도 조회되도록 수정

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/user/dto/extension/UserDtoExtension.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/user/dto/extension/UserDtoExtension.kt
@@ -9,7 +9,8 @@ fun User.toDto(): UserResDto =
     UserResDto(
         id =  this.id,
         email = this.email,
-        name = this.name
+        name = this.name,
+        status = this.status
     )
 
 fun UserResDto.toProfileDto(workspaceList: List<WorkspaceProfileResDto>): UserProfileResDto =

--- a/src/main/kotlin/com/dcd/server/core/domain/user/dto/response/UserResDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/user/dto/response/UserResDto.kt
@@ -1,7 +1,10 @@
 package com.dcd.server.core.domain.user.dto.response
 
+import com.dcd.server.core.domain.user.model.Status
+
 data class UserResDto(
     val id: String,
     val email: String,
-    val name: String
+    val name: String,
+    val status: Status
 )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/user/data/exetension/UserResponseDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/user/data/exetension/UserResponseDataExtension.kt
@@ -10,7 +10,8 @@ fun UserResDto.toResponse(): UserResponse =
     UserResponse(
         id = this.id,
         email = this.email,
-        name = this.name
+        name = this.name,
+        status = this.status
     )
 
 fun UserProfileResDto.toResponse(): UserProfileResponse =

--- a/src/main/kotlin/com/dcd/server/presentation/domain/user/data/response/UserResponse.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/user/data/response/UserResponse.kt
@@ -1,7 +1,10 @@
 package com.dcd.server.presentation.domain.user.data.response
 
+import com.dcd.server.core.domain.user.model.Status
+
 data class UserResponse(
     val id: String,
     val email: String,
-    val name: String
+    val name: String,
+    val status: Status
 )

--- a/src/test/kotlin/com/dcd/server/presentation/domain/workspace/WorkspaceWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/workspace/WorkspaceWebAdapterTest.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.presentation.domain.workspace
 
 import com.dcd.server.core.domain.user.dto.response.UserResDto
+import com.dcd.server.core.domain.user.model.Status
 import com.dcd.server.core.domain.workspace.dto.request.AddGlobalEnvReqDto
 import com.dcd.server.core.domain.workspace.dto.request.CreateWorkspaceReqDto
 import com.dcd.server.core.domain.workspace.dto.request.UpdateGlobalEnvReqDto
@@ -61,7 +62,8 @@ class WorkspaceWebAdapterTest : BehaviorSpec({
         val userResponse = UserResDto(
             id = UUID.randomUUID().toString(),
             email = "testEmail",
-            name = "test"
+            name = "test",
+            status = Status.CREATED
         )
         val workspaceResDto = WorkspaceResDto(
             id = UUID.randomUUID().toString(),


### PR DESCRIPTION
## 개요
* 유저 조회시 유저 상태도 조회되도록 수정합니다.
## 작업내용
* UserResDto에 status 필드 추가
* UserResponse에 status 필드 추가
* UserResDto의 확장함수 toResponse에 status 필드를 초기화하는 코드 추가
* User의 확장함수 toResDto에 status 필드를 초기화하는 코드 추가
* UserResDto를 사용하는 테스트 코드에서 UserResDto 수정