### PR TITLE
🔀 :: [#332] - 커맨드를 실행할 수 있는 API 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
@@ -36,10 +36,11 @@ enum class ErrorCode(
     CONFLICT("해당 요청은 서버의 상태와 충돌됩니다.", 409),
     CAN_NOT_DEPLOY_APPLICATION("애플리케이션을 배포할 수 없습니다. 애플리케이션을 정지시킨 후 실행해주세요.", 409),
     CAN_NOT_DELETE_APPLICATION("애플리케이션을 삭제할 수 없습니다. 애플리케이션을 정지시킨 후 실행해주세요.", 409),
+    INVALID_APPLICATION_STATUS("애플리케이션 상태가 유효하지 않음", 409),
 
     CONTAINER_NOT_RUN("해당 애플리케이션을 실행할 수 없음", 500),
     CONTAINER_NOT_STOPPED("해당 애플리케이션을 정지할 수 없음", 500),
     CONTAINER_NOT_CREATED("해당 애플리케이션의 이미지를 컨테이너로 빌드할 수 없음", 500),
     IMAGE_NOT_BUILT("해당 애플리케이션을 이미지로 빌드할 수 없음", 500),
-    INTERNAL_ERROR("서버 내부 에러", 500)
+    INTERNAL_ERROR("서버 내부 에러", 500),
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/request/ExecuteCommandReqDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/request/ExecuteCommandReqDto.kt
@@ -1,0 +1,5 @@
+package com.dcd.server.core.domain.application.dto.request
+
+data class ExecuteCommandReqDto(
+    val command: String
+)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/response/CommandResultResDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/response/CommandResultResDto.kt
@@ -1,0 +1,5 @@
+package com.dcd.server.core.domain.application.dto.response
+
+data class CommandResultResDto(
+    val result: List<String>
+)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/exception/InvalidApplicationStatusException.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/exception/InvalidApplicationStatusException.kt
@@ -1,0 +1,7 @@
+package com.dcd.server.core.domain.application.exception
+
+import com.dcd.server.core.common.error.BasicException
+import com.dcd.server.core.common.error.ErrorCode
+
+class InvalidApplicationStatusException : BasicException(ErrorCode.INVALID_APPLICATION_STATUS) {
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCase.kt
@@ -1,0 +1,29 @@
+package com.dcd.server.core.domain.application.usecase
+
+import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.domain.application.dto.request.ExecuteCommandReqDto
+import com.dcd.server.core.domain.application.dto.response.CommandResultResDto
+import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
+import com.dcd.server.core.domain.application.exception.InvalidApplicationStatusException
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
+import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+
+@UseCase
+class ExecuteCommandUseCase(
+    private val queryApplicationPort: QueryApplicationPort,
+    private val commandPort: CommandPort
+) {
+    fun execute(applicationId: String, executeCommandReqDto: ExecuteCommandReqDto): CommandResultResDto {
+        val application = (queryApplicationPort.findById(applicationId)
+            ?: throw ApplicationNotFoundException())
+
+        if (application.status != ApplicationStatus.RUNNING)
+            throw InvalidApplicationStatusException()
+
+        val result =
+            commandPort.executeShellCommandWithResult("docker exec ${application.name.lowercase()} ${executeCommandReqDto.command}")
+
+        return CommandResultResDto(result)
+    }
+}

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
@@ -64,6 +64,7 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.DELETE, "/{workspaceId}/application/{id}/env").authenticated()
                 it.requestMatchers(HttpMethod.PATCH, "/{workspaceId}/application/{applicationId}/env").authenticated()
                 it.requestMatchers(HttpMethod.GET, "/{workspaceId}/application/version/{applicationType}").authenticated()
+                it.requestMatchers(HttpMethod.POST, "/{workspaceId}/application/{id}/exec").authenticated()
 
                 //workspace
                 it.requestMatchers(HttpMethod.POST, "/workspace").authenticated()

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
@@ -28,7 +28,8 @@ class ApplicationWebAdapter(
     private val getAvailableVersionUseCase: GetAvailableVersionUseCase,
     private val generateSSLCertificateUseCase: GenerateSSLCertificateUseCase,
     private val getApplicationLogUseCase: GetApplicationLogUseCase,
-    private val deployApplicationUseCase: DeployApplicationUseCase
+    private val deployApplicationUseCase: DeployApplicationUseCase,
+    private val executeCommandUseCase: ExecuteCommandUseCase
 ) {
     @PostMapping
     @WorkspaceOwnerVerification
@@ -136,5 +137,11 @@ class ApplicationWebAdapter(
     @WorkspaceOwnerVerification
     fun getApplicationLog(@PathVariable workspaceId: String, @PathVariable applicationId: String): ResponseEntity<ApplicationLogResponse> =
         getApplicationLogUseCase.execute(applicationId)
+            .let { ResponseEntity.ok(it.toResponse()) }
+
+    @PostMapping("/{applicationId}/exec")
+    @WorkspaceOwnerVerification
+    fun execCommand(@PathVariable workspaceId: String, @PathVariable applicationId: String, @Validated @RequestBody executeCommandRequest: ExecuteCommandRequest): ResponseEntity<CommandResultResponse> =
+        executeCommandUseCase.execute(applicationId, executeCommandRequest.toDto())
             .let { ResponseEntity.ok(it.toResponse()) }
 }

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationRequestDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationRequestDataExtension.kt
@@ -38,3 +38,8 @@ fun UpdateApplicationEnvRequest.toDto(): UpdateApplicationEnvReqDto =
     UpdateApplicationEnvReqDto(
         newValue = this.newValue
     )
+
+fun ExecuteCommandRequest.toDto(): ExecuteCommandReqDto =
+    ExecuteCommandReqDto(
+        command = this.command
+    )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationResponseDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationResponseDataExtension.kt
@@ -52,3 +52,8 @@ fun WorkspaceApplicationResDto.toResponse(): WorkspaceApplicationResponse =
         externalPort = this.externalPort,
         status = this.status
     )
+
+fun CommandResultResDto.toResponse(): CommandResultResponse =
+    CommandResultResponse(
+        result = this.result
+    )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/request/ExecuteCommandRequest.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/request/ExecuteCommandRequest.kt
@@ -1,0 +1,8 @@
+package com.dcd.server.presentation.domain.application.data.request
+
+import jakarta.validation.constraints.NotBlank
+
+data class ExecuteCommandRequest(
+    @field:NotBlank
+    val command: String
+)

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/response/CommandResultResponse.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/response/CommandResultResponse.kt
@@ -1,0 +1,5 @@
+package com.dcd.server.presentation.domain.application.data.response
+
+data class CommandResultResponse(
+    val result: List<String>
+)

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -31,7 +31,8 @@ class ApplicationWebAdapterTest : BehaviorSpec({
     val generateSSLCertificateUseCase = mockk<GenerateSSLCertificateUseCase>(relaxUnitFun = true)
     val getApplicationLogUseCase = mockk<GetApplicationLogUseCase>()
     val deployApplicationUseCase = mockk<DeployApplicationUseCase>(relaxUnitFun = true)
-    val applicationWebAdapter = ApplicationWebAdapter(createApplicationUseCase, springRunApplicationUseCase, getAllApplicationUseCase, getOneApplicationUseCase, addApplicationEnvUseCase, deleteApplicationEnvUseCase, updateApplicationEnvUseCase, stopApplicationUseCase, deleteApplicationUseCase, updateApplicationUseCase, getAvailableVersionUseCase, generateSSLCertificateUseCase, getApplicationLogUseCase, deployApplicationUseCase)
+    val executeCommandUseCase = mockk<ExecuteCommandUseCase>(relaxUnitFun = true)
+    val applicationWebAdapter = ApplicationWebAdapter(createApplicationUseCase, springRunApplicationUseCase, getAllApplicationUseCase, getOneApplicationUseCase, addApplicationEnvUseCase, deleteApplicationEnvUseCase, updateApplicationEnvUseCase, stopApplicationUseCase, deleteApplicationUseCase, updateApplicationUseCase, getAvailableVersionUseCase, generateSSLCertificateUseCase, getApplicationLogUseCase, deployApplicationUseCase, executeCommandUseCase)
 
     val testWorkspaceId = "testWorkspaceId"
 


### PR DESCRIPTION
## 개요
* 특정 애플리케이션 컨테이너에 커맨드를 실행할 수 있는 API를 추가합니다.
## 작업내용
* 커맨드 실행 요청 dto 추가
* 커맨드 결과 응답 dto 추가
* InvalidApplicationStatusException 추가
* 특정 애플리케이션의 컨테이너에서 커맨드를 실행하는 유스케이스 추가
* 커맨드 실행 요청 객체 추가
* 커맨드 결과 응답 객체 추가
* 커맨드 실행 엔드포인트 추가