### PR TITLE
🔀 :: [#338] - exec api 테스트 코드 작성

### DIFF
--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCaseTest.kt
@@ -43,5 +43,15 @@ class ExecuteCommandUseCaseTest : BehaviorSpec({
                 }
             }
         }
+
+        `when`("애플리케이션의 상태가 올바르지 않을때") {
+            every { queryApplicationPort.findById(applicationId) } returns givenApplication.copy(status = ApplicationStatus.STOPPED)
+
+            then("InvalidApplicationStatusException이 발생해야함") {
+                shouldThrow<InvalidApplicationStatusException> {
+                    executeCommandUseCase.execute(applicationId, request)
+                }
+            }
+        }
     }
 })

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCaseTest.kt
@@ -53,5 +53,17 @@ class ExecuteCommandUseCaseTest : BehaviorSpec({
                 }
             }
         }
+
+        `when`("execute 메서드를 실행할때") {
+            every { queryApplicationPort.findById(applicationId) } returns givenApplication
+            every { commandPort.executeShellCommandWithResult(executedCmd) } returns testCmdResult
+            val result = executeCommandUseCase.execute(applicationId, request)
+
+            then("testCmdResult가 응답에 있어야함") {
+                result.result shouldBe testCmdResult
+                verify { queryApplicationPort.findById(applicationId) }
+                verify { commandPort.executeShellCommandWithResult(executedCmd) }
+            }
+        }
     }
 })

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCaseTest.kt
@@ -1,0 +1,47 @@
+package com.dcd.server.core.domain.application.usecase
+
+import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.domain.application.dto.request.ExecuteCommandReqDto
+import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
+import com.dcd.server.core.domain.application.exception.InvalidApplicationStatusException
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
+import com.dcd.server.core.domain.application.service.ExecContainerService
+import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import com.dcd.server.infrastructure.global.jwt.adapter.ParseTokenAdapter
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import util.application.ApplicationGenerator
+
+class ExecuteCommandUseCaseTest : BehaviorSpec({
+    val queryApplicationPort = mockk<QueryApplicationPort>(relaxUnitFun = true)
+    val parseTokenAdapter = mockk<ParseTokenAdapter>(relaxUnitFun = true)
+    val execContainerService = mockk<ExecContainerService>(relaxUnitFun = true)
+    val commandPort = mockk<CommandPort>(relaxUnitFun = true)
+
+    val executeCommandUseCase =
+        ExecuteCommandUseCase(queryApplicationPort, execContainerService, parseTokenAdapter, commandPort)
+
+    given("애플리케이션 id, ExecuteCommandReqDto가 주어지고") {
+        val applicationId = "testApplicationId"
+        val cmd = "test"
+        val request = ExecuteCommandReqDto(cmd)
+
+        val givenApplication = ApplicationGenerator.generateApplication(id = applicationId, status = ApplicationStatus.RUNNING)
+        val executedCmd = "docker exec ${givenApplication.name.lowercase()} $cmd"
+        val testCmdResult = listOf("test cmd result")
+
+        `when`("주어진 아이디를 가진 애플리케이션이 없을때") {
+            every { queryApplicationPort.findById(applicationId) } returns null
+
+            then("ApplicationNotFoundException이 발생해야함") {
+                shouldThrow<ApplicationNotFoundException> {
+                    executeCommandUseCase.execute(applicationId, request)
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -1,11 +1,13 @@
 package com.dcd.server.presentation.domain.application
 
+import com.dcd.server.core.domain.application.dto.request.ExecuteCommandReqDto
 import com.dcd.server.core.domain.application.dto.request.GenerateSSLCertificateReqDto
 import com.dcd.server.core.domain.application.dto.request.UpdateApplicationReqDto
 import com.dcd.server.core.domain.application.dto.response.*
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.usecase.*
+import com.dcd.server.presentation.domain.application.data.exetension.toDto
 import com.dcd.server.presentation.domain.application.data.exetension.toResponse
 import com.dcd.server.presentation.domain.application.data.request.*
 import com.dcd.server.presentation.domain.application.data.response.RunApplicationResponse
@@ -13,6 +15,7 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.spyk
 import io.mockk.verify
 import org.springframework.http.HttpStatus
 
@@ -239,5 +242,25 @@ class ApplicationWebAdapterTest : BehaviorSpec({
                 result.statusCode shouldBe HttpStatus.OK
             }
         }
+    }
+
+    given("애플리케이션 id와 ExecuteCmdRequest가 주어지고") {
+        val request = ExecuteCommandRequest(command = "test cmd")
+        val applicationId = "testApplicationId"
+
+        `when`("execCommand 메서드를 실행할때") {
+            val expectedResult = listOf("cmd result")
+            every { executeCommandUseCase.execute(applicationId, any() as ExecuteCommandReqDto) } returns CommandResultResDto(expectedResult)
+            val result = applicationWebAdapter.execCommand(testWorkspaceId, applicationId, request)
+
+            then("상태코드는 200이여야함") {
+                result.statusCode shouldBe HttpStatus.OK
+                result.body?.result shouldBe expectedResult
+            }
+            then("executeCommandUseCase가 실행되야함") {
+                verify { executeCommandUseCase.execute(applicationId, any() as ExecuteCommandReqDto) }
+            }
+        }
+
     }
 })


### PR DESCRIPTION
## 개요
* exec api 테스트 코드를 작성합니다.
## 작업내용
* 주어진 애플리케이션이 없을때 execute 메서드를 실행하는 테스트 케이스 추가
* 애플리케이션의 상태가 올바르지 않는 테스트케이스 추가
* execute가 정상적으로 실행되는 테스트 케이스 추가
* ApplicationWebAdapterTest에 execCommand를 실행하는 테스트 케이스 추가