### PR TITLE
🔀 :: [#300] - 아키텍처에 맞지 않는 부분 수정

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/annotation/WorkspaceOwnerVerification.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/annotation/WorkspaceOwnerVerification.kt
@@ -1,4 +1,4 @@
-package com.dcd.server.core.common.aop.annotation
+package com.dcd.server.core.common.annotation
 
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.FUNCTION)

--- a/src/main/kotlin/com/dcd/server/core/common/aop/OwnerValidateAspect.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/aop/OwnerValidateAspect.kt
@@ -15,7 +15,7 @@ class OwnerValidateAspect(
     private val getCurrentUserService: GetCurrentUserService,
     private val queryWorkspacePort: QueryWorkspacePort
 ) {
-    @Pointcut("@annotation(com.dcd.server.core.common.aop.annotation.WorkspaceOwnerVerification)")
+    @Pointcut("@annotation(com.dcd.server.core.common.annotation.WorkspaceOwnerVerification)")
     fun workspaceOwnerVerificationPointcut() {}
 
     @Before("workspaceOwnerVerificationPointcut() && args(id, ..)")

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCase.kt
@@ -1,7 +1,6 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.ReadOnlyUseCase
-import com.dcd.server.core.common.aop.annotation.WorkspaceOwnerVerification
 import com.dcd.server.core.domain.application.dto.extenstion.toDto
 import com.dcd.server.core.domain.application.dto.response.ApplicationListResDto
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/dto/extension/AuthDtoExtension.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/dto/extension/AuthDtoExtension.kt
@@ -2,7 +2,7 @@ package com.dcd.server.core.domain.auth.dto.extension
 
 import com.dcd.server.core.domain.auth.dto.request.SignUpReqDto
 import com.dcd.server.core.domain.auth.model.Role
-import com.dcd.server.core.domain.user.model.Status
+import com.dcd.server.core.domain.user.model.enums.Status
 import com.dcd.server.core.domain.user.model.User
 
 fun SignUpReqDto.toEntity(encodedPassword: String): User =

--- a/src/main/kotlin/com/dcd/server/core/domain/user/dto/response/UserResDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/user/dto/response/UserResDto.kt
@@ -1,6 +1,6 @@
 package com.dcd.server.core.domain.user.dto.response
 
-import com.dcd.server.core.domain.user.model.Status
+import com.dcd.server.core.domain.user.model.enums.Status
 
 data class UserResDto(
     val id: String,

--- a/src/main/kotlin/com/dcd/server/core/domain/user/model/Status.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/user/model/Status.kt
@@ -1,6 +1,0 @@
-package com.dcd.server.core.domain.user.model
-
-enum class Status {
-    PENDING,
-    CREATED
-}

--- a/src/main/kotlin/com/dcd/server/core/domain/user/model/User.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/user/model/User.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.core.domain.user.model
 
 import com.dcd.server.core.domain.auth.model.Role
+import com.dcd.server.core.domain.user.model.enums.Status
 import java.util.*
 
 data class User(

--- a/src/main/kotlin/com/dcd/server/core/domain/user/model/enums/Status.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/user/model/enums/Status.kt
@@ -1,0 +1,6 @@
+package com.dcd.server.core.domain.user.model.enums
+
+enum class Status {
+    PENDING,
+    CREATED
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/user/spi/QueryUserPort.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/user/spi/QueryUserPort.kt
@@ -1,6 +1,6 @@
 package com.dcd.server.core.domain.user.spi
 
-import com.dcd.server.core.domain.user.model.Status
+import com.dcd.server.core.domain.user.model.enums.Status
 import com.dcd.server.core.domain.user.model.User
 
 interface QueryUserPort {

--- a/src/main/kotlin/com/dcd/server/core/domain/user/usecase/ChangeUserStatusUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/user/usecase/ChangeUserStatusUseCase.kt
@@ -2,7 +2,7 @@ package com.dcd.server.core.domain.user.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.domain.auth.exception.UserNotFoundException
-import com.dcd.server.core.domain.user.model.Status
+import com.dcd.server.core.domain.user.model.enums.Status
 import com.dcd.server.core.domain.user.spi.CommandUserPort
 import com.dcd.server.core.domain.user.spi.QueryUserPort
 

--- a/src/main/kotlin/com/dcd/server/core/domain/user/usecase/GetUserByStatusUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/user/usecase/GetUserByStatusUseCase.kt
@@ -3,7 +3,7 @@ package com.dcd.server.core.domain.user.usecase
 import com.dcd.server.core.common.annotation.ReadOnlyUseCase
 import com.dcd.server.core.domain.user.dto.extension.toDto
 import com.dcd.server.core.domain.user.dto.response.UserListResDto
-import com.dcd.server.core.domain.user.model.Status
+import com.dcd.server.core.domain.user.model.enums.Status
 import com.dcd.server.core.domain.user.spi.QueryUserPort
 
 @ReadOnlyUseCase

--- a/src/main/kotlin/com/dcd/server/persistence/user/UserPersistenceAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/user/UserPersistenceAdapter.kt
@@ -1,6 +1,6 @@
 package com.dcd.server.persistence.user
 
-import com.dcd.server.core.domain.user.model.Status
+import com.dcd.server.core.domain.user.model.enums.Status
 import com.dcd.server.core.domain.user.model.User
 import com.dcd.server.core.domain.user.spi.UserPort
 import com.dcd.server.persistence.user.adapter.toDomain

--- a/src/main/kotlin/com/dcd/server/persistence/user/entity/UserJpaEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/user/entity/UserJpaEntity.kt
@@ -1,7 +1,7 @@
 package com.dcd.server.persistence.user.entity
 
 import com.dcd.server.core.domain.auth.model.Role
-import com.dcd.server.core.domain.user.model.Status
+import com.dcd.server.core.domain.user.model.enums.Status
 import jakarta.persistence.*
 import java.util.*
 

--- a/src/main/kotlin/com/dcd/server/persistence/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/user/repository/UserRepository.kt
@@ -1,6 +1,6 @@
 package com.dcd.server.persistence.user.repository
 
-import com.dcd.server.core.domain.user.model.Status
+import com.dcd.server.core.domain.user.model.enums.Status
 import com.dcd.server.persistence.user.entity.UserJpaEntity
 import org.springframework.data.jpa.repository.JpaRepository
 

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
@@ -1,6 +1,6 @@
 package com.dcd.server.presentation.domain.application
 
-import com.dcd.server.core.common.aop.annotation.WorkspaceOwnerVerification
+import com.dcd.server.core.common.annotation.WorkspaceOwnerVerification
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.usecase.*
 import com.dcd.server.presentation.domain.application.data.exetension.toDto

--- a/src/main/kotlin/com/dcd/server/presentation/domain/user/UserWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/user/UserWebAdapter.kt
@@ -1,6 +1,6 @@
 package com.dcd.server.presentation.domain.user
 
-import com.dcd.server.core.domain.user.model.Status
+import com.dcd.server.core.domain.user.model.enums.Status
 import com.dcd.server.core.domain.user.usecase.ChangePasswordUseCase
 import com.dcd.server.core.domain.user.usecase.ChangeUserStatusUseCase
 import com.dcd.server.core.domain.user.usecase.GetUserByStatusUseCase

--- a/src/main/kotlin/com/dcd/server/presentation/domain/user/data/response/UserResponse.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/user/data/response/UserResponse.kt
@@ -1,6 +1,6 @@
 package com.dcd.server.presentation.domain.user.data.response
 
-import com.dcd.server.core.domain.user.model.Status
+import com.dcd.server.core.domain.user.model.enums.Status
 
 data class UserResponse(
     val id: String,

--- a/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangeUserStatusUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangeUserStatusUseCaseTest.kt
@@ -1,7 +1,7 @@
 package com.dcd.server.core.domain.user.usecase
 
 import com.dcd.server.core.domain.auth.exception.UserNotFoundException
-import com.dcd.server.core.domain.user.model.Status
+import com.dcd.server.core.domain.user.model.enums.Status
 import com.dcd.server.core.domain.user.spi.CommandUserPort
 import com.dcd.server.core.domain.user.spi.QueryUserPort
 import io.kotest.assertions.throwables.shouldThrow

--- a/src/test/kotlin/com/dcd/server/core/domain/user/usecase/GetUserByStatusUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/user/usecase/GetUserByStatusUseCaseTest.kt
@@ -1,7 +1,7 @@
 package com.dcd.server.core.domain.user.usecase
 
 import com.dcd.server.core.domain.user.dto.extension.toDto
-import com.dcd.server.core.domain.user.model.Status
+import com.dcd.server.core.domain.user.model.enums.Status
 import com.dcd.server.core.domain.user.spi.QueryUserPort
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/service/ValidateWorkspaceOwnerServiceTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/service/ValidateWorkspaceOwnerServiceTest.kt
@@ -1,11 +1,10 @@
 package com.dcd.server.core.domain.workspace.service
 
 import com.dcd.server.core.domain.auth.model.Role
-import com.dcd.server.core.domain.user.model.Status
+import com.dcd.server.core.domain.user.model.enums.Status
 import com.dcd.server.core.domain.user.model.User
 import com.dcd.server.core.domain.user.service.GetCurrentUserService
 import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameException
-import com.dcd.server.core.domain.workspace.model.Workspace
 import com.dcd.server.core.domain.workspace.service.impl.ValidateWorkspaceOwnerServiceImpl
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
@@ -13,7 +12,6 @@ import io.kotest.matchers.shouldBe
 import io.mockk.mockk
 import util.user.UserGenerator
 import util.workspace.WorkspaceGenerator
-import java.util.*
 
 class ValidateWorkspaceOwnerServiceTest : BehaviorSpec({
     val getCurrentUserService = mockk<GetCurrentUserService>()

--- a/src/test/kotlin/com/dcd/server/persistence/application/ApplicationPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/persistence/application/ApplicationPersistenceAdapterTest.kt
@@ -4,7 +4,7 @@ import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.auth.model.Role
-import com.dcd.server.core.domain.user.model.Status
+import com.dcd.server.core.domain.user.model.enums.Status
 import com.dcd.server.core.domain.user.model.User
 import com.dcd.server.core.domain.workspace.model.Workspace
 import com.dcd.server.persistence.application.adapter.toEntity

--- a/src/test/kotlin/com/dcd/server/persistence/user/UserPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/persistence/user/UserPersistenceAdapterTest.kt
@@ -1,7 +1,7 @@
 package com.dcd.server.persistence.user
 
 import com.dcd.server.core.domain.auth.model.Role
-import com.dcd.server.core.domain.user.model.Status
+import com.dcd.server.core.domain.user.model.enums.Status
 import com.dcd.server.core.domain.user.model.User
 import com.dcd.server.persistence.user.adapter.toEntity
 import com.dcd.server.persistence.user.repository.UserRepository

--- a/src/test/kotlin/com/dcd/server/persistence/workspace/WorkspacePersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/persistence/workspace/WorkspacePersistenceAdapterTest.kt
@@ -1,10 +1,9 @@
 package com.dcd.server.persistence.workspace
 
 import com.dcd.server.core.domain.auth.model.Role
-import com.dcd.server.core.domain.user.model.Status
+import com.dcd.server.core.domain.user.model.enums.Status
 import com.dcd.server.core.domain.user.model.User
 import com.dcd.server.core.domain.workspace.model.Workspace
-import com.dcd.server.persistence.user.adapter.toEntity
 import com.dcd.server.persistence.user.entity.UserJpaEntity
 import com.dcd.server.persistence.workspace.adapter.toEntity
 import com.dcd.server.persistence.workspace.entity.WorkspaceJpaEntity

--- a/src/test/kotlin/com/dcd/server/presentation/domain/user/UserWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/user/UserWebAdapterTest.kt
@@ -4,7 +4,7 @@ import com.dcd.server.core.domain.auth.model.Role
 import com.dcd.server.core.domain.user.dto.extension.toDto
 import com.dcd.server.core.domain.user.dto.response.UserListResDto
 import com.dcd.server.core.domain.user.dto.response.UserProfileResDto
-import com.dcd.server.core.domain.user.model.Status
+import com.dcd.server.core.domain.user.model.enums.Status
 import com.dcd.server.core.domain.user.model.User
 import com.dcd.server.core.domain.user.usecase.ChangePasswordUseCase
 import com.dcd.server.core.domain.user.usecase.ChangeUserStatusUseCase

--- a/src/test/kotlin/com/dcd/server/presentation/domain/workspace/WorkspaceWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/workspace/WorkspaceWebAdapterTest.kt
@@ -1,7 +1,7 @@
 package com.dcd.server.presentation.domain.workspace
 
 import com.dcd.server.core.domain.user.dto.response.UserResDto
-import com.dcd.server.core.domain.user.model.Status
+import com.dcd.server.core.domain.user.model.enums.Status
 import com.dcd.server.core.domain.workspace.dto.request.AddGlobalEnvReqDto
 import com.dcd.server.core.domain.workspace.dto.request.CreateWorkspaceReqDto
 import com.dcd.server.core.domain.workspace.dto.request.UpdateGlobalEnvReqDto

--- a/src/test/kotlin/util/user/UserGenerator.kt
+++ b/src/test/kotlin/util/user/UserGenerator.kt
@@ -9,13 +9,14 @@ object UserGenerator {
         email: String = "testEmail",
         password: String = "testPassword",
         name: String = "testName",
-        roles: MutableList<Role> = mutableListOf(Role.ROLE_USER)
+        roles: MutableList<Role> = mutableListOf(Role.ROLE_USER),
+        status: Status = Status.CREATED
     ): User =
         User(
             email = email,
             password = password,
             name = name,
             roles = roles,
-            status = Status.CREATED
+            status = status
         )
 }

--- a/src/test/kotlin/util/user/UserGenerator.kt
+++ b/src/test/kotlin/util/user/UserGenerator.kt
@@ -1,7 +1,7 @@
 package util.user
 
 import com.dcd.server.core.domain.auth.model.Role
-import com.dcd.server.core.domain.user.model.Status
+import com.dcd.server.core.domain.user.model.enums.Status
 import com.dcd.server.core.domain.user.model.User
 
 object UserGenerator {


### PR DESCRIPTION
## 개요
* 아키텍처에 맞지 않거나, 수정되어야되는 부분을 리펙토링합니다.
## 작업내용
* User의 status를 user.model.enums 패키지 이동
* 테스트 코드에서도 status의 import 경로 수정
* WorkspaceOwnerVerification 어노테이션을 core.common.annotation으로 이동
* WorkspaceOwnerVerification을 사용하는 임포트 구문 수정
* UserGenerator에서 status를 외부에서 받을수있도록 수정