### PR TITLE
🔀 :: [#364] - 라벨로 애플리케이션의 환경변수를 제거하는 API 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationEnvUseCase.kt
@@ -1,15 +1,18 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.common.data.WorkspaceInfo
 import com.dcd.server.core.domain.application.exception.ApplicationEnvNotFoundException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
 
 @UseCase
 class DeleteApplicationEnvUseCase(
     private val queryApplicationPort: QueryApplicationPort,
-    private val commandApplicationPort: CommandApplicationPort
+    private val commandApplicationPort: CommandApplicationPort,
+    private val workspaceInfo: WorkspaceInfo
 ) {
     fun execute(id: String, key: String) {
         val application = (queryApplicationPort.findById(id)
@@ -18,5 +21,23 @@ class DeleteApplicationEnvUseCase(
         updatedEnv.remove(key)
             ?: throw ApplicationEnvNotFoundException()
         commandApplicationPort.save(application.copy(env = updatedEnv))
+    }
+
+    fun execute(labels: List<String>, key: String) {
+        val workspace = (workspaceInfo.workspace
+            ?: throw WorkspaceNotFoundException())
+
+        val applicationList = queryApplicationPort.findAllByWorkspace(workspace, labels)
+        val updatedApplicationList = applicationList.mapNotNull { application ->
+            val env = application.env
+
+            val mutableEnv = env.toMutableMap()
+            mutableEnv.remove(key)
+                ?: return@mapNotNull null
+
+            return@mapNotNull application.copy(env = mutableEnv)
+        }
+
+        commandApplicationPort.saveAll(updatedApplicationList)
     }
 }

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
@@ -66,6 +66,7 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.POST, "/{workspaceId}/application/{id}/env").authenticated()
                 it.requestMatchers(HttpMethod.POST, "/{workspaceId}/application/env").authenticated()
                 it.requestMatchers(HttpMethod.DELETE, "/{workspaceId}/application/{id}/env").authenticated()
+                it.requestMatchers(HttpMethod.DELETE, "/{workspaceId}/application/env").authenticated()
                 it.requestMatchers(HttpMethod.PATCH, "/{workspaceId}/application/{applicationId}/env").authenticated()
                 it.requestMatchers(HttpMethod.PATCH, "/{workspaceId}/application/env").authenticated()
                 it.requestMatchers(HttpMethod.GET, "/{workspaceId}/application/version/{applicationType}").authenticated()

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
@@ -109,6 +109,16 @@ class ApplicationWebAdapter(
         deleteApplicationEnvUseCase.execute(applicationId, key)
             .run { ResponseEntity.ok().build() }
 
+    @DeleteMapping("/env")
+    @WorkspaceOwnerVerification
+    fun deleteApplicationEnvWithLabels(
+        @PathVariable workspaceId: String,
+        @RequestParam labels: List<String>,
+        @RequestParam key: String
+    ): ResponseEntity<Void> =
+        deleteApplicationEnvUseCase.execute(labels, key)
+            .run { ResponseEntity.ok().build() }
+
     @PatchMapping("/{applicationId}/env")
     @WorkspaceOwnerVerification
     fun updateApplicationEnv(

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationEnvUseCaseTest.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.core.domain.application.usecase
 
+import com.dcd.server.core.common.data.WorkspaceInfo
 import com.dcd.server.core.domain.application.exception.ApplicationEnvNotFoundException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.Application
@@ -22,7 +23,8 @@ import java.util.*
 class DeleteApplicationEnvUseCaseTest : BehaviorSpec({
     val queryApplicationPort = mockk<QueryApplicationPort>()
     val commandApplicationPort = mockk<CommandApplicationPort>()
-    val deleteApplicationEnvUseCase = DeleteApplicationEnvUseCase(queryApplicationPort, commandApplicationPort)
+    val workspaceInfo = WorkspaceInfo()
+    val deleteApplicationEnvUseCase = DeleteApplicationEnvUseCase(queryApplicationPort, commandApplicationPort, workspaceInfo)
 
     given("애플리케이션 Id와 삭제할 key가 주어지고") {
         val applicationId = "testId"


### PR DESCRIPTION
## 개요
* 라벨로 애플리케이션의 환경변수를 제거하는 API를 추가합니다.
## 작업내용
* 라벨로 애플리케이션의 환경변수를 제거하는 메서드 추가
* 라벨로 애플리케이션의 환경변수를 제거하는 엔드포인트 추가
* 엔드포인트 제거 테스트 코드에 workspaceInfo 파라미터 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- 새로운 메서드 `deleteApplicationEnvWithLabels` 추가: 레이블을 사용하여 애플리케이션 환경 변수를 삭제할 수 있는 기능 제공.
	- `execute` 메서드 오버로드 추가: 레이블 목록과 키를 사용하여 환경 변수를 삭제하는 기능 추가.
- **Bug Fixes**
	- 작업 공간을 찾을 수 없는 경우 예외 처리 개선: `WorkspaceNotFoundException` 추가.
- **Security**
	- DELETE 요청에 대한 인증 요구 사항 추가: `/{workspaceId}/application/env` 엔드포인트 보호.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->