### PR TITLE
🔀 :: [#382] - label이 포함된 애플리케이션의 환경변수를 수정하는 API 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationEnvUseCase.kt
@@ -1,16 +1,19 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.common.data.WorkspaceInfo
 import com.dcd.server.core.domain.application.dto.request.UpdateApplicationEnvReqDto
 import com.dcd.server.core.domain.application.exception.ApplicationEnvNotFoundException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
 
 @UseCase
 class UpdateApplicationEnvUseCase(
     private val queryApplicationPort: QueryApplicationPort,
-    private val commandApplicationPort: CommandApplicationPort
+    private val commandApplicationPort: CommandApplicationPort,
+    private val workspaceInfo: WorkspaceInfo
 ) {
     fun execute(applicationId: String, envKey: String, updateApplicationEnvReqDto: UpdateApplicationEnvReqDto) {
         val application = (queryApplicationPort.findById(applicationId)
@@ -27,5 +30,24 @@ class UpdateApplicationEnvUseCase(
                 env = mutableEnv
             )
         )
+    }
+
+    fun execute(labels: List<String>, envKey: String, updateApplicationEnvReqDto: UpdateApplicationEnvReqDto) {
+        val workspace = (workspaceInfo.workspace
+            ?: throw WorkspaceNotFoundException())
+
+        val applicationList = queryApplicationPort.findAllByWorkspace(workspace, labels)
+
+        val updatedApplicationList = applicationList.mapNotNull { application ->
+            val env = application.env
+            if (env.containsKey(envKey).not())
+                return@mapNotNull null
+
+            val mutableEnv = env.toMutableMap()
+            mutableEnv[envKey] = updateApplicationEnvReqDto.newValue
+            return@mapNotNull application.copy(env = mutableEnv)
+        }
+
+        commandApplicationPort.saveAll(updatedApplicationList)
     }
 }

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
@@ -67,6 +67,7 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.POST, "/{workspaceId}/application/env").authenticated()
                 it.requestMatchers(HttpMethod.DELETE, "/{workspaceId}/application/{id}/env").authenticated()
                 it.requestMatchers(HttpMethod.PATCH, "/{workspaceId}/application/{applicationId}/env").authenticated()
+                it.requestMatchers(HttpMethod.PATCH, "/{workspaceId}/application/env").authenticated()
                 it.requestMatchers(HttpMethod.GET, "/{workspaceId}/application/version/{applicationType}").authenticated()
                 it.requestMatchers(HttpMethod.POST, "/{workspaceId}/application/{id}/exec").authenticated()
                 it.requestMatchers(HttpMethod.GET, "/application/exec").authenticated()

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
@@ -120,6 +120,17 @@ class ApplicationWebAdapter(
         updateApplicationEnvUseCase.execute(applicationId, key, updateApplicationEnvRequest.toDto())
             .run { ResponseEntity.ok().build() }
 
+    @PatchMapping("/env")
+    @WorkspaceOwnerVerification
+    fun updateApplicationEnvWithLabels(
+        @PathVariable workspaceId: String,
+        @RequestParam labels: List<String>,
+        @RequestParam key: String,
+        @RequestBody updateApplicationEnvRequest: UpdateApplicationEnvRequest
+    ): ResponseEntity<Void> =
+        updateApplicationEnvUseCase.execute(labels, key, updateApplicationEnvRequest.toDto())
+            .run { ResponseEntity.ok().build() }
+
     @PostMapping("/{applicationId}/stop")
     @WorkspaceOwnerVerification
     fun stopApplication(@PathVariable workspaceId: String, @PathVariable applicationId: String): ResponseEntity<Void> =

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationEnvUseCaseTest.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.core.domain.application.usecase
 
+import com.dcd.server.core.common.data.WorkspaceInfo
 import com.dcd.server.core.domain.application.dto.request.UpdateApplicationEnvReqDto
 import com.dcd.server.core.domain.application.exception.ApplicationEnvNotFoundException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
@@ -16,7 +17,8 @@ import util.application.ApplicationGenerator
 class UpdateApplicationEnvUseCaseTest : BehaviorSpec({
     val queryApplicationPort = mockk<QueryApplicationPort>()
     val commandApplicationPort = mockk<CommandApplicationPort>(relaxUnitFun = true)
-    val updateApplicationEnvUseCase = UpdateApplicationEnvUseCase(queryApplicationPort, commandApplicationPort)
+    val workspaceInfo = WorkspaceInfo()
+    val updateApplicationEnvUseCase = UpdateApplicationEnvUseCase(queryApplicationPort, commandApplicationPort, workspaceInfo)
 
     given("애플리케이션 아이디와 수정할 환경변수값이 주어지고") {
         val applicationId = "testId"


### PR DESCRIPTION
## 개요
* label이 포함된 애플리케이션의 환경변수를 수정하는 API를 추가합니다.
## 작업내용
* labels로 애플리케이션 환경변수를 수정하는 메서드 추가
* labels로 애플리케이션 환경변수를 수정하는 엔드포인트 추가
* 환경변수 수정 테스트 코드 파라미터 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- 애플리케이션 환경을 레이블에 따라 일괄 업데이트할 수 있는 기능 추가.
	- PATCH 요청을 위한 새로운 엔드포인트 `/env` 추가, 워크스페이스 소유자 확인 필요.
  
- **Bug Fixes**
	- 특정 워크스페이스에 대한 환경 키가 없을 경우 예외 처리 개선.

- **Chores**
	- 보안 구성을 업데이트하여 특정 엔드포인트에 대한 인증 요구 사항 강화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->