### PR TITLE
🔀 :: [#340] - 웹소켓에서 사용하는 ExecuteCmdUseCase 테스트 코드

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCase.kt
@@ -44,6 +44,9 @@ class ExecuteCommandUseCase(
         val application = (queryApplicationPort.findById(applicationId)
             ?: throw ApplicationNotFoundException())
 
+        if (application.status != ApplicationStatus.RUNNING)
+            throw InvalidApplicationStatusException()
+
         if (userId != application.workspace.owner.id)
             throw WorkspaceOwnerNotSameException()
 

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCaseTest.kt
@@ -83,5 +83,15 @@ class ExecuteCommandUseCaseTest : BehaviorSpec({
         val givenToken = "${givenUser.id}"
         val givenWorkspace = WorkspaceGenerator.generateWorkspace(user = givenUser)
         val givenApplication = ApplicationGenerator.generateApplication(workspace = givenWorkspace, status = ApplicationStatus.RUNNING)
+
+        `when`("세션에 엑세스 토큰이 존재하지 않음") {
+            every { session.attributes["accessToken"] } returns null
+
+            then("InvalidConnectionInfoException이 발생해야함") {
+                shouldThrow<InvalidConnectionInfoException> {
+                    executeCommandUseCase.execute(testApplicationId, session, cmd)
+                }
+            }
+        }
     }
 })

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCaseTest.kt
@@ -116,5 +116,15 @@ class ExecuteCommandUseCaseTest : BehaviorSpec({
                 }
             }
         }
+
+        `when`("execute 메서드를 실행할때") {
+            every { queryApplicationPort.findById(testApplicationId) } returns givenApplication
+            executeCommandUseCase.execute(testApplicationId, session, cmd)
+
+            then("testCmdResult가 응답에 있어야함") {
+                verify { queryApplicationPort.findById(testApplicationId) }
+                verify { execContainerService.execCmd(givenApplication, session, cmd) }
+            }
+        }
     }
 })

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCaseTest.kt
@@ -93,5 +93,18 @@ class ExecuteCommandUseCaseTest : BehaviorSpec({
                 }
             }
         }
+
+        `when`("주어진 아이디를 가진 애플리케이션이 없을때") {
+            every { session.attributes["accessToken"] } returns givenToken
+            every { givenAuthentication.name } returns givenUser.id
+            every { parseTokenAdapter.getAuthentication(givenToken) } returns givenAuthentication
+            every { queryApplicationPort.findById(testApplicationId) } returns null
+
+            then("ApplicationNotFoundException이 발생해야함") {
+                shouldThrow<ApplicationNotFoundException> {
+                    executeCommandUseCase.execute(testApplicationId, session, cmd)
+                }
+            }
+        }
     }
 })

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCaseTest.kt
@@ -106,5 +106,15 @@ class ExecuteCommandUseCaseTest : BehaviorSpec({
                 }
             }
         }
+
+        `when`("애플리케이션의 상태가 올바르지 않을때") {
+            every { queryApplicationPort.findById(testApplicationId) } returns givenApplication.copy(status = ApplicationStatus.STOPPED)
+
+            then("InvalidApplicationStatusException이 발생해야함") {
+                shouldThrow<InvalidApplicationStatusException> {
+                    executeCommandUseCase.execute(testApplicationId, session, cmd)
+                }
+            }
+        }
     }
 })

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCaseTest.kt
@@ -8,13 +8,19 @@ import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.service.ExecContainerService
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.infrastructure.global.jwt.adapter.ParseTokenAdapter
+import com.dcd.server.presentation.domain.application.exception.InvalidConnectionInfoException
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.spyk
 import io.mockk.verify
+import org.springframework.security.core.Authentication
+import org.springframework.web.socket.WebSocketSession
 import util.application.ApplicationGenerator
+import util.user.UserGenerator
+import util.workspace.WorkspaceGenerator
 
 class ExecuteCommandUseCaseTest : BehaviorSpec({
     val queryApplicationPort = mockk<QueryApplicationPort>(relaxUnitFun = true)
@@ -65,5 +71,17 @@ class ExecuteCommandUseCaseTest : BehaviorSpec({
                 verify { commandPort.executeShellCommandWithResult(executedCmd) }
             }
         }
+    }
+
+    given("애플리케이션 id, session, cmd가 주어지고") {
+        val testApplicationId = "testApplicationId"
+        val session = mockk<WebSocketSession>()
+        val cmd = "testCmd"
+
+        val givenUser = UserGenerator.generateUser()
+        val givenAuthentication = spyk<Authentication>()
+        val givenToken = "${givenUser.id}"
+        val givenWorkspace = WorkspaceGenerator.generateWorkspace(user = givenUser)
+        val givenApplication = ApplicationGenerator.generateApplication(workspace = givenWorkspace, status = ApplicationStatus.RUNNING)
     }
 })


### PR DESCRIPTION
## 개요
* 웹소켓에서 사용하는 ExecuteCmdUseCase 테스트 코드 추가
## 작업내용
* 애플리케이션 상태가 실행중이지 않을때 에러 발생 로직 추가
* 웹소켓에서 사용하는 execute 메서드 테스트 환경 추가
* 세션에 엑세스 토큰이 존재하지 않는 테스트 케이스 추가
* 주어진 id를 가진 애플리케이션이 없는 테스트 케이스 추가
* 애플리케이션 상태가 올바르지 않은 테스트 케이스 추가
* execute 메서드가 정상적으로 실행되는 테스트 케이스 추가