### PR TITLE
🔀 :: [#304] - 토큰 재발급 로직 리펙토링

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/ReissueTokenUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/ReissueTokenUseCase.kt
@@ -8,15 +8,22 @@ import com.dcd.server.core.domain.auth.spi.CommandRefreshTokenPort
 import com.dcd.server.core.domain.auth.spi.JwtPort
 import com.dcd.server.core.domain.auth.spi.QueryRefreshTokenPort
 import com.dcd.server.core.domain.user.spi.QueryUserPort
+import com.dcd.server.infrastructure.global.jwt.adapter.ParseTokenAdapter
+import com.dcd.server.infrastructure.global.jwt.exception.TokenTypeNotValidException
 
 @UseCase
 class ReissueTokenUseCase(
     private val queryRefreshTokenPort: QueryRefreshTokenPort,
     private val commandRefreshTokenPort: CommandRefreshTokenPort,
     private val jwtPort: JwtPort,
-    private val queryUserPort: QueryUserPort
+    private val queryUserPort: QueryUserPort,
+    private val parseTokenAdapter: ParseTokenAdapter
 ) {
     fun execute(token: String): TokenResDto {
+        val jwtType = parseTokenAdapter.getJwtType(token)
+        if (jwtType != "REFRESH")
+            throw TokenTypeNotValidException()
+
         val refreshToken = (queryRefreshTokenPort.findByToken(token)
             ?: throw ExpiredRefreshTokenException()) // 리프레시 토큰 만료
         val user = (queryUserPort.findById(refreshToken.userId)

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/jwt/adapter/ParseTokenAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/jwt/adapter/ParseTokenAdapter.kt
@@ -26,6 +26,7 @@ class ParseTokenAdapter(
 ) {
     object JwtPrefix{
         const val ACCESS = "access"
+        const val REFRESH = "refresh"
         const val ROLE = "role"
         const val PREFIX = "Bearer "
     }
@@ -40,6 +41,12 @@ class ParseTokenAdapter(
         val userDetails = getDetails(claims.body)
 
         return UsernamePasswordAuthenticationToken(userDetails, "", userDetails.authorities)
+    }
+
+    fun getJwtType(token: String): String {
+        val claims = getClaims(token, jwtProperty.refreshSecret)
+
+        return claims.header[Header.JWT_TYPE] as? String ?: ""
     }
 
     private fun getClaims(token: String, secret: Key): Jws<Claims> {

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/ReissueTokenUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/ReissueTokenUseCaseTest.kt
@@ -11,6 +11,7 @@ import com.dcd.server.core.domain.auth.spi.QueryRefreshTokenPort
 import com.dcd.server.core.domain.user.model.User
 import com.dcd.server.core.domain.user.spi.QueryUserPort
 import com.dcd.server.infrastructure.global.jwt.adapter.ParseTokenAdapter
+import com.dcd.server.infrastructure.global.jwt.exception.TokenTypeNotValidException
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -25,7 +26,7 @@ class ReissueTokenUseCaseTest : BehaviorSpec({
     val commandRefreshTokenPort = mockk<CommandRefreshTokenPort>()
     val jwtPort = mockk<JwtPort>()
     val queryUserPort = mockk<QueryUserPort>()
-    val parseTokenAdapter = mockk<ParseTokenAdapter>()
+    val parseTokenAdapter = mockk<ParseTokenAdapter>(relaxUnitFun = true)
     val reissueTokenUseCase =
         ReissueTokenUseCase(queryRefreshTokenPort, commandRefreshTokenPort, jwtPort, queryUserPort, parseTokenAdapter)
 
@@ -43,6 +44,7 @@ class ReissueTokenUseCaseTest : BehaviorSpec({
             every { queryUserPort.findById(userId) } returns user
             every { commandRefreshTokenPort.delete(refreshToken) } returns Unit
             every { jwtPort.generateToken(user.id, user.roles) } returns tokenResDto
+            every { parseTokenAdapter.getJwtType(token) } returns "REFRESH"
         }
 
         init()
@@ -70,6 +72,15 @@ class ReissueTokenUseCaseTest : BehaviorSpec({
         `when`("토큰에 있는 유저가 없을때") {
             then("UserNotFoundException이 발생해야함") {
                 shouldThrow<UserNotFoundException> {
+                    reissueTokenUseCase.execute(token)
+                }
+            }
+        }
+
+        every { parseTokenAdapter.getJwtType(token) } returns "ACCESS"
+        `when`("해당 토큰이 REFRESH 타입이 아닐때") {
+            then("TokenTypeNotValidException이 발생해야함") {
+                shouldThrow<TokenTypeNotValidException> {
                     reissueTokenUseCase.execute(token)
                 }
             }

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/ReissueTokenUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/ReissueTokenUseCaseTest.kt
@@ -10,6 +10,7 @@ import com.dcd.server.core.domain.auth.spi.JwtPort
 import com.dcd.server.core.domain.auth.spi.QueryRefreshTokenPort
 import com.dcd.server.core.domain.user.model.User
 import com.dcd.server.core.domain.user.spi.QueryUserPort
+import com.dcd.server.infrastructure.global.jwt.adapter.ParseTokenAdapter
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -24,8 +25,9 @@ class ReissueTokenUseCaseTest : BehaviorSpec({
     val commandRefreshTokenPort = mockk<CommandRefreshTokenPort>()
     val jwtPort = mockk<JwtPort>()
     val queryUserPort = mockk<QueryUserPort>()
+    val parseTokenAdapter = mockk<ParseTokenAdapter>()
     val reissueTokenUseCase =
-        ReissueTokenUseCase(queryRefreshTokenPort, commandRefreshTokenPort, jwtPort, queryUserPort)
+        ReissueTokenUseCase(queryRefreshTokenPort, commandRefreshTokenPort, jwtPort, queryUserPort, parseTokenAdapter)
 
     val userId = "testUserId"
     val token = "testRefreshToken"


### PR DESCRIPTION
## 개요
* 토큰 재발급 로직을 리펙토링합니다.
## 작업내용
* getJwtType 메서드 추가
* ReissueTokenUseCase에서 REFRESH 타입의 토큰인지 검증하는 로직 추가
* ReissueTokenUseCaseTest에서 ReissueTokenUseCase를 생성할때 parseTokenAdapter를 사용해서 생성하도록 수정
* ReissueTokenUseCaseTest에서 토큰 타입이 리프레시 토큰이 아닌 테스트 케이스 추가