### PR TITLE
🔀 :: [#346] - 애플리케이션 이름에 공백을 허용하지 않도록 수정

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateDockerFileServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateDockerFileServiceImpl.kt
@@ -46,7 +46,7 @@ class CreateDockerFileServiceImpl(
         val mutableEnv = application.env.toMutableMap()
         mutableEnv.putAll(application.workspace.globalEnv)
 
-        commandPort.executeShellCommand("mkdir $name")
+        commandPort.executeShellCommand("mkdir -p $name")
             .also {exitValue ->
                 checkExitValuePort.checkApplicationExitValue(exitValue, application, coroutineScope)
             }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
@@ -57,6 +57,7 @@ class DeployApplicationUseCase(
             createContainerService.createContainer(application, externalPort)
 
             deleteApplicationDirectoryService.deleteApplicationDirectory(application)
+            eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.STOPPED, application))
         }
 
         eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.PENDING, application))

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationRequestDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationRequestDataExtension.kt
@@ -10,7 +10,7 @@ fun AddApplicationEnvRequest.toDto(): AddApplicationEnvReqDto =
 
 fun CreateApplicationRequest.toDto(): CreateApplicationReqDto =
     CreateApplicationReqDto(
-        name = this.name,
+        name = this.name.replace(" ", "-"),
         description = this.description,
         githubUrl = this.githubUrl,
         env = this.env,

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationRequestDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationRequestDataExtension.kt
@@ -21,7 +21,7 @@ fun CreateApplicationRequest.toDto(): CreateApplicationReqDto =
 
 fun UpdateApplicationRequest.toDto(): UpdateApplicationReqDto =
     UpdateApplicationReqDto(
-        name = this.name,
+        name = this.name.replace(" ", "-"),
         description = this.description,
         applicationType = this.applicationType,
         githubUrl = this.githubUrl,

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/CreateDockerFileServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/CreateDockerFileServiceImplTest.kt
@@ -30,7 +30,7 @@ class CreateDockerFileServiceImplTest : BehaviorSpec({
             createDockerFileService.createFileToApplication(application, application.version)
 
             then("애플리케이션의 이름을 가진 디렉토리를 생성해야함") {
-                verify { commandPort.executeShellCommand("mkdir ${application.name}") }
+                verify { commandPort.executeShellCommand("mkdir -p ${application.name}") }
             }
             then("실제로 애플리케이션 이름의 디렉토리가 생성되야함") {
                 commandPort.executeShellCommand("test -e ${application.name}") shouldBe 0
@@ -57,7 +57,7 @@ class CreateDockerFileServiceImplTest : BehaviorSpec({
             createDockerFileService.createFileToApplication(application, application.version)
 
             then("애플리케이션의 이름을 가진 디렉토리를 생성해야함") {
-                verify { commandPort.executeShellCommand("mkdir ${application.name}") }
+                verify { commandPort.executeShellCommand("mkdir -p ${application.name}") }
             }
             then("실제로 애플리케이션 이름의 디렉토리가 생성되야함") {
                 commandPort.executeShellCommand("test -e ${application.name}") shouldBe 0
@@ -83,7 +83,7 @@ class CreateDockerFileServiceImplTest : BehaviorSpec({
             createDockerFileService.createFileToApplication(application, application.version)
 
             then("애플리케이션의 이름을 가진 디렉토리를 생성해야함") {
-                verify { commandPort.executeShellCommand("mkdir ${application.name}") }
+                verify { commandPort.executeShellCommand("mkdir -p ${application.name}") }
             }
             then("실제로 애플리케이션 이름의 디렉토리가 생성되야함") {
                 commandPort.executeShellCommand("test -e ${application.name}") shouldBe 0
@@ -109,7 +109,7 @@ class CreateDockerFileServiceImplTest : BehaviorSpec({
             createDockerFileService.createFileToApplication(application, application.version)
 
             then("애플리케이션의 이름을 가진 디렉토리를 생성해야함") {
-                verify { commandPort.executeShellCommand("mkdir ${application.name}") }
+                verify { commandPort.executeShellCommand("mkdir -p ${application.name}") }
             }
             then("실제로 애플리케이션 이름의 디렉토리가 생성되야함") {
                 commandPort.executeShellCommand("test -e ${application.name}") shouldBe 0


### PR DESCRIPTION
## 개요
* 애플리케이션 이름에 공백을 허용하지 않도록 수정합니다.
## 작업내용
* 애플리케이션 생성시 이름에 공백이 포함되어 있다면, 공백을 하이폰으로 치환하게 수정
* 애플리케이션 수정시 이름에 공백이 포함되어 있다면, 공백을 하이폰으로 치환하게 수정
* 애플리케이션 배포후 STOPPED 상태로 변경하도록 수정
* 도커파일 생성시 mkdir의 -p 플래그를 사용하도록 수정