### PR TITLE
🔀 :: [#322] - commandPort에서 커맨드 응답값을 리턴하는 메서드 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/command/CommandPort.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/command/CommandPort.kt
@@ -2,4 +2,5 @@ package com.dcd.server.core.common.command
 
 interface CommandPort {
     fun executeShellCommand(cmd: String): Int
+    fun executeShellCommandWithResult(cmd: String): List<String>
 }

--- a/src/main/kotlin/com/dcd/server/core/common/command/adapter/CommandAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/command/adapter/CommandAdapter.kt
@@ -23,4 +23,13 @@ class CommandAdapter : CommandPort {
         return exitValue
     }
 
+    override fun executeShellCommandWithResult(cmd: String): List<String> {
+        val cmd = arrayOf("/bin/sh", "-c", cmd)
+        val p = Runtime.getRuntime().exec(cmd)
+        val br = BufferedReader(InputStreamReader(p.inputStream))
+        p.waitFor()
+        p.destroy()
+        return br.readLines()
+    }
+
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExistsPortServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExistsPortServiceImpl.kt
@@ -1,23 +1,18 @@
 package com.dcd.server.core.domain.application.service.impl
 
+import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.domain.application.service.ExistsPortService
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import org.springframework.stereotype.Service
-import java.io.BufferedReader
-import java.io.InputStreamReader
 
 @Service
 class ExistsPortServiceImpl (
-    private val queryApplicationPort: QueryApplicationPort
+    private val queryApplicationPort: QueryApplicationPort,
+    private val commandPort: CommandPort
 )
     : ExistsPortService {
     override fun existsPort(port: Int): Boolean {
-        val cmd = arrayOf("/bin/sh", "-c", "lsof -i :${port}")
-        val p = Runtime.getRuntime().exec(cmd)
-        val br = BufferedReader(InputStreamReader(p.inputStream))
-        val result = br.readLine() != null && queryApplicationPort.existsByExternalPort(port)
-        p.waitFor()
-        p.destroy()
-        return result
+        val commandResult = commandPort.executeShellCommandWithResult("lsof -i :${port}")
+        return commandResult.isEmpty() && queryApplicationPort.existsByExternalPort(port)
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetContainerLogServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetContainerLogServiceImpl.kt
@@ -1,20 +1,14 @@
 package com.dcd.server.core.domain.application.service.impl
 
+import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.service.GetContainerLogService
 import org.springframework.stereotype.Service
-import java.io.BufferedReader
-import java.io.InputStreamReader
 
 @Service
-class GetContainerLogServiceImpl : GetContainerLogService {
-    override fun getLogs(application: Application): List<String> {
-        val cmd = arrayOf("/bin/sh", "-c", "docker logs ${application.name.lowercase()}")
-        val p = Runtime.getRuntime().exec(cmd)
-        val br = BufferedReader(InputStreamReader(p.inputStream))
-        val result = br.readLines()
-        p.waitFor()
-        p.destroy()
-        return result
-    }
+class GetContainerLogServiceImpl(
+    private val commandPort: CommandPort
+) : GetContainerLogService {
+    override fun getLogs(application: Application): List<String> =
+        commandPort.executeShellCommandWithResult("docker logs ${application.name.lowercase()}")
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetContainerServiceImpl.kt
@@ -1,20 +1,14 @@
 package com.dcd.server.core.domain.application.service.impl
 
+import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.domain.application.scheduler.enums.ContainerStatus
 import com.dcd.server.core.domain.application.service.GetContainerService
 import org.springframework.stereotype.Service
-import java.io.BufferedReader
-import java.io.InputStreamReader
 
 @Service
-class GetContainerServiceImpl : GetContainerService {
-    override fun getContainerNameByStatus(status: ContainerStatus): List<String> {
-        val cmd = arrayOf("/bin/sh", "-c", "docker ps -a --filter \"status=${status.description}\" --format \"{{.Names}}\"")
-        val p = Runtime.getRuntime().exec(cmd)
-        val br = BufferedReader(InputStreamReader(p.inputStream))
-        val result = br.readLines()
-        p.waitFor()
-        p.destroy()
-        return result
-    }
+class GetContainerServiceImpl(
+    private val commandPort: CommandPort
+) : GetContainerService {
+    override fun getContainerNameByStatus(status: ContainerStatus): List<String> =
+        commandPort.executeShellCommandWithResult("docker ps -a --filter \"status=${status.description}\" --format \"{{.Names}}\"")
 }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/ExistsPortServiceTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/ExistsPortServiceTest.kt
@@ -15,7 +15,7 @@ class ExistsPortServiceTest : BehaviorSpec({
         val testPort = 9999
         val commandPort = mockk<CommandPort>()
         every { queryApplicationPort.existsByExternalPort(testPort) } returns false
-        every { commandPort.executeShellCommandWithResult("lsof -i ${testPort}") } returns emptyList()
+        every { commandPort.executeShellCommandWithResult("lsof -i :${testPort}") } returns emptyList()
 
         val service = ExistsPortServiceImpl(queryApplicationPort, commandPort)
 

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/ExistsPortServiceTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/ExistsPortServiceTest.kt
@@ -23,7 +23,7 @@ class ExistsPortServiceTest : BehaviorSpec({
             val result = service.existsPort(9999)
             then("결과값은 false여야함") {
                 result shouldBe false
-                verify { commandPort.executeShellCommandWithResult("lsof -i ${testPort}") }
+                verify { commandPort.executeShellCommandWithResult("lsof -i :${testPort}") }
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/ExistsPortServiceTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/ExistsPortServiceTest.kt
@@ -23,7 +23,7 @@ class ExistsPortServiceTest : BehaviorSpec({
             val result = service.existsPort(9999)
             then("결과값은 false여야함") {
                 result shouldBe false
-                verify { commandPort.executeShellCommand("lsof -i ${testPort}") }
+                verify { commandPort.executeShellCommandWithResult("lsof -i ${testPort}") }
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/ExistsPortServiceTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/ExistsPortServiceTest.kt
@@ -1,23 +1,29 @@
 package com.dcd.server.core.domain.application.service
 
+import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.domain.application.service.impl.ExistsPortServiceImpl
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 
 class ExistsPortServiceTest : BehaviorSpec({
     given("service 구현체가 주어지고") {
         val queryApplicationPort = mockk<QueryApplicationPort>()
-        every { queryApplicationPort.existsByExternalPort(9999) } returns false
+        val testPort = 9999
+        val commandPort = mockk<CommandPort>()
+        every { queryApplicationPort.existsByExternalPort(testPort) } returns false
+        every { commandPort.executeShellCommandWithResult("lsof -i ${testPort}") } returns emptyList()
 
-        val service = ExistsPortServiceImpl(queryApplicationPort)
+        val service = ExistsPortServiceImpl(queryApplicationPort, commandPort)
 
         `when`("9999 포트가 사용중인지 검증할때") {
             val result = service.existsPort(9999)
             then("결과값은 false여야함") {
                 result shouldBe false
+                verify { commandPort.executeShellCommand("lsof -i ${testPort}") }
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/GetApplicationVersionServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/GetApplicationVersionServiceImplTest.kt
@@ -1,18 +1,36 @@
 package com.dcd.server.core.domain.application.service
 
+import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.impl.GetApplicationVersionServiceImpl
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 
 class GetApplicationVersionServiceImplTest : BehaviorSpec({
     given("ApplicationType이 주어지고") {
         val applicationType = ApplicationType.MYSQL
+        val commandPort = mockk<CommandPort>()
 
         `when`("getAvailableVersion 실행할때") {
-            val getApplicationVersionService = GetApplicationVersionServiceImpl()
+            every { commandPort.executeShellCommandWithResult("docker images ${applicationType.name.lowercase()}") } returns
+                    listOf(
+                        "REPOSITORY   TAG       IMAGE ID       CREATED         SIZE\n",
+                        "mysql        <none>    2010e93e56ca   8 weeks ago     608MB\n",
+                        "mysql        <none>    affb2bfc837e   8 weeks ago     608MB\n",
+                        "mysql        latest    0367e9abf33f   8 weeks ago     609MB\n",
+                        "mysql        <none>    f958d2869db0   8 weeks ago     609MB\n",
+                        "mysql        <none>    70e413dee93d   2 months ago    608MB\n",
+                        "mysql        <none>    c3239d2b6d88   2 months ago    608MB"
+                    )
+
+            val getApplicationVersionService = GetApplicationVersionServiceImpl(commandPort)
             val result = getApplicationVersionService.getAvailableVersion(applicationType)
             then("latest가 있어야함") {
-                println("result = ${result}")
+                result.size shouldBe 6
+                result.contains("latest") shouldBe true
             }
         }
     }


### PR DESCRIPTION
## 개요
* commandPort에서 커맨드 응답값을 리턴하는 메서드 추가
## 작업내용
* executeShellCommandWithResult 메서드 추가
* executeShellCommandWithResult 구현 메서드 추가
* command의 결과값을 받아야되는 서비스에서 executeShellCommandWithResult 메서드를 사용하도록 수정