### PR TITLE
🔀 :: [#326] - 애플리케이션 정지 로직에 비동기 적용

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/StopContainerService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/StopContainerService.kt
@@ -3,5 +3,5 @@ package com.dcd.server.core.domain.application.service
 import com.dcd.server.core.domain.application.model.Application
 
 interface StopContainerService {
-    fun stopContainer(application: Application)
+    suspend fun stopContainer(application: Application)
 }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
@@ -11,6 +11,7 @@ import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -33,7 +34,7 @@ class StopApplicationUseCaseTest : BehaviorSpec({
             every { queryApplicationPort.findById(applicationId) } returns application
             stopApplicationUseCase.execute(applicationId)
             then("deleteContainerService와 deleteApplicationDirectoryService가 실행되어야함") {
-                verify { stopContainerService.stopContainer(application) }
+                coVerify { stopContainerService.stopContainer(application) }
                 verify { changeApplicationStatusService.changeApplicationStatus(application, ApplicationStatus.PENDING) }
             }
         }


### PR DESCRIPTION
## 개요
* 애플리케이션 정지 로직에 비동기 처리를 적용합니다.
## 작업내용
* StopContainerService의 stopContainer 메서드를 suspend 메서드로 수정
* StopContainerService 구현체의 stopContainer 메서드에 코루틴 적용
* StopApplicationUseCase에 코루틴 스코프 적용
* StopApplicationUseCase 테스트 코드가 코루틴에서도 동작할 수 있도록 수정