### PR TITLE
🔀 :: [#324] - 커맨드 실행 로직 리펙토링

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/command/adapter/CommandAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/command/adapter/CommandAdapter.kt
@@ -4,6 +4,7 @@ import com.dcd.server.core.common.command.CommandPort
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import java.io.BufferedReader
+import java.io.IOException
 import java.io.InputStreamReader
 
 @Component
@@ -27,9 +28,14 @@ class CommandAdapter : CommandPort {
         val cmd = arrayOf("/bin/sh", "-c", cmd)
         val p = Runtime.getRuntime().exec(cmd)
         val br = BufferedReader(InputStreamReader(p.inputStream))
-        p.waitFor()
-        p.destroy()
-        return br.readLines()
+        try {
+            val result = br.readLines()
+            p.waitFor()
+            p.destroy()
+            return result
+        } catch (ex: IOException) {
+            return emptyList()
+        }
     }
 
 }

--- a/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
@@ -30,7 +30,7 @@ object FileContent {
         getEnvString(env)
 
     fun getRedisDockerFileContent(version: String, port: Int, env: Map<String, String>): String =
-        "FROM mariadb:${version}\n" +
+        "FROM redis:${version}\n" +
         "EXPOSE ${port}\n" +
         getEnvString(env)
 

--- a/src/main/kotlin/com/dcd/server/core/domain/application/scheduler/enums/ContainerStatus.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/scheduler/enums/ContainerStatus.kt
@@ -1,7 +1,7 @@
 package com.dcd.server.core.domain.application.scheduler.enums
 
 enum class ContainerStatus(
-    val description: String
+    val value: String
 ) {
     EXITED("exited"),
     RUNNING("running"),

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetContainerServiceImpl.kt
@@ -10,5 +10,5 @@ class GetContainerServiceImpl(
     private val commandPort: CommandPort
 ) : GetContainerService {
     override fun getContainerNameByStatus(status: ContainerStatus): List<String> =
-        commandPort.executeShellCommandWithResult("docker ps -a --filter \"status=${status.description}\" --format \"{{.Names}}\"")
+        commandPort.executeShellCommandWithResult("docker ps -a --filter \"status=${status.value}\" --format \"{{.Names}}\"")
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
@@ -34,12 +34,15 @@ class DeployApplicationUseCase(
         val externalPort = application.externalPort
 
         val applicationType = application.applicationType
-        if (applicationType == ApplicationType.SPRING_BOOT) {
-            cloneApplicationByUrlService.cloneByApplication(application)
-            modifyGradleService.modifyGradleByApplication(application)
-        }
-        else if (applicationType == ApplicationType.NEST_JS) {
-            cloneApplicationByUrlService.cloneByApplication(application)
+        when(applicationType) {
+            ApplicationType.SPRING_BOOT -> {
+                cloneApplicationByUrlService.cloneByApplication(application)
+                modifyGradleService.modifyGradleByApplication(application)
+            }
+            ApplicationType.NEST_JS -> {
+                cloneApplicationByUrlService.cloneByApplication(application)
+            }
+            else -> {}
         }
 
         createDockerFileService.createFileToApplication(application, version)


### PR DESCRIPTION
## 개요
* 커맨드 실행 로직을 리펙토링합니다.
## 작업내용
* ContainerStatus의 description을 value로 리네이밍
* executeShellCommandWithResult 메서드에서 결과값을 리턴할때 커맨드에서 에러를 발생시키면 빈 리스트를 반환하도록 수정
* 애플리케이션 배포시 when 구문을 사용하도록 가독성 개선
* Redis 도커파일 내용 수정