### PR TITLE
🔀 :: [#292] - 서비스 객체의 인터페이스, 구현체 분리

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/service/CreateNetworkService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/service/CreateNetworkService.kt
@@ -1,13 +1,5 @@
 package com.dcd.server.core.domain.workspace.service
 
-import com.dcd.server.core.common.command.CommandPort
-import org.springframework.stereotype.Service
-
-@Service
-class CreateNetworkService(
-    private val commandPort: CommandPort
-) {
-    fun createNetwork(networkTitle: String) {
-        commandPort.executeShellCommand("docker network create --driver bridge ${networkTitle.replace(' ', '_')}")
-    }
+interface CreateNetworkService {
+    fun createNetwork(networkTitle: String)
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/service/impl/CreateNetworkServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/service/impl/CreateNetworkServiceImpl.kt
@@ -1,0 +1,14 @@
+package com.dcd.server.core.domain.workspace.service.impl
+
+import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.domain.workspace.service.CreateNetworkService
+import org.springframework.stereotype.Service
+
+@Service
+class CreateNetworkServiceImpl(
+    private val commandPort: CommandPort
+) : CreateNetworkService {
+    override fun createNetwork(networkTitle: String) {
+        commandPort.executeShellCommand("docker network create --driver bridge ${networkTitle.replace(' ', '_')}")
+    }
+}

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/service/CreateNetworkServiceTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/service/CreateNetworkServiceTest.kt
@@ -1,0 +1,25 @@
+package com.dcd.server.core.domain.workspace.service
+
+import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.domain.workspace.service.impl.CreateNetworkServiceImpl
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.mockk
+import io.mockk.verify
+
+class CreateNetworkServiceTest : BehaviorSpec({
+    val commandPort = mockk<CommandPort>(relaxed = true)
+    val createNetworkService = CreateNetworkServiceImpl(commandPort)
+
+    given("생성할 네트워크 제목을 주어지고") {
+        val testNetworkTitle = "test network"
+
+        `when`("createNetwork 메서드를 실행할때") {
+            createNetworkService.createNetwork(testNetworkTitle)
+
+            then("cmd를 실행해야함") {
+                val cmd = "docker network create --driver bridge test_network"
+                verify { commandPort.executeShellCommand(cmd) }
+            }
+        }
+    }
+})


### PR DESCRIPTION
## 개요
* 서비스 객체의 인터페이스, 구현체 분리
## 작업내용
* CreateNetworkService를 인터페이스로 수정
* CreateNetworkSerivce의 구현체 추가
* CreateNetworkService 테스트 코드 추가