### PR TITLE
🔀 :: [#354] - 레이블로 애플리케이션을 배포하는 API 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/aop/OwnerValidateAspect.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/aop/OwnerValidateAspect.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.core.common.aop
 
+import com.dcd.server.core.common.data.WorkspaceInfo
 import com.dcd.server.core.domain.user.service.GetCurrentUserService
 import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
 import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameException
@@ -13,7 +14,8 @@ import org.springframework.stereotype.Component
 @Component
 class OwnerValidateAspect(
     private val getCurrentUserService: GetCurrentUserService,
-    private val queryWorkspacePort: QueryWorkspacePort
+    private val queryWorkspacePort: QueryWorkspacePort,
+    private val workspaceInfo: WorkspaceInfo
 ) {
     @Pointcut("@annotation(com.dcd.server.core.common.annotation.WorkspaceOwnerVerification)")
     fun workspaceOwnerVerificationPointcut() {}
@@ -28,5 +30,7 @@ class OwnerValidateAspect(
         val owner = workspace.owner
         if (owner.id != user.id)
             throw WorkspaceOwnerNotSameException()
+
+        workspaceInfo.workspace = workspace
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/common/data/WorkspaceInfo.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/data/WorkspaceInfo.kt
@@ -1,0 +1,9 @@
+package com.dcd.server.core.common.data
+
+import com.dcd.server.core.domain.workspace.model.Workspace
+import org.springframework.stereotype.Component
+
+@Component
+data class WorkspaceInfo(
+    var workspace: Workspace? = null
+)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
@@ -1,13 +1,16 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.common.data.WorkspaceInfo
 import com.dcd.server.core.domain.application.event.ChangeApplicationStatusEvent
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.exception.CanNotDeployApplicationException
+import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.*
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -24,7 +27,8 @@ class DeployApplicationUseCase(
     private val buildDockerImageService: BuildDockerImageService,
     private val createContainerService: CreateContainerService,
     private val deleteApplicationDirectoryService: DeleteApplicationDirectoryService,
-    private val eventPublisher: ApplicationEventPublisher
+    private val eventPublisher: ApplicationEventPublisher,
+    private val workspaceInfo: WorkspaceInfo
 ) : CoroutineScope by CoroutineScope(Dispatchers.IO) {
     fun execute(id: String) {
         val application = (queryApplicationPort.findById(id)
@@ -33,6 +37,24 @@ class DeployApplicationUseCase(
         if (application.status == ApplicationStatus.RUNNING || application.status == ApplicationStatus.PENDING)
             throw CanNotDeployApplicationException()
 
+        deployApplication(application)
+
+        eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.PENDING, application))
+    }
+
+    fun execute(labels: List<String>) {
+        val workspace = (workspaceInfo.workspace
+            ?: throw WorkspaceNotFoundException())
+
+        val applicationList = queryApplicationPort.findAllByWorkspace(workspace, labels)
+
+        applicationList.forEach {
+            deployApplication(it)
+            eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.PENDING, it))
+        }
+    }
+
+    private fun deployApplication(application: Application) {
         launch {
             deleteContainerService.deleteContainer(application)
             deleteImageService.deleteImage(application)
@@ -59,7 +81,5 @@ class DeployApplicationUseCase(
             deleteApplicationDirectoryService.deleteApplicationDirectory(application)
             eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.STOPPED, application))
         }
-
-        eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.PENDING, application))
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
@@ -49,11 +49,12 @@ class DeployApplicationUseCase(
         if (application.status == ApplicationStatus.RUNNING || application.status == ApplicationStatus.PENDING)
             throw CanNotDeployApplicationException()
 
-        launch {
-            deployApplication(application)
-        }
+        val success = deploymentChannel.trySend(application).isSuccess
 
-        eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.PENDING, application))
+        if (success)
+            eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.PENDING, application))
+        else
+            eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application))
     }
 
     fun execute(labels: List<String>) {

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
@@ -54,6 +54,7 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.POST, "/{workspaceId}/application/{id}/run").authenticated()
                 it.requestMatchers(HttpMethod.POST, "/{workspaceId}/application/{id}/stop").authenticated()
                 it.requestMatchers(HttpMethod.POST, "/{workspaceId}/application/{id}/deploy").authenticated()
+                it.requestMatchers(HttpMethod.POST, "/{workspaceId}/application/deploy").authenticated()
                 it.requestMatchers(HttpMethod.GET, "/{workspaceId}/application").authenticated()
                 it.requestMatchers(HttpMethod.GET, "/{workspaceId}/application/{id}").authenticated()
                 it.requestMatchers(HttpMethod.DELETE, "/{workspaceId}/application/{id}").authenticated()

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
@@ -52,6 +52,12 @@ class ApplicationWebAdapter(
         deployApplicationUseCase.execute(applicationId)
             .run { ResponseEntity.ok().build() }
 
+    @PostMapping("/deploy")
+    @WorkspaceOwnerVerification
+    fun deployApplicationWithLabels(@PathVariable workspaceId: String, @RequestParam labels: List<String>): ResponseEntity<Void> =
+        deployApplicationUseCase.execute(labels)
+            .run { ResponseEntity.ok().build() }
+
     @GetMapping
     @WorkspaceOwnerVerification
     fun getAllApplication(

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCaseTest.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.core.domain.application.usecase
 
+import com.dcd.server.core.common.data.WorkspaceInfo
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.exception.CanNotDeployApplicationException
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
@@ -26,6 +27,7 @@ class DeployApplicationUseCaseTest : BehaviorSpec({
     val createContainerService = mockk<CreateContainerService>(relaxUnitFun = true)
     val deleteApplicationDirectoryService = mockk<DeleteApplicationDirectoryService>(relaxUnitFun = true)
     val eventPublisher = mockk<ApplicationEventPublisher>(relaxUnitFun = true)
+    val workspaceInfo = WorkspaceInfo()
     val deployApplicationUseCase = DeployApplicationUseCase(
         queryApplicationPort,
         deleteContainerService,
@@ -36,7 +38,8 @@ class DeployApplicationUseCaseTest : BehaviorSpec({
         buildDockerImageService,
         createContainerService,
         deleteApplicationDirectoryService,
-        eventPublisher
+        eventPublisher,
+        workspaceInfo
     )
 
     given("애플리케이션 id가 주어지고") {


### PR DESCRIPTION
## 개요
* 레이블로 애플리케이션을 배포하는 API를 추가합니다.
## 작업내용
* WokrspaceInfo 추가
* 워크스페이스 검증후 workspaceInfo에 workspace를 넣는 로직 추가
* 레이블로 애플리케이션 배포 메서드 추가
* 레이블로 애플리케이션을 배포하는 엔드포인트 추가
* 테스트 코드 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 워크스페이스 ID와 레이블 목록을 사용하여 애플리케이션을 배포하는 새로운 POST 엔드포인트 추가.
	- `DeployApplicationUseCase`에서 애플리케이션 상태 확인 후 배포 로직을 포함하도록 수정.
	- 배포 애플리케이션을 위한 새로운 `WorkspaceInfo` 클래스 추가 및 관리 방식 개선.
	- `validWorkspaceOwner` 메서드에서 워크스페이스 정보를 저장하도록 기능 향상.

- **버그 수정**
	- 워크스페이스 정보가 없을 경우 `WorkspaceNotFoundException`을 발생시키도록 개선.

- **문서화**
	- `WorkspaceInfo` 데이터 클래스 추가 및 관리 방식 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->