### PR TITLE
🔀 :: [#330] - 애플리케이션 배포에 비동기 처리 적용

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/BuildDockerImageService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/BuildDockerImageService.kt
@@ -3,6 +3,6 @@ package com.dcd.server.core.domain.application.service
 import com.dcd.server.core.domain.application.model.Application
 
 interface BuildDockerImageService {
-    fun buildImageByApplicationId(id: String)
-    fun buildImageByApplication(application: Application)
+    suspend fun buildImageByApplicationId(id: String)
+    suspend fun buildImageByApplication(application: Application)
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/CloneApplicationByUrlService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/CloneApplicationByUrlService.kt
@@ -3,6 +3,6 @@ package com.dcd.server.core.domain.application.service
 import com.dcd.server.core.domain.application.model.Application
 
 interface CloneApplicationByUrlService {
-    fun cloneById(id: String)
-    fun cloneByApplication(application: Application)
+    suspend fun cloneById(id: String)
+    suspend fun cloneByApplication(application: Application)
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/CreateContainerService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/CreateContainerService.kt
@@ -3,5 +3,5 @@ package com.dcd.server.core.domain.application.service
 import com.dcd.server.core.domain.application.model.Application
 
 interface CreateContainerService {
-    fun createContainer(application: Application, externalPort: Int)
+    suspend fun createContainer(application: Application, externalPort: Int)
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/CreateDockerFileService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/CreateDockerFileService.kt
@@ -3,6 +3,6 @@ package com.dcd.server.core.domain.application.service
 import com.dcd.server.core.domain.application.model.Application
 
 interface CreateDockerFileService {
-    fun createFileByApplicationId(id: String, version: String)
-    fun createFileToApplication(application: Application, version: String)
+    suspend fun createFileByApplicationId(id: String, version: String)
+    suspend fun createFileToApplication(application: Application, version: String)
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/DeleteApplicationDirectoryService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/DeleteApplicationDirectoryService.kt
@@ -3,5 +3,5 @@ package com.dcd.server.core.domain.application.service
 import com.dcd.server.core.domain.application.model.Application
 
 interface DeleteApplicationDirectoryService {
-    fun deleteApplicationDirectory(application: Application)
+    suspend fun deleteApplicationDirectory(application: Application)
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/DeleteContainerService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/DeleteContainerService.kt
@@ -3,5 +3,5 @@ package com.dcd.server.core.domain.application.service
 import com.dcd.server.core.domain.application.model.Application
 
 interface DeleteContainerService {
-    fun deleteContainer(application: Application)
+    suspend fun deleteContainer(application: Application)
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/DeleteImageService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/DeleteImageService.kt
@@ -3,5 +3,5 @@ package com.dcd.server.core.domain.application.service
 import com.dcd.server.core.domain.application.model.Application
 
 interface DeleteImageService {
-    fun deleteImage(application: Application)
+    suspend fun deleteImage(application: Application)
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/ModifyGradleService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/ModifyGradleService.kt
@@ -3,6 +3,6 @@ package com.dcd.server.core.domain.application.service
 import com.dcd.server.core.domain.application.model.Application
 
 interface ModifyGradleService {
-    fun modifyGradleByApplicationId(id: String)
-    fun modifyGradleByApplication(application: Application)
+    suspend fun modifyGradleByApplicationId(id: String)
+    suspend fun modifyGradleByApplication(application: Application)
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/BuildDockerImageServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/BuildDockerImageServiceImpl.kt
@@ -1,48 +1,58 @@
 package com.dcd.server.core.domain.application.service.impl
 
 import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.domain.application.event.ChangeApplicationStatusEvent
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.exception.ImageNotBuiltException
 import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.BuildDockerImageService
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 
 @Service
 class BuildDockerImageServiceImpl(
     private val commandPort: CommandPort,
-    private val queryApplicationPort: QueryApplicationPort
+    private val queryApplicationPort: QueryApplicationPort,
+    private val eventPublisher: ApplicationEventPublisher
 ) : BuildDockerImageService {
-    override fun buildImageByApplicationId(id: String) {
+    override suspend fun buildImageByApplicationId(id: String) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
         val name = application.name
-        val exitValue = when (application.applicationType) {
-            ApplicationType.SPRING_BOOT -> {
-                commandPort.executeShellCommand("cd ./$name && ./gradlew clean build")
-                commandPort.executeShellCommand("cd ./$name && docker build -t ${name.lowercase()}:latest .")
-            }
+        withContext(Dispatchers.IO) {
+            val exitValue = when (application.applicationType) {
+                ApplicationType.SPRING_BOOT -> {
+                    commandPort.executeShellCommand("cd ./$name && ./gradlew clean build")
+                    commandPort.executeShellCommand("cd ./$name && docker build -t ${name.lowercase()}:latest .")
+                }
 
-            else -> {
-                commandPort.executeShellCommand("cd ./$name && docker build -t ${name.lowercase()}:latest .")
+                else -> {
+                    commandPort.executeShellCommand("cd ./$name && docker build -t ${name.lowercase()}:latest .")
+                }
             }
+            if (exitValue != 0) eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application))
         }
-        if (exitValue != 0) throw ImageNotBuiltException()
     }
 
-    override fun buildImageByApplication(application: Application) {
+    override suspend fun buildImageByApplication(application: Application) {
         val name = application.name
-        val exitValue = when(application.applicationType) {
-            ApplicationType.SPRING_BOOT -> {
-                commandPort.executeShellCommand("cd ./$name && ./gradlew clean build")
-                commandPort.executeShellCommand("cd ./$name && docker build -t ${name.lowercase()}:latest .")
+        withContext(Dispatchers.IO) {
+            val exitValue = when(application.applicationType) {
+                ApplicationType.SPRING_BOOT -> {
+                    commandPort.executeShellCommand("cd ./$name && ./gradlew clean build")
+                    commandPort.executeShellCommand("cd ./$name && docker build -t ${name.lowercase()}:latest .")
+                }
+                else -> {
+                    commandPort.executeShellCommand("cd ./$name && docker build -t ${name.lowercase()}:latest .")
+                }
             }
-            else -> {
-                commandPort.executeShellCommand("cd ./$name && docker build -t ${name.lowercase()}:latest .")
-            }
+            if (exitValue != 0) eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application))
         }
-        if (exitValue != 0) throw ImageNotBuiltException()
     }
 
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CloneApplicationByUrlServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CloneApplicationByUrlServiceImpl.kt
@@ -5,6 +5,8 @@ import com.dcd.server.core.domain.application.exception.ApplicationNotFoundExcep
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.service.CloneApplicationByUrlService
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.springframework.stereotype.Service
 
 @Service
@@ -12,15 +14,19 @@ class CloneApplicationByUrlServiceImpl(
     private val queryApplicationPort: QueryApplicationPort,
     private val commandPort: CommandPort
 ) : CloneApplicationByUrlService {
-    override fun cloneById(id: String) {
-        val application = (queryApplicationPort.findById(id)
-            ?: throw ApplicationNotFoundException())
-        val githubUrl = application.githubUrl
-        commandPort.executeShellCommand("git clone $githubUrl ${application.name}")
+    override suspend fun cloneById(id: String) {
+        withContext(Dispatchers.IO) {
+            val application = (queryApplicationPort.findById(id)
+                ?: throw ApplicationNotFoundException())
+            val githubUrl = application.githubUrl
+            commandPort.executeShellCommand("git clone $githubUrl ${application.name}")
+        }
     }
 
-    override fun cloneByApplication(application: Application) {
-        val githubUrl = application.githubUrl
-        commandPort.executeShellCommand("git clone $githubUrl ${application.name}")
+    override suspend fun cloneByApplication(application: Application) {
+        withContext(Dispatchers.IO) {
+            val githubUrl = application.githubUrl
+            commandPort.executeShellCommand("git clone $githubUrl ${application.name}")
+        }
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateContainerServiceImpl.kt
@@ -5,6 +5,8 @@ import com.dcd.server.core.domain.application.event.ChangeApplicationStatusEvent
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.service.CreateContainerService
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
@@ -15,16 +17,18 @@ class CreateContainerServiceImpl(
     private val eventPublisher: ApplicationEventPublisher
 ) : CreateContainerService {
     private val log = LoggerFactory.getLogger(this::class.simpleName)
-    override fun createContainer(application: Application, externalPort: Int) {
-        val cmd =
-            "docker create --network ${application.workspace.title.replace(' ', '_')} " +
-            "--name ${application.name.lowercase()} " +
-            "-p ${externalPort}:${application.port} ${application.name.lowercase()}:latest"
+    override suspend fun createContainer(application: Application, externalPort: Int) {
+        withContext(Dispatchers.IO) {
+            val cmd =
+                "docker create --network ${application.workspace.title.replace(' ', '_')} " +
+                        "--name ${application.name.lowercase()} " +
+                        "-p ${externalPort}:${application.port} ${application.name.lowercase()}:latest"
 
-        val exitValue = commandPort.executeShellCommand(cmd)
-        if (exitValue != 0) {
-            log.error("$exitValue")
-            eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application))
+            val exitValue = commandPort.executeShellCommand(cmd)
+            if (exitValue != 0) {
+                log.error("$exitValue")
+                eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application))
+            }
         }
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateDockerFileServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateDockerFileServiceImpl.kt
@@ -8,6 +8,8 @@ import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.CreateDockerFileService
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.springframework.stereotype.Service
 import java.io.File
 import java.io.IOException
@@ -17,14 +19,18 @@ class CreateDockerFileServiceImpl(
     private val queryApplicationPort: QueryApplicationPort,
     private val commandPort: CommandPort
 ) : CreateDockerFileService {
-    override fun createFileByApplicationId(id: String, version: String) {
+    override suspend fun createFileByApplicationId(id: String, version: String) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
-        createFile(application, version)
+        withContext(Dispatchers.IO) {
+            createFile(application, version)
+        }
     }
 
-    override fun createFileToApplication(application: Application, version: String) {
-        createFile(application, version)
+    override suspend fun createFileToApplication(application: Application, version: String) {
+        withContext(Dispatchers.IO) {
+            createFile(application, version)
+        }
     }
 
     private fun createFile(application: Application, version: String) {

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteApplicationDirectoryServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteApplicationDirectoryServiceImpl.kt
@@ -3,13 +3,17 @@ package com.dcd.server.core.domain.application.service.impl
 import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.service.DeleteApplicationDirectoryService
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.springframework.stereotype.Service
 
 @Service
 class DeleteApplicationDirectoryServiceImpl(
     private val commandPort: CommandPort
 ) : DeleteApplicationDirectoryService {
-    override fun deleteApplicationDirectory(application: Application) {
-        commandPort.executeShellCommand("rm -rf ${application.name}")
+    override suspend fun deleteApplicationDirectory(application: Application) {
+        withContext(Dispatchers.IO) {
+            commandPort.executeShellCommand("rm -rf ${application.name}")
+        }
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteContainerServiceImpl.kt
@@ -3,15 +3,19 @@ package com.dcd.server.core.domain.application.service.impl
 import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.service.DeleteContainerService
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.springframework.stereotype.Service
 
 @Service
 class DeleteContainerServiceImpl(
     private val commandPort: CommandPort
 ) : DeleteContainerService {
-    override fun deleteContainer(application: Application) {
-        val name = application.name.lowercase()
-        commandPort.executeShellCommand("docker stop $name && docker rm $name")
+    override suspend fun deleteContainer(application: Application) {
+        withContext(Dispatchers.IO) {
+            val name = application.name.lowercase()
+            commandPort.executeShellCommand("docker stop $name && docker rm $name")
+        }
     }
 
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteImageServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteImageServiceImpl.kt
@@ -3,13 +3,17 @@ package com.dcd.server.core.domain.application.service.impl
 import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.service.DeleteImageService
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.springframework.stereotype.Service
 
 @Service
 class DeleteImageServiceImpl(
     private val commandPort: CommandPort
 ) : DeleteImageService {
-    override fun deleteImage(application: Application) {
-        commandPort.executeShellCommand("docker rmi ${application.name.lowercase()}")
+    override suspend fun deleteImage(application: Application) {
+        withContext(Dispatchers.IO) {
+            commandPort.executeShellCommand("docker rmi ${application.name.lowercase()}")
+        }
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ModifyGradleServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ModifyGradleServiceImpl.kt
@@ -5,6 +5,8 @@ import com.dcd.server.core.domain.application.exception.ApplicationNotFoundExcep
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.service.ModifyGradleService
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.springframework.stereotype.Service
 import java.io.BufferedWriter
 import java.io.File
@@ -14,13 +16,17 @@ import java.io.FileWriter
 class ModifyGradleServiceImpl(
     private val queryApplicationPort: QueryApplicationPort,
 ) : ModifyGradleService{
-    override fun modifyGradleByApplicationId(id: String) {
+    override suspend fun modifyGradleByApplicationId(id: String) {
         val application = queryApplicationPort.findById(id) ?: throw ApplicationNotFoundException()
-        modifyGradle(application)
+        withContext(Dispatchers.IO) {
+            modifyGradle(application)
+        }
     }
 
-    override fun modifyGradleByApplication(application: Application) {
-        modifyGradle(application)
+    override suspend fun modifyGradleByApplication(application: Application) {
+        withContext(Dispatchers.IO) {
+            modifyGradle(application)
+        }
     }
 
     private fun modifyGradle(application: Application) {

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
@@ -1,12 +1,17 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.domain.application.event.ChangeApplicationStatusEvent
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.exception.CanNotDeployApplicationException
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.*
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.springframework.context.ApplicationEventPublisher
 
 @UseCase
 class DeployApplicationUseCase(
@@ -18,8 +23,9 @@ class DeployApplicationUseCase(
     private val createDockerFileService: CreateDockerFileService,
     private val buildDockerImageService: BuildDockerImageService,
     private val createContainerService: CreateContainerService,
-    private val deleteApplicationDirectoryService: DeleteApplicationDirectoryService
-) {
+    private val deleteApplicationDirectoryService: DeleteApplicationDirectoryService,
+    private val eventPublisher: ApplicationEventPublisher
+) : CoroutineScope by CoroutineScope(Dispatchers.IO) {
     fun execute(id: String) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
@@ -27,28 +33,32 @@ class DeployApplicationUseCase(
         if (application.status == ApplicationStatus.RUNNING || application.status == ApplicationStatus.PENDING)
             throw CanNotDeployApplicationException()
 
-        deleteContainerService.deleteContainer(application)
-        deleteImageService.deleteImage(application)
+        launch {
+            deleteContainerService.deleteContainer(application)
+            deleteImageService.deleteImage(application)
 
-        val version = application.version
-        val externalPort = application.externalPort
+            val version = application.version
+            val externalPort = application.externalPort
 
-        val applicationType = application.applicationType
-        when(applicationType) {
-            ApplicationType.SPRING_BOOT -> {
-                cloneApplicationByUrlService.cloneByApplication(application)
-                modifyGradleService.modifyGradleByApplication(application)
+            val applicationType = application.applicationType
+            when(applicationType) {
+                ApplicationType.SPRING_BOOT -> {
+                    cloneApplicationByUrlService.cloneByApplication(application)
+                    modifyGradleService.modifyGradleByApplication(application)
+                }
+                ApplicationType.NEST_JS -> {
+                    cloneApplicationByUrlService.cloneByApplication(application)
+                }
+                else -> {}
             }
-            ApplicationType.NEST_JS -> {
-                cloneApplicationByUrlService.cloneByApplication(application)
-            }
-            else -> {}
+
+            createDockerFileService.createFileToApplication(application, version)
+            buildDockerImageService.buildImageByApplication(application)
+            createContainerService.createContainer(application, externalPort)
+
+            deleteApplicationDirectoryService.deleteApplicationDirectory(application)
         }
 
-        createDockerFileService.createFileToApplication(application, version)
-        buildDockerImageService.buildImageByApplication(application)
-        createContainerService.createContainer(application, externalPort)
-
-        deleteApplicationDirectoryService.deleteApplicationDirectory(application)
+        eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.PENDING, application))
     }
 }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/BuildDockerImageServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/BuildDockerImageServiceImplTest.kt
@@ -10,9 +10,8 @@ import com.dcd.server.core.domain.auth.model.Role
 import com.dcd.server.core.domain.user.model.User
 import com.dcd.server.core.domain.workspace.model.Workspace
 import io.kotest.core.spec.style.BehaviorSpec
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.verify
+import io.mockk.*
+import org.springframework.context.ApplicationEventPublisher
 import util.application.ApplicationGenerator
 import util.user.UserGenerator
 import util.workspace.WorkspaceGenerator
@@ -21,7 +20,8 @@ import java.util.*
 class BuildDockerImageServiceImplTest : BehaviorSpec({
     val commandPort = mockk<CommandPort>(relaxed = true)
     val queryApplicationPort = mockk<QueryApplicationPort>()
-    val service = BuildDockerImageServiceImpl(commandPort, queryApplicationPort)
+    val eventPublisher = mockk<ApplicationEventPublisher>(relaxUnitFun = true)
+    val service = BuildDockerImageServiceImpl(commandPort, queryApplicationPort, eventPublisher)
 
     val user = UserGenerator.generateUser()
     given("애플리케이션id가 주어지고") {
@@ -34,8 +34,8 @@ class BuildDockerImageServiceImplTest : BehaviorSpec({
 
             service.buildImageByApplicationId(appId)
             then("commandPort가 실행되어야함") {
-                verify { commandPort.executeShellCommand("cd ./${application.name} && ./gradlew clean build") }
-                verify { commandPort.executeShellCommand("cd ./${application.name} && docker build -t ${application.name.lowercase()}:latest .") }
+                coVerify { commandPort.executeShellCommand("cd ./${application.name} && ./gradlew clean build") }
+                coVerify { commandPort.executeShellCommand("cd ./${application.name} && docker build -t ${application.name.lowercase()}:latest .") }
             }
         }
     }
@@ -48,8 +48,8 @@ class BuildDockerImageServiceImplTest : BehaviorSpec({
             service.buildImageByApplication(application)
 
             then("commandPort가 실행되어야함") {
-                verify { commandPort.executeShellCommand("cd ./${application.name} && ./gradlew clean build") }
-                verify { commandPort.executeShellCommand("cd ./${application.name} && docker build -t ${application.name.lowercase()}:latest .") }
+                coVerify { commandPort.executeShellCommand("cd ./${application.name} && ./gradlew clean build") }
+                coVerify { commandPort.executeShellCommand("cd ./${application.name} && docker build -t ${application.name.lowercase()}:latest .") }
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
@@ -15,6 +15,7 @@ import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerServic
 import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -67,12 +68,12 @@ class CreateApplicationUseCaseTest : BehaviorSpec({
             createApplicationUseCase.execute(workspace.id, request)
             then("repository의 save메서드가 실행되어야함") {
                 verify { commandApplicationPort.save(any()) }
-                verify { cloneApplicationByUrlService.cloneByApplication(any() as Application) }
-                verify { modifyGradleService.modifyGradleByApplication(any() as Application) }
-                verify { createDockerFileService.createFileToApplication(any() as Application, request.version) }
-                verify { buildDockerImageService.buildImageByApplication(any() as Application) }
-                verify { getExternalPortService.getExternalPort(request.port) }
-                verify { deleteApplicationDirectoryService.deleteApplicationDirectory(any() as Application) }
+                coVerify { cloneApplicationByUrlService.cloneByApplication(any() as Application) }
+                coVerify { modifyGradleService.modifyGradleByApplication(any() as Application) }
+                coVerify { createDockerFileService.createFileToApplication(any() as Application, request.version) }
+                coVerify { buildDockerImageService.buildImageByApplication(any() as Application) }
+                coVerify { getExternalPortService.getExternalPort(request.port) }
+                coVerify { deleteApplicationDirectoryService.deleteApplicationDirectory(any() as Application) }
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationUseCaseTest.kt
@@ -16,6 +16,7 @@ import com.dcd.server.core.domain.workspace.model.Workspace
 import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -42,8 +43,8 @@ class DeleteApplicationUseCaseTest : BehaviorSpec({
             deleteApplicationUseCase.execute(applicationId)
             then("commandApplicationPort의 delete메서드가 실행되어야함") {
                 verify { commandApplicationPort.delete(application) }
-                verify { deleteContainerService.deleteContainer(application) }
-                verify { deleteImageService.deleteImage(application) }
+                coVerify { deleteContainerService.deleteContainer(application) }
+                coVerify { deleteImageService.deleteImage(application) }
             }
         }
         `when`("application을 찾을 수 없을때") {

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCaseTest.kt
@@ -8,9 +8,11 @@ import com.dcd.server.core.domain.application.service.*
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.springframework.context.ApplicationEventPublisher
 import util.application.ApplicationGenerator
 
 class DeployApplicationUseCaseTest : BehaviorSpec({
@@ -23,6 +25,7 @@ class DeployApplicationUseCaseTest : BehaviorSpec({
     val buildDockerImageService = mockk<BuildDockerImageService>(relaxUnitFun = true)
     val createContainerService = mockk<CreateContainerService>(relaxUnitFun = true)
     val deleteApplicationDirectoryService = mockk<DeleteApplicationDirectoryService>(relaxUnitFun = true)
+    val eventPublisher = mockk<ApplicationEventPublisher>(relaxUnitFun = true)
     val deployApplicationUseCase = DeployApplicationUseCase(
         queryApplicationPort,
         deleteContainerService,
@@ -32,7 +35,8 @@ class DeployApplicationUseCaseTest : BehaviorSpec({
         createDockerFileService,
         buildDockerImageService,
         createContainerService,
-        deleteApplicationDirectoryService
+        deleteApplicationDirectoryService,
+        eventPublisher
     )
 
     given("애플리케이션 id가 주어지고") {
@@ -48,20 +52,20 @@ class DeployApplicationUseCaseTest : BehaviorSpec({
             deployApplicationUseCase.execute(applicationId)
 
             then("이미지와 컨테이너를 삭제하는 서비스를 실행해야함") {
-                verify { deleteContainerService.deleteContainer(application) }
-                verify { deleteImageService.deleteImage(application) }
+                coVerify { deleteContainerService.deleteContainer(application) }
+                coVerify { deleteImageService.deleteImage(application) }
             }
             then("애플리케이션을 클론하고, 그래들 파일을 수정해야함") {
-                verify { cloneApplicationByUrlService.cloneByApplication(application) }
-                verify { modifyGradleService.modifyGradleByApplication(application) }
+                coVerify { cloneApplicationByUrlService.cloneByApplication(application) }
+                coVerify { modifyGradleService.modifyGradleByApplication(application) }
             }
             then("도커파일을 생성하고, 이미지를 빌드하고, 컨테이너를 생성해야함") {
-                verify { createDockerFileService.createFileToApplication(application, application.version) }
-                verify { buildDockerImageService.buildImageByApplication(application) }
-                verify { createContainerService.createContainer(application, application.externalPort) }
+                coVerify { createDockerFileService.createFileToApplication(application, application.version) }
+                coVerify { buildDockerImageService.buildImageByApplication(application) }
+                coVerify { createContainerService.createContainer(application, application.externalPort) }
             }
             then("생성된 애플리케이션 디렉토리를 제거해야함") {
-                verify { deleteApplicationDirectoryService.deleteApplicationDirectory(application) }
+                coVerify { deleteApplicationDirectoryService.deleteApplicationDirectory(application) }
             }
         }
 
@@ -75,16 +79,16 @@ class DeployApplicationUseCaseTest : BehaviorSpec({
             deployApplicationUseCase.execute(applicationId)
 
             then("이미지와 컨테이너를 삭제하는 서비스를 실행해야함") {
-                verify { deleteContainerService.deleteContainer(application) }
-                verify { deleteImageService.deleteImage(application) }
+                coVerify { deleteContainerService.deleteContainer(application) }
+                coVerify { deleteImageService.deleteImage(application) }
             }
             then("도커파일을 생성하고, 이미지를 빌드하고, 컨테이너를 생성해야함") {
-                verify { createDockerFileService.createFileToApplication(application, application.version) }
-                verify { buildDockerImageService.buildImageByApplication(application) }
-                verify { createContainerService.createContainer(application, application.externalPort) }
+                coVerify { createDockerFileService.createFileToApplication(application, application.version) }
+                coVerify { buildDockerImageService.buildImageByApplication(application) }
+                coVerify { createContainerService.createContainer(application, application.externalPort) }
             }
             then("생성된 애플리케이션 디렉토리를 제거해야함") {
-                verify { deleteApplicationDirectoryService.deleteApplicationDirectory(application) }
+                coVerify { deleteApplicationDirectoryService.deleteApplicationDirectory(application) }
             }
         }
 
@@ -98,16 +102,16 @@ class DeployApplicationUseCaseTest : BehaviorSpec({
             deployApplicationUseCase.execute(applicationId)
 
             then("이미지와 컨테이너를 삭제하는 서비스를 실행해야함") {
-                verify { deleteContainerService.deleteContainer(application) }
-                verify { deleteImageService.deleteImage(application) }
+                coVerify { deleteContainerService.deleteContainer(application) }
+                coVerify { deleteImageService.deleteImage(application) }
             }
             then("도커파일을 생성하고, 이미지를 빌드하고, 컨테이너를 생성해야함") {
-                verify { createDockerFileService.createFileToApplication(application, application.version) }
-                verify { buildDockerImageService.buildImageByApplication(application) }
-                verify { createContainerService.createContainer(application, application.externalPort) }
+                coVerify { createDockerFileService.createFileToApplication(application, application.version) }
+                coVerify { buildDockerImageService.buildImageByApplication(application) }
+                coVerify { createContainerService.createContainer(application, application.externalPort) }
             }
             then("생성된 애플리케이션 디렉토리를 제거해야함") {
-                verify { deleteApplicationDirectoryService.deleteApplicationDirectory(application) }
+                coVerify { deleteApplicationDirectoryService.deleteApplicationDirectory(application) }
             }
         }
 


### PR DESCRIPTION
## 개요
* 애플리케이션 배포 로직에 비동기 처리를 적용합니다.
## 작업내용
* BuildDockerService에 비동기 처리 적용
* CloneApplicationByUrlService에 비동기 처리 적용
* CreateContainerService에 비동기 적용
* CreateDockerFileService에 비동기 처리 적용
* DeleteApplicationDirectoryService에 비동기 적용
* DeleteImageService에 비동기 적용
* ModifyGradleService에 비동기 적용
* usecase에 코루틴 스코프 적용
* BuildDockerImageServiceImplTest 테스트 코드 수정