### PR TITLE
🔀 :: [#336] - cd 명령 실행시 directory not found가 발생하는 현상

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExecContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExecContainerServiceImpl.kt
@@ -24,6 +24,9 @@ class ExecContainerServiceImpl(
             val currentDir = session.attributes["workingDir"] as? String ?: "/"
             val updatedDir = updateWorkingDir(currentDir, newDir)
             session.attributes["workingDir"] = updatedDir
+            session.sendMessage(TextMessage("current dir = ${session.attributes["workingDir"] ?: "/"}"))
+            session.sendMessage(TextMessage("cmd end"))
+            return
         }
 
         val workingDir = session.attributes["workingDir"] as? String ?: "/"
@@ -40,7 +43,6 @@ class ExecContainerServiceImpl(
         dockerClient.execStartCmd(execInstance.id)
             .withDetach(false)
             .exec(AttachResultCallback(session))
-
     }
 
     private fun updateWorkingDir(currentDir: String, newDir: String): String {


### PR DESCRIPTION
## 개요
* exec에서 cd 명령 실행시 `directory not found`가 발생하는 현상을 수정합니다.
## 작업내용
* cd 커맨드가 감지됐을때 세션에서 관리하는 작업 디렉토리만 변경하고 컨테이너에서 실제로 실행하지 않도록 수정