### PR TITLE
🔀 :: [#344] - commandAdapter를 사용하는 서비스에서 exitValue에 따라 event를 발급하도록 수정

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CloneApplicationByUrlServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CloneApplicationByUrlServiceImpl.kt
@@ -4,6 +4,7 @@ import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.service.CloneApplicationByUrlService
+import com.dcd.server.core.domain.application.spi.CheckExitValuePort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Service
 @Service
 class CloneApplicationByUrlServiceImpl(
     private val queryApplicationPort: QueryApplicationPort,
+    private val checkExitValuePort: CheckExitValuePort,
     private val commandPort: CommandPort
 ) : CloneApplicationByUrlService {
     override suspend fun cloneById(id: String) {
@@ -19,7 +21,8 @@ class CloneApplicationByUrlServiceImpl(
             val application = (queryApplicationPort.findById(id)
                 ?: throw ApplicationNotFoundException())
             val githubUrl = application.githubUrl
-            commandPort.executeShellCommand("git clone $githubUrl ${application.name}")
+            val exitValue = commandPort.executeShellCommand("git clone $githubUrl ${application.name}")
+            checkExitValuePort.checkApplicationExitValue(exitValue, application, this)
         }
     }
 
@@ -27,6 +30,9 @@ class CloneApplicationByUrlServiceImpl(
         withContext(Dispatchers.IO) {
             val githubUrl = application.githubUrl
             commandPort.executeShellCommand("git clone $githubUrl ${application.name}")
+                .also {exitValue ->
+                    checkExitValuePort.checkApplicationExitValue(exitValue, application, this)
+                }
         }
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteApplicationDirectoryServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteApplicationDirectoryServiceImpl.kt
@@ -1,19 +1,27 @@
 package com.dcd.server.core.domain.application.service.impl
 
 import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.domain.application.event.ChangeApplicationStatusEvent
 import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.service.DeleteApplicationDirectoryService
+import com.dcd.server.core.domain.application.spi.CheckExitValuePort
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 
 @Service
 class DeleteApplicationDirectoryServiceImpl(
-    private val commandPort: CommandPort
+    private val commandPort: CommandPort,
+    private val checkExitValuePort: CheckExitValuePort
 ) : DeleteApplicationDirectoryService {
     override suspend fun deleteApplicationDirectory(application: Application) {
         withContext(Dispatchers.IO) {
             commandPort.executeShellCommand("rm -rf ${application.name}")
+                .also {exitValue ->
+                    checkExitValuePort.checkApplicationExitValue(exitValue, application, this)
+                }
         }
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteContainerServiceImpl.kt
@@ -3,18 +3,24 @@ package com.dcd.server.core.domain.application.service.impl
 import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.service.DeleteContainerService
+import com.dcd.server.core.domain.application.spi.CheckExitValuePort
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.springframework.stereotype.Service
 
 @Service
 class DeleteContainerServiceImpl(
-    private val commandPort: CommandPort
+    private val commandPort: CommandPort,
+    private val checkExitValuePort: CheckExitValuePort
 ) : DeleteContainerService {
     override suspend fun deleteContainer(application: Application) {
         withContext(Dispatchers.IO) {
             val name = application.name.lowercase()
-            commandPort.executeShellCommand("docker stop $name && docker rm $name")
+            commandPort.executeShellCommand("docker rm $name")
+                .also {exitValue ->
+                    if (exitValue != 0 && exitValue != 1)
+                        checkExitValuePort.checkApplicationExitValue(exitValue, application, this)
+                }
         }
     }
 

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteImageServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteImageServiceImpl.kt
@@ -3,17 +3,23 @@ package com.dcd.server.core.domain.application.service.impl
 import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.service.DeleteImageService
+import com.dcd.server.core.domain.application.spi.CheckExitValuePort
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.springframework.stereotype.Service
 
 @Service
 class DeleteImageServiceImpl(
-    private val commandPort: CommandPort
+    private val commandPort: CommandPort,
+    private val checkExitValuePort: CheckExitValuePort
 ) : DeleteImageService {
     override suspend fun deleteImage(application: Application) {
         withContext(Dispatchers.IO) {
             commandPort.executeShellCommand("docker rmi ${application.name.lowercase()}")
+                .also {exitValue ->
+                    if (exitValue != 0 && exitValue != 1)
+                        checkExitValuePort.checkApplicationExitValue(exitValue, application, this)
+                }
         }
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExistsPortServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExistsPortServiceImpl.kt
@@ -9,8 +9,7 @@ import org.springframework.stereotype.Service
 class ExistsPortServiceImpl (
     private val queryApplicationPort: QueryApplicationPort,
     private val commandPort: CommandPort
-)
-    : ExistsPortService {
+) : ExistsPortService {
     override fun existsPort(port: Int): Boolean {
         val commandResult = commandPort.executeShellCommandWithResult("lsof -i :${port}")
         return commandResult.isEmpty() && queryApplicationPort.existsByExternalPort(port)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/spi/CheckExitValuePort.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/spi/CheckExitValuePort.kt
@@ -1,0 +1,10 @@
+package com.dcd.server.core.domain.application.spi
+
+import com.dcd.server.core.domain.application.model.Application
+import kotlinx.coroutines.CoroutineScope
+
+interface CheckExitValuePort {
+    fun checkApplicationExitValue(exitValue: Int, application: Application)
+
+    fun checkApplicationExitValue(exitValue: Int, application: Application, coroutineScope: CoroutineScope)
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/spi/adapter/CheckExitValueAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/spi/adapter/CheckExitValueAdapter.kt
@@ -17,12 +17,15 @@ class CheckExitValueAdapter(
     private val log = LoggerFactory.getLogger(this::class.simpleName)
 
     override fun checkApplicationExitValue(exitValue: Int, application: Application) {
-        if (exitValue != 0)
+        if (exitValue != 0) {
+            log.error("${application.name} - $exitValue")
             eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application))
+        }
     }
 
     override fun checkApplicationExitValue(exitValue: Int, application: Application, coroutineScope: CoroutineScope) {
         if (exitValue != 0) {
+            log.error("${application.name} - $exitValue")
             eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application))
             coroutineScope.cancel()
         }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/spi/adapter/CheckExitValueAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/spi/adapter/CheckExitValueAdapter.kt
@@ -1,0 +1,30 @@
+package com.dcd.server.core.domain.application.spi.adapter
+
+import com.dcd.server.core.domain.application.event.ChangeApplicationStatusEvent
+import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
+import com.dcd.server.core.domain.application.spi.CheckExitValuePort
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+import org.slf4j.LoggerFactory
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+
+@Component
+class CheckExitValueAdapter(
+    private val eventPublisher: ApplicationEventPublisher
+) : CheckExitValuePort {
+    private val log = LoggerFactory.getLogger(this::class.simpleName)
+
+    override fun checkApplicationExitValue(exitValue: Int, application: Application) {
+        if (exitValue != 0)
+            eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application))
+    }
+
+    override fun checkApplicationExitValue(exitValue: Int, application: Application, coroutineScope: CoroutineScope) {
+        if (exitValue != 0) {
+            eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application))
+            coroutineScope.cancel()
+        }
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -63,4 +63,7 @@
     <logger name="CommandAdapter" level="info" additivity="true">
         <appender-ref ref="COMMAND_APPENDER"/>
     </logger>
+    <logger name="CheckExitValueAdapter" level="info" additivity="true">
+        <appender-ref ref="ERROR_ADAPTER"/>
+    </logger>
 </configuration>

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/BuildDockerImageServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/BuildDockerImageServiceImplTest.kt
@@ -5,6 +5,7 @@ import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.impl.BuildDockerImageServiceImpl
+import com.dcd.server.core.domain.application.spi.CheckExitValuePort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.auth.model.Role
 import com.dcd.server.core.domain.user.model.User
@@ -20,8 +21,8 @@ import java.util.*
 class BuildDockerImageServiceImplTest : BehaviorSpec({
     val commandPort = mockk<CommandPort>(relaxed = true)
     val queryApplicationPort = mockk<QueryApplicationPort>()
-    val eventPublisher = mockk<ApplicationEventPublisher>(relaxUnitFun = true)
-    val service = BuildDockerImageServiceImpl(commandPort, queryApplicationPort, eventPublisher)
+    val checkExitValuePort = mockk<CheckExitValuePort>(relaxUnitFun = true)
+    val service = BuildDockerImageServiceImpl(commandPort, queryApplicationPort, checkExitValuePort)
 
     val user = UserGenerator.generateUser()
     given("애플리케이션id가 주어지고") {

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/CloneApplicationByUrlServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/CloneApplicationByUrlServiceImplTest.kt
@@ -5,6 +5,7 @@ import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.impl.CloneApplicationByUrlServiceImpl
+import com.dcd.server.core.domain.application.spi.CheckExitValuePort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.auth.model.Role
 import com.dcd.server.core.domain.user.model.User
@@ -21,7 +22,8 @@ import java.util.*
 class CloneApplicationByUrlServiceImplTest : BehaviorSpec({
     val commandPort = mockk<CommandPort>(relaxed = true)
     val queryApplicationPort = mockk<QueryApplicationPort>()
-    val service = CloneApplicationByUrlServiceImpl(queryApplicationPort, commandPort)
+    val checkExitValuePort = mockk<CheckExitValuePort>(relaxUnitFun = true)
+    val service = CloneApplicationByUrlServiceImpl(queryApplicationPort, checkExitValuePort, commandPort)
 
     given("애플리케이션id가 주어지고") {
         val appId = UUID.randomUUID().toString()

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/CreateContainerServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/CreateContainerServiceImplTest.kt
@@ -2,20 +2,19 @@ package com.dcd.server.core.domain.application.service
 
 import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.domain.application.event.ChangeApplicationStatusEvent
-import com.dcd.server.core.domain.application.exception.ContainerNotCreatedException
 import com.dcd.server.core.domain.application.service.impl.CreateContainerServiceImpl
-import io.kotest.assertions.throwables.shouldThrow
+import com.dcd.server.core.domain.application.spi.CheckExitValuePort
 import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import org.springframework.context.ApplicationEventPublisher
+import kotlinx.coroutines.CoroutineScope
 import util.application.ApplicationGenerator
 
 class CreateContainerServiceImplTest : BehaviorSpec({
     val commandPort = mockk<CommandPort>(relaxed = true)
-    val eventPublisher = mockk<ApplicationEventPublisher>(relaxed = true)
-    val createContainerService = CreateContainerServiceImpl(commandPort, eventPublisher)
+    val checkExitValuePort = mockk<CheckExitValuePort>(relaxUnitFun = true)
+    val createContainerService = CreateContainerServiceImpl(commandPort, checkExitValuePort)
 
     given("애플리케이션이 주어지고") {
         val application = ApplicationGenerator.generateApplication()
@@ -31,21 +30,7 @@ class CreateContainerServiceImplTest : BehaviorSpec({
                         "-p ${application.externalPort}:${application.port} ${application.name.lowercase()}:latest"
                     )
                 }
-            }
-        }
-
-        `when`("만약 명령이 성공하지 못할때") {
-            every {
-                commandPort.executeShellCommand(
-                    "docker create --network ${application.workspace.title.replace(' ', '_')} " +
-                            "--name ${application.name.lowercase()} " +
-                            "-p ${application.externalPort}:${application.port} ${application.name.lowercase()}:latest"
-                )
-            } returns 125
-            createContainerService.createContainer(application, application.externalPort)
-
-            then("ContainerNotCreatedException이 발생해야함") {
-                verify { eventPublisher.publishEvent(any() as ChangeApplicationStatusEvent) }
+                verify { checkExitValuePort.checkApplicationExitValue(0, application, any() as CoroutineScope) }
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/CreateDockerFileServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/CreateDockerFileServiceImplTest.kt
@@ -5,18 +5,22 @@ import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.impl.CreateDockerFileServiceImpl
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.common.command.adapter.CommandAdapter
+import com.dcd.server.core.domain.application.spi.CheckExitValuePort
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
+import org.springframework.context.ApplicationEventPublisher
 import util.application.ApplicationGenerator
 import java.io.File
 
 class CreateDockerFileServiceImplTest : BehaviorSpec({
     val queryApplicationPort = mockk<QueryApplicationPort>()
     val commandPort = spyk(CommandAdapter())
-    val createDockerFileService = CreateDockerFileServiceImpl(queryApplicationPort, commandPort)
+    val eventPublisher = mockk<ApplicationEventPublisher>(relaxed = true)
+    val checkExitValuePort = mockk<CheckExitValuePort>(relaxUnitFun = true)
+    val createDockerFileService = CreateDockerFileServiceImpl(queryApplicationPort, commandPort, checkExitValuePort, eventPublisher)
 
     given("스프링 애플리케이션이 주어지고") {
         val application =

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/DeleteApplicationDirectoryServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/DeleteApplicationDirectoryServiceImplTest.kt
@@ -5,6 +5,7 @@ import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.impl.DeleteApplicationDirectoryServiceImpl
+import com.dcd.server.core.domain.application.spi.CheckExitValuePort
 import com.dcd.server.core.domain.auth.model.Role
 import com.dcd.server.core.domain.user.model.User
 import com.dcd.server.core.domain.workspace.model.Workspace
@@ -17,7 +18,8 @@ import java.util.*
 
 class DeleteApplicationDirectoryServiceImplTest : BehaviorSpec({
     val commandPort = mockk<CommandPort>(relaxed = true)
-    val service = DeleteApplicationDirectoryServiceImpl(commandPort)
+    val checkExitValuePort = mockk<CheckExitValuePort>(relaxUnitFun = true)
+    val service = DeleteApplicationDirectoryServiceImpl(commandPort, checkExitValuePort)
 
     given("애플리케이션이 주이지고") {
         val application = ApplicationGenerator.generateApplication()

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/DeleteContainerServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/DeleteContainerServiceImplTest.kt
@@ -20,7 +20,7 @@ class DeleteContainerServiceImplTest : BehaviorSpec({
             service.deleteContainer(application)
 
             then("commandPort가 실행되어야함") {
-                verify { commandPort.executeShellCommand("docker stop ${application.name.lowercase()} && docker rm ${application.name.lowercase()}") }
+                verify { commandPort.executeShellCommand("docker rm ${application.name.lowercase()}") }
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/DeleteContainerServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/DeleteContainerServiceImplTest.kt
@@ -2,6 +2,7 @@ package com.dcd.server.core.domain.application.service
 
 import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.domain.application.service.impl.DeleteContainerServiceImpl
+import com.dcd.server.core.domain.application.spi.CheckExitValuePort
 import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.mockk
 import io.mockk.verify
@@ -9,7 +10,8 @@ import util.application.ApplicationGenerator
 
 class DeleteContainerServiceImplTest : BehaviorSpec({
     val commandPort = mockk<CommandPort>(relaxed = true)
-    val service = DeleteContainerServiceImpl(commandPort)
+    val checkExitValuePort = mockk<CheckExitValuePort>(relaxUnitFun = true)
+    val service = DeleteContainerServiceImpl(commandPort, checkExitValuePort)
 
     given("애플리케이션이 주이지고") {
         val application = ApplicationGenerator.generateApplication()

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/DeleteImageServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/DeleteImageServiceImplTest.kt
@@ -2,6 +2,7 @@ package com.dcd.server.core.domain.application.service
 
 import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.domain.application.service.impl.DeleteImageServiceImpl
+import com.dcd.server.core.domain.application.spi.CheckExitValuePort
 import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.mockk
 import io.mockk.verify
@@ -9,7 +10,8 @@ import util.application.ApplicationGenerator
 
 class DeleteImageServiceImplTest : BehaviorSpec({
     val commandPort = mockk<CommandPort>(relaxed = true)
-    val deleteImageService = DeleteImageServiceImpl(commandPort)
+    val checkExitValuePort = mockk<CheckExitValuePort>(relaxUnitFun = true)
+    val deleteImageService = DeleteImageServiceImpl(commandPort, checkExitValuePort)
 
     given("애플리케이션이 주어지고") {
         val application = ApplicationGenerator.generateApplication()


### PR DESCRIPTION
## 개요
* commandAdappter를 사용하는 서비스에서 exitValue에 따라 event를 발급하도록 수정합니다.
## 작업내용
* CheckExitValuePort 추가
* checkExitValuePort를 사용해서 exitValue를 검증하는 로직 추가
* 테스트 코드 추가
* CheckExitValueAdapter에서 로깅하는 코드 추가