### PR TITLE
🔀 :: [#298] - CommandPort 구조 리펙토링

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/command/adapter/CommandAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/command/adapter/CommandAdapter.kt
@@ -1,4 +1,4 @@
-package com.dcd.server.infrastructure.common.command
+package com.dcd.server.core.common.command.adapter
 
 import com.dcd.server.core.common.command.CommandPort
 import org.springframework.stereotype.Component

--- a/src/main/kotlin/com/dcd/server/core/common/command/adapter/CommandAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/command/adapter/CommandAdapter.kt
@@ -1,18 +1,21 @@
 package com.dcd.server.core.common.command.adapter
 
 import com.dcd.server.core.common.command.CommandPort
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import java.io.BufferedReader
 import java.io.InputStreamReader
 
 @Component
 class CommandAdapter : CommandPort {
+    private val log = LoggerFactory.getLogger(this::class.simpleName)
+
     override fun executeShellCommand(cmd: String): Int {
         val cmd = arrayOf("/bin/sh", "-c", cmd)
         val p = Runtime.getRuntime().exec(cmd)
         val br = BufferedReader(InputStreamReader(p.inputStream))
         br.readLines().forEach {
-            println("$it")
+            log.info("$it")
         }
         p.waitFor()
         val exitValue = p.exitValue()

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/CreateDockerFileServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/CreateDockerFileServiceImplTest.kt
@@ -4,7 +4,7 @@ import com.dcd.server.core.common.file.FileContent
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.impl.CreateDockerFileServiceImpl
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
-import com.dcd.server.infrastructure.common.command.CommandAdapter
+import com.dcd.server.core.common.command.adapter.CommandAdapter
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.mockk


### PR DESCRIPTION
## 개요
* CommandPort 구조 리펙토링
## 작업내용
* CommandAdapter를 core 계층으로 이동
* CommandAdapter를 사용하는 부분의 임포트 수정
* 커맨드 실행시 print대신 logging하도록 수정