### PR TITLE
🔀 :: [#296] - 유저 검증로직 수정

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GenerateSSLCertificateUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GenerateSSLCertificateUseCase.kt
@@ -22,7 +22,7 @@ class GenerateSSLCertificateUseCase(
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
         val currentUser = getCurrentUserService.getCurrentUser()
-        if (currentUser.equals(application.workspace.owner).not())
+        if (currentUser.id != application.workspace.owner.id)
             throw WorkspaceOwnerNotSameException()
         val domain = generateSSLCertificateReqDto.domain
         val externalPort = getExternalPortService.getExternalPort(application.port)

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/service/impl/ValidateWorkspaceOwnerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/service/impl/ValidateWorkspaceOwnerServiceImpl.kt
@@ -12,13 +12,13 @@ class ValidateWorkspaceOwnerServiceImpl(
     private val getCurrentUserService: GetCurrentUserService
 ) : ValidateWorkspaceOwnerService{
     override fun validateOwner(user: User, workspace: Workspace) {
-        if (user.equals(workspace.owner).not())
+        if (user.id != workspace.owner.id)
             throw WorkspaceOwnerNotSameException()
     }
 
     override fun validateOwner(workspace: Workspace) {
         val user = getCurrentUserService.getCurrentUser()
-        if (user.equals(workspace.owner).not())
+        if (user.id != workspace.owner.id)
             throw WorkspaceOwnerNotSameException()
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/UpdateWorkspaceUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/UpdateWorkspaceUseCase.kt
@@ -19,7 +19,7 @@ class UpdateWorkspaceUseCase(
             ?: throw WorkspaceNotFoundException())
         val currentUser = getCurrentUserService.getCurrentUser()
 
-        if (workspace.owner.equals(currentUser).not())
+        if (workspace.owner.id != currentUser.id)
             throw WorkspaceOwnerNotSameException()
 
         val updatedWorkspace = workspace.copy(title = updateWorkspaceReqDto.title, description = updateWorkspaceReqDto.description)


### PR DESCRIPTION
## 개요
* 현재 DCD 구조에서 도메인은 영속성 컨텍스트에서 가져온후 새로운 객체를 생성하므로 동일성을 보장할 수 없기때문에 기존에 사용하던 방식을 수정합니다.
## 작업내용
* GenerateSSLCertificateUseCase에서 사용하는 유저 검증로직 수정
* UpdateWorkspaceUseCase에서 사용하는 유저 검증로직 수정
* ValidateWorkspaceOwnerService의 구현체에서 사용하는 유저 검증로직 수정