### PR TITLE
🔀 :: [#356] - 라벨로 애플리케이션을 실행시키는 API 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCase.kt
@@ -43,19 +43,16 @@ class RunApplicationUseCase(
         val runChannel = Channel<Application>(capacity = Channel.UNLIMITED)
         val job = SupervisorJob()
         val scope = this + job
-        scope.launch {
-            applicationList.forEach {
-                if (it.status == ApplicationStatus.RUNNING)
-                    return@forEach
+        applicationList.forEach {
+            if (it.status == ApplicationStatus.RUNNING)
+                return@forEach
 
-                runChannel.trySend(it).isSuccess
-                changeApplicationStatusService.changeApplicationStatus(it, ApplicationStatus.PENDING)
-            }
-            runChannel.close()
+            runChannel.trySend(it).isSuccess
+            changeApplicationStatusService.changeApplicationStatus(it, ApplicationStatus.PENDING)
         }
 
         // 코루틴을 생성하여 작업 처리
-        List(3) {
+        repeat(3) {
             scope.launch {
                 for (application in runChannel) {
                     runContainerService.runApplication(application)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCase.kt
@@ -1,20 +1,24 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.common.data.WorkspaceInfo
+import com.dcd.server.core.domain.application.event.ChangeApplicationStatusEvent
 import com.dcd.server.core.domain.application.exception.AlreadyRunningException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
+import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.service.*
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
+import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.Channel
 
 @UseCase
 class RunApplicationUseCase(
     private val runContainerService: RunContainerService,
     private val queryApplicationPort: QueryApplicationPort,
-    private val changeApplicationStatusService: ChangeApplicationStatusService
+    private val changeApplicationStatusService: ChangeApplicationStatusService,
+    private val workspaceInfo: WorkspaceInfo
 ): CoroutineScope by CoroutineScope(Dispatchers.IO) {
     fun execute(id: String) {
         val application = (queryApplicationPort.findById(id)
@@ -28,5 +32,38 @@ class RunApplicationUseCase(
         }
 
         changeApplicationStatusService.changeApplicationStatus(application, ApplicationStatus.PENDING)
+    }
+
+    fun execute(labels: List<String>) {
+        val workspace = (workspaceInfo.workspace
+            ?: throw WorkspaceNotFoundException())
+
+        val applicationList = queryApplicationPort.findAllByWorkspace(workspace, labels)
+
+        val runChannel = Channel<Application>(capacity = Channel.UNLIMITED)
+        val job = SupervisorJob()
+        val scope = this + job
+        applicationList.forEach {
+            if (it.status == ApplicationStatus.RUNNING)
+                return@forEach
+
+            runChannel.trySend(it).isSuccess
+            changeApplicationStatusService.changeApplicationStatus(it, ApplicationStatus.PENDING)
+        }
+
+        // 코루틴을 생성하여 작업 처리
+        repeat(3) {
+            scope.launch {
+                for (application in runChannel) {
+                    runContainerService.runApplication(application)
+                }
+            }
+        }
+
+        // 작업 완료 후 코루틴 스코프 종료
+        scope.launch {
+            runChannel.close()
+            job.complete()
+        }
     }
 }

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
@@ -52,6 +52,7 @@ class SecurityConfig(
                 //application
                 it.requestMatchers(HttpMethod.POST, "/{workspaceId}/application").authenticated()
                 it.requestMatchers(HttpMethod.POST, "/{workspaceId}/application/{id}/run").authenticated()
+                it.requestMatchers(HttpMethod.POST, "/{workspaceId}/application/run").authenticated()
                 it.requestMatchers(HttpMethod.POST, "/{workspaceId}/application/{id}/stop").authenticated()
                 it.requestMatchers(HttpMethod.POST, "/{workspaceId}/application/{id}/deploy").authenticated()
                 it.requestMatchers(HttpMethod.POST, "/{workspaceId}/application/deploy").authenticated()

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
@@ -46,6 +46,12 @@ class ApplicationWebAdapter(
         runApplicationUseCase.execute(applicationId)
             .run { ResponseEntity.ok().build() }
 
+    @PostMapping("/run")
+    @WorkspaceOwnerVerification
+    fun runApplication(@PathVariable workspaceId: String, @RequestParam labels: List<String>): ResponseEntity<Void> =
+        runApplicationUseCase.execute(labels)
+            .run { ResponseEntity.ok().build() }
+
     @PostMapping("/{applicationId}/deploy")
     @WorkspaceOwnerVerification
     fun deployApplication(@PathVariable workspaceId: String, @PathVariable applicationId: String): ResponseEntity<Void> =

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCaseTest.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.core.domain.application.usecase
 
+import com.dcd.server.core.common.data.WorkspaceInfo
 import com.dcd.server.core.domain.application.exception.AlreadyRunningException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
@@ -20,10 +21,12 @@ class RunApplicationUseCaseTest : BehaviorSpec({
     val runContainerService = mockk<RunContainerService>(relaxUnitFun = true)
     val queryApplicationPort = mockk<QueryApplicationPort>(relaxUnitFun = true)
     val changeApplicationStatusService = mockk<ChangeApplicationStatusService>(relaxUnitFun = true)
+    val workspaceInfo = WorkspaceInfo()
     val runApplicationUseCase = RunApplicationUseCase(
         runContainerService,
         queryApplicationPort,
-        changeApplicationStatusService
+        changeApplicationStatusService,
+        workspaceInfo
     )
 
     val user = UserGenerator.generateUser()


### PR DESCRIPTION
## 개요
* 라벨로 애플리케이션을 실행시킬 수 있는 API를 추가합니다.
## 작업내용
* 애플리케이션을 라벨을 통해 실행하는 메서드 추가
* 애플리케이션을 라벨로 실행하는 엔드포인트 추가
* 기존 RunApplicationUseCase의 테스트 코드에 workspaceInfo 파라미터 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 여러 애플리케이션을 레이블로 실행할 수 있는 새로운 POST 엔드포인트 `/run` 추가.
	- 레이블을 사용하여 애플리케이션을 배포하는 새로운 POST 엔드포인트 `/deploy` 추가.
	- `RunApplicationUseCase` 클래스에 작업 공간 관련 데이터 관리 기능 향상.

- **보안 강화**
	- POST 요청에 대한 인증 접근을 허용하는 새로운 요청 매처 추가.

- **버그 수정**
	- 기존의 단일 애플리케이션 실행 기능 유지.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->