### PR TITLE
🔀 :: [#360] - 특정 라벨이 포함된 애플리케이션에 환경변수를 추가하는 API 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/AddApplicationEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/AddApplicationEnvUseCase.kt
@@ -1,16 +1,19 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.common.data.WorkspaceInfo
 import com.dcd.server.core.domain.application.dto.request.AddApplicationEnvReqDto
 import com.dcd.server.core.domain.application.exception.AlreadyExistsEnvException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
 
 @UseCase
 class AddApplicationEnvUseCase(
     private val queryApplicationPort: QueryApplicationPort,
-    private val commandApplicationPort: CommandApplicationPort
+    private val commandApplicationPort: CommandApplicationPort,
+    private val workspaceInfo: WorkspaceInfo
 ) {
     fun execute(id: String, addApplicationEnvReqDto: AddApplicationEnvReqDto) {
         val application = (queryApplicationPort.findById(id)
@@ -22,5 +25,23 @@ class AddApplicationEnvUseCase(
             envMutable[it.key] = it.value
         }
         commandApplicationPort.save(application.copy(env = envMutable))
+    }
+
+    fun execute(labels: List<String>, addApplicationEnvReqDto: AddApplicationEnvReqDto) {
+        val workspace = workspaceInfo.workspace
+            ?: throw WorkspaceNotFoundException()
+        val applicationList = queryApplicationPort.findAllByWorkspace(workspace, labels)
+
+        val updatedApplicationList = applicationList.map { application ->
+            val envMutable = application.env.toMutableMap()
+            addApplicationEnvReqDto.envList.forEach {
+                if (envMutable.containsKey(it.key)) throw AlreadyExistsEnvException()
+
+                envMutable[it.key] = it.value
+            }
+            application.copy(env = envMutable)
+        }
+
+        commandApplicationPort.saveAll(updatedApplicationList)
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/AddApplicationEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/AddApplicationEnvUseCase.kt
@@ -35,7 +35,7 @@ class AddApplicationEnvUseCase(
         val updatedApplicationList = applicationList.map { application ->
             val envMutable = application.env.toMutableMap()
             addApplicationEnvReqDto.envList.forEach {
-                if (envMutable.containsKey(it.key)) throw AlreadyExistsEnvException()
+                if (envMutable.containsKey(it.key)) return@forEach
 
                 envMutable[it.key] = it.value
             }

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
@@ -64,6 +64,7 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.GET, "/{workspaceId}/application/{id}/logs").authenticated()
                 it.requestMatchers(HttpMethod.POST, "/{workspaceId}/application/{id}/certificate").authenticated()
                 it.requestMatchers(HttpMethod.POST, "/{workspaceId}/application/{id}/env").authenticated()
+                it.requestMatchers(HttpMethod.POST, "/{workspaceId}/application/env").authenticated()
                 it.requestMatchers(HttpMethod.DELETE, "/{workspaceId}/application/{id}/env").authenticated()
                 it.requestMatchers(HttpMethod.PATCH, "/{workspaceId}/application/{applicationId}/env").authenticated()
                 it.requestMatchers(HttpMethod.GET, "/{workspaceId}/application/version/{applicationType}").authenticated()

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
@@ -89,6 +89,16 @@ class ApplicationWebAdapter(
         addApplicationEnvUseCase.execute(applicationId, addApplicationEnvRequest.toDto())
             .run { ResponseEntity.ok().build() }
 
+    @PostMapping("/env")
+    @WorkspaceOwnerVerification
+    fun addApplicationEnvWithLabels(
+        @PathVariable workspaceId: String,
+        @RequestParam labels: List<String>,
+        @RequestBody addApplicationEnvRequest: AddApplicationEnvRequest
+    ): ResponseEntity<Void> =
+        addApplicationEnvUseCase.execute(labels, addApplicationEnvRequest.toDto())
+            .run { ResponseEntity.ok().build() }
+
     @DeleteMapping("/{applicationId}/env")
     @WorkspaceOwnerVerification
     fun deleteApplicationEnv(

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/AddApplicationEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/AddApplicationEnvUseCaseTest.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.core.domain.application.usecase
 
+import com.dcd.server.core.common.data.WorkspaceInfo
 import com.dcd.server.core.domain.application.dto.request.AddApplicationEnvReqDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.Application
@@ -22,7 +23,8 @@ import java.util.*
 class AddApplicationEnvUseCaseTest : BehaviorSpec({
     val queryApplicationPort = mockk<QueryApplicationPort>()
     val commandApplicationPort = mockk<CommandApplicationPort>()
-    val addApplicationEnvUseCase = AddApplicationEnvUseCase(queryApplicationPort, commandApplicationPort)
+    val workspaceInfo = WorkspaceInfo()
+    val addApplicationEnvUseCase = AddApplicationEnvUseCase(queryApplicationPort, commandApplicationPort, workspaceInfo)
 
     given("request가 주어지고") {
         val request = AddApplicationEnvReqDto(


### PR DESCRIPTION
## 개요
* 특정 라벨이 포함된 애플리케이션에 환경변수를 추가하는 API를 추가합니다.
## 작업내용
* 라벨로 애플리케이션 env를 추가하는 로직 추가
* 라벨로 애플리케이션 env를 추가하는 엔드포인트 추가
* env 추가 테스트 코드에 workspaceInfo 파라미터 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- 애플리케이션 환경 변수를 추가하는 새로운 API 엔드포인트가 도입되었습니다. (`POST /{workspaceId}/application/env`)
	- 라벨 목록을 사용하여 애플리케이션 환경 변수를 추가할 수 있는 기능이 추가되었습니다.
  
- **Bug Fixes**
	- 기존의 애플리케이션 업데이트 기능이 유지되며, 새로운 메서드가 추가되어 여러 애플리케이션을 동시에 처리할 수 있습니다.

- **Tests**
	- 테스트에서 `WorkspaceInfo` 의존성이 추가되고, 새로운 생성자 매개변수가 포함되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->