### PR TITLE
🔀 :: [#316] - 애플리케이션 스케줄러 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/ServerApplication.kt
+++ b/src/main/kotlin/com/dcd/server/ServerApplication.kt
@@ -3,7 +3,9 @@ package com.dcd.server
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableScheduling
 
+@EnableScheduling
 @SpringBootApplication
 @ConfigurationPropertiesScan
 class ServerApplication

--- a/src/main/kotlin/com/dcd/server/core/domain/application/scheduler/ApplicationStatusScheduler.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/scheduler/ApplicationStatusScheduler.kt
@@ -1,0 +1,74 @@
+package com.dcd.server.core.domain.application.scheduler
+
+import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
+import com.dcd.server.core.domain.application.scheduler.enums.ContainerStatus
+import com.dcd.server.core.domain.application.service.GetContainerService
+import com.dcd.server.core.domain.application.spi.CommandApplicationPort
+import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class ApplicationStatusScheduler(
+    private val queryApplicationPort: QueryApplicationPort,
+    private val getContainerService: GetContainerService,
+    private val commandApplicationPort: CommandApplicationPort
+) {
+    @Scheduled(cron = "0 * * * * ?")
+    fun checkExitedApplication() {
+        val runningApplicationList = queryApplicationPort.findAllByStatus(ApplicationStatus.RUNNING)
+
+        val updatedApplicationList = mutableListOf<Application>()
+        getContainerService.getContainerNameByStatus(ContainerStatus.EXITED)
+            .forEach {containerName ->
+                val containerExitedApplication = runningApplicationList.lastOrNull { it.name.lowercase() == containerName }
+                    ?: return@forEach
+
+                val updatedApplication = containerExitedApplication.copy(
+                    status = ApplicationStatus.STOPPED
+                )
+                updatedApplicationList.add(updatedApplication)
+            }
+
+        commandApplicationPort.saveAll(updatedApplicationList)
+    }
+
+    @Scheduled(cron = "0 * * * * ?")
+    fun checkRunningApplication() {
+        val stoppedApplicationList = queryApplicationPort.findAllByStatus(ApplicationStatus.STOPPED)
+
+        val updatedApplicationList = mutableListOf<Application>()
+        getContainerService.getContainerNameByStatus(ContainerStatus.RUNNING)
+            .forEach {containerName ->
+                val containerRunningApplication = stoppedApplicationList.lastOrNull { it.name.lowercase() == containerName }
+                    ?: return@forEach
+
+                val updatedApplication = containerRunningApplication.copy(
+                    status = ApplicationStatus.RUNNING
+                )
+                updatedApplicationList.add(updatedApplication)
+            }
+
+        commandApplicationPort.saveAll(updatedApplicationList)
+    }
+
+    @Scheduled(cron = "0 * * * * ?")
+    fun checkCreatedContainer() {
+        val runningApplicationList = queryApplicationPort.findAllByStatus(ApplicationStatus.RUNNING)
+
+        val updatedApplicationList = mutableListOf<Application>()
+        getContainerService.getContainerNameByStatus(ContainerStatus.CREATED)
+            .forEach {containerName ->
+                val containerExitedApplication = runningApplicationList.lastOrNull { it.name.lowercase() == containerName }
+                    ?: return@forEach
+
+                val updatedApplication = containerExitedApplication.copy(
+                    status = ApplicationStatus.STOPPED
+                )
+                updatedApplicationList.add(updatedApplication)
+            }
+
+        commandApplicationPort.saveAll(updatedApplicationList)
+    }
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/scheduler/enums/ContainerStatus.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/scheduler/enums/ContainerStatus.kt
@@ -1,0 +1,9 @@
+package com.dcd.server.core.domain.application.scheduler.enums
+
+enum class ContainerStatus(
+    val description: String
+) {
+    EXITED("exited"),
+    RUNNING("running"),
+    CREATED("created")
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/GetContainerService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/GetContainerService.kt
@@ -1,0 +1,7 @@
+package com.dcd.server.core.domain.application.service
+
+import com.dcd.server.core.domain.application.scheduler.enums.ContainerStatus
+
+interface GetContainerService {
+    fun getContainerNameByStatus(status: ContainerStatus): List<String>
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetContainerServiceImpl.kt
@@ -1,0 +1,20 @@
+package com.dcd.server.core.domain.application.service.impl
+
+import com.dcd.server.core.domain.application.scheduler.enums.ContainerStatus
+import com.dcd.server.core.domain.application.service.GetContainerService
+import org.springframework.stereotype.Service
+import java.io.BufferedReader
+import java.io.InputStreamReader
+
+@Service
+class GetContainerServiceImpl : GetContainerService {
+    override fun getContainerNameByStatus(status: ContainerStatus): List<String> {
+        val cmd = arrayOf("/bin/sh", "-c", "docker ps -a --filter \"status=${status.description}\" --format \"{{.Names}}\"")
+        val p = Runtime.getRuntime().exec(cmd)
+        val br = BufferedReader(InputStreamReader(p.inputStream))
+        val result = br.readLines()
+        p.waitFor()
+        p.destroy()
+        return result
+    }
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/spi/CommandApplicationPort.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/spi/CommandApplicationPort.kt
@@ -5,4 +5,5 @@ import com.dcd.server.core.domain.application.model.Application
 interface CommandApplicationPort {
     fun save(application: Application)
     fun delete(application: Application)
+    fun saveAll(applicationList: List<Application>)
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/spi/QueryApplicationPort.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/spi/QueryApplicationPort.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.core.domain.application.spi
 
 import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.user.model.User
 import com.dcd.server.core.domain.workspace.model.Workspace
 
@@ -8,4 +9,5 @@ interface QueryApplicationPort {
     fun findAllByWorkspace(workspace: Workspace): List<Application>
     fun findById(id: String): Application?
     fun existsByExternalPort(externalPort: Int): Boolean
+    fun findAllByStatus(status: ApplicationStatus): List<Application>
 }

--- a/src/main/kotlin/com/dcd/server/persistence/application/ApplicationPersistenceAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/application/ApplicationPersistenceAdapter.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.persistence.application
 
 import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.spi.ApplicationPort
 import com.dcd.server.core.domain.user.model.User
 import com.dcd.server.core.domain.workspace.model.Workspace
@@ -34,4 +35,8 @@ class ApplicationPersistenceAdapter(
 
     override fun existsByExternalPort(externalPort: Int): Boolean =
         applicationRepository.existsByExternalPort(externalPort)
+
+    override fun findAllByStatus(status: ApplicationStatus): List<Application> =
+        applicationRepository.findAllByStatus(status)
+            .map { it.toDomain() }
 }

--- a/src/main/kotlin/com/dcd/server/persistence/application/ApplicationPersistenceAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/application/ApplicationPersistenceAdapter.kt
@@ -25,6 +25,10 @@ class ApplicationPersistenceAdapter(
         applicationRepository.delete(application.toEntity())
     }
 
+    override fun saveAll(applicationList: List<Application>) {
+        applicationRepository.saveAll(applicationList.map { it.toEntity() })
+    }
+
     override fun findAllByWorkspace(workspace: Workspace): List<Application> =
         applicationRepository.findAllByWorkspace(workspace.toEntity())
             .map { it.toDomain() }

--- a/src/main/kotlin/com/dcd/server/persistence/application/repository/ApplicationRepository.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/application/repository/ApplicationRepository.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.persistence.application.repository
 
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.persistence.application.entity.ApplicationJpaEntity
 import com.dcd.server.persistence.workspace.entity.WorkspaceJpaEntity
 import org.springframework.data.jpa.repository.JpaRepository
@@ -7,4 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface ApplicationRepository : JpaRepository<ApplicationJpaEntity, String> {
     fun findAllByWorkspace(workspace: WorkspaceJpaEntity): List<ApplicationJpaEntity>
     fun existsByExternalPort(externalPort: Int): Boolean
+    fun findAllByStatus(status: ApplicationStatus): List<ApplicationJpaEntity>
 }


### PR DESCRIPTION
## 개요
* 애플리케이션 스케줄러를 추가합니다.
## 작업내용
* 애플리케이션 status를 기준으로 조회하는 findAllByStatus 메서드 추가
* 애플리케이션 리스트를 저장할 수 있는 saveAll 메서드 추가
* GetContainerService(컨테이너의 상태로 이름을 조회하는 서비스) 추가
* ServerApplication에 EnableScheduling 어노테이션 추가
* ApplicationStatusScheduler 추가
## 기타
* 해당 스케줄러를 통해 애플리케이션과 컨테이너의 상태를 동기화할 수 있음
  * 추후에 event를 통해서도 상태를 일치시키는 방법도 좋을듯