### PR TITLE
🔀 :: [#328] - 토큰 재발급 로직 수정

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/ReissueTokenUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/ReissueTokenUseCase.kt
@@ -21,7 +21,7 @@ class ReissueTokenUseCase(
 ) {
     fun execute(token: String): TokenResDto {
         val jwtType = parseTokenAdapter.getJwtType(token)
-        if (jwtType != "REFRESH")
+        if (jwtType != ParseTokenAdapter.JwtPrefix.REFRESH)
             throw TokenTypeNotValidException()
 
         val refreshToken = (queryRefreshTokenPort.findByToken(token)

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/ReissueTokenUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/ReissueTokenUseCaseTest.kt
@@ -44,7 +44,7 @@ class ReissueTokenUseCaseTest : BehaviorSpec({
             every { queryUserPort.findById(userId) } returns user
             every { commandRefreshTokenPort.delete(refreshToken) } returns Unit
             every { jwtPort.generateToken(user.id) } returns tokenResDto
-            every { parseTokenAdapter.getJwtType(token) } returns "REFRESH"
+            every { parseTokenAdapter.getJwtType(token) } returns ParseTokenAdapter.JwtPrefix.REFRESH
 
             val result = reissueTokenUseCase.execute(token)
             then("jwtPort에서 생성한 dto가 반환되어야함") {


### PR DESCRIPTION
## 개요
* 토큰 재발급 로직에서 휴먼에러가 발생하는 부분을 수정합니다.
## 작업내용
* 토큰 재발급시 토큰 어뎁터의 jwtType이랑 비교하도록 수정