### PR TITLE
🔀 :: [#314] - 메일 전송 로직에서 비동기 처리하도록 수정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,6 +50,10 @@ dependencies {
 
 	//mail
 	implementation("org.springframework.boot:spring-boot-starter-mail")
+
+	//coroutine
+	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
+	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.6.4")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/service/EmailSendService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/service/EmailSendService.kt
@@ -1,5 +1,5 @@
 package com.dcd.server.core.domain.auth.service
 
 interface EmailSendService {
-    fun sendEmail(email: String)
+    suspend fun sendEmail(email: String)
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/service/impl/EmailSendServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/service/impl/EmailSendServiceImpl.kt
@@ -12,7 +12,7 @@ class EmailSendServiceImpl(
     private val commandEmailAuthPort: CommandEmailAuthPort,
     private val emailSender: JavaMailSender,
 ) : EmailSendService{
-    override fun sendEmail(email: String) {
+    override suspend fun sendEmail(email: String) {
         val emailAuth = EmailAuth(email = email)
         val code = emailAuth.code
         val message = emailSender.createMimeMessage()

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/service/impl/EmailSendServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/service/impl/EmailSendServiceImpl.kt
@@ -3,6 +3,8 @@ package com.dcd.server.core.domain.auth.service.impl
 import com.dcd.server.core.domain.auth.model.EmailAuth
 import com.dcd.server.core.domain.auth.service.EmailSendService
 import com.dcd.server.core.domain.auth.spi.CommandEmailAuthPort
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.mail.javamail.MimeMessageHelper
 import org.springframework.stereotype.Service
@@ -15,12 +17,16 @@ class EmailSendServiceImpl(
     override suspend fun sendEmail(email: String) {
         val emailAuth = EmailAuth(email = email)
         val code = emailAuth.code
-        val message = emailSender.createMimeMessage()
-        val messageHelper = MimeMessageHelper(message, "UTF-8")
-        messageHelper.setTo(email)
-        messageHelper.setSubject("[DCD] 메일인증 코드")
-        messageHelper.setText("$code \n위의 코드를 입력해주세요!")
-        emailSender.send(message)
+
+        withContext(Dispatchers.IO) {
+            val message = emailSender.createMimeMessage()
+            val messageHelper = MimeMessageHelper(message, "UTF-8")
+            messageHelper.setTo(email)
+            messageHelper.setSubject("[DCD] 메일인증 코드")
+            messageHelper.setText("$code \n위의 코드를 입력해주세요!")
+            emailSender.send(message)
+        }
+
         commandEmailAuthPort.save(emailAuth)
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/AuthMailSendUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/AuthMailSendUseCase.kt
@@ -3,13 +3,17 @@ package com.dcd.server.core.domain.auth.usecase
 import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.domain.auth.dto.request.EmailSendReqDto
 import com.dcd.server.core.domain.auth.service.EmailSendService
-
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 @UseCase
 class AuthMailSendUseCase(
     private val emailSendService: EmailSendService
-) {
+) : CoroutineScope by CoroutineScope(Dispatchers.IO){
     fun execute(emailSendReqDto: EmailSendReqDto) {
-        emailSendService.sendEmail(emailSendReqDto.email)
+        launch {
+            emailSendService.sendEmail(emailSendReqDto.email)
+        }
     }
 }

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/AuthMailSendUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/AuthMailSendUseCaseTest.kt
@@ -3,9 +3,9 @@ package com.dcd.server.core.domain.auth.usecase
 import com.dcd.server.core.domain.auth.dto.request.EmailSendReqDto
 import com.dcd.server.core.domain.auth.service.EmailSendService
 import io.kotest.core.spec.style.BehaviorSpec
-import io.mockk.every
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.mockk
-import io.mockk.verify
 
 class AuthMailSendUseCaseTest : BehaviorSpec({
     val emailSendService = mockk<EmailSendService>()
@@ -15,10 +15,10 @@ class AuthMailSendUseCaseTest : BehaviorSpec({
         val testEmail = "testEmail"
         val request = EmailSendReqDto(testEmail)
         `when`("execute메서드를 실행할때") {
-            every { emailSendService.sendEmail(testEmail) } returns Unit
+            coEvery { emailSendService.sendEmail(testEmail) } returns Unit
             useCase.execute(request)
             then("emailSendService의 sendEmail메서드를 실행해아함") {
-                verify { emailSendService.sendEmail(testEmail) }
+                coVerify { emailSendService.sendEmail(testEmail) }
             }
         }
     }


### PR DESCRIPTION
## 개요
* 메일 전송 로직에 비동기 처리를 적용합니다.
## 작업내용
* coroutine 의존성 추가
* EmailSendService의 sendEmail 메서드를 suspend 메서드로 수정
* 이메일 전송 로직에 코루틴 적용
* AuthMailSendUseCase에서 코루틴을 실행하도록 수정
* 테스트 코드가 코루틴환경에서 동작하도록 수정
## 기타
<img width="2038" alt="스크린샷 2024-09-15 오후 12 04 04" src="https://github.com/user-attachments/assets/73f7b3c9-7b33-49f4-95f4-d778e898f9ca">
위가 개선전 아래가 개선후 응답 속도
