### PR TITLE
🔀 :: [#368] - 애플리케이션의 내부에서 명령을 실행할때 다중 명령 실행시 컨테이너 외부에서 실행되는 현상 수정

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCase.kt
@@ -30,7 +30,7 @@ class ExecuteCommandUseCase(
             throw InvalidApplicationStatusException()
 
         val result =
-            commandPort.executeShellCommandWithResult("docker exec ${application.name.lowercase()} ${executeCommandReqDto.command}")
+            commandPort.executeShellCommandWithResult("docker exec ${application.name.lowercase()} sh -c '${executeCommandReqDto.command}'")
 
         return CommandResultResDto(result)
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCase.kt
@@ -30,7 +30,7 @@ class ExecuteCommandUseCase(
             throw InvalidApplicationStatusException()
 
         val result =
-            commandPort.executeShellCommandWithResult("docker exec ${application.name.lowercase()} sh -c '${executeCommandReqDto.command}'")
+            commandPort.executeShellCommandWithResult("docker exec ${application.name.lowercase()} sh -c 'cd / && ${executeCommandReqDto.command}'")
 
         return CommandResultResDto(result)
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCaseTest.kt
@@ -37,7 +37,7 @@ class ExecuteCommandUseCaseTest : BehaviorSpec({
         val request = ExecuteCommandReqDto(cmd)
 
         val givenApplication = ApplicationGenerator.generateApplication(id = applicationId, status = ApplicationStatus.RUNNING)
-        val executedCmd = "docker exec ${givenApplication.name.lowercase()} $cmd"
+        val executedCmd = "docker exec ${givenApplication.name.lowercase()} sh -c 'cd / && $cmd'"
         val testCmdResult = listOf("test cmd result")
 
         `when`("주어진 아이디를 가진 애플리케이션이 없을때") {


### PR DESCRIPTION
## 개요
* 애플리케이션의 내부에서 명령을 실행할때 다중 명령 실행시 컨테이너 외부에서 실행되는 현상을 수정합니다.
## 작업내용
* API 호출을 통해 커맨드 실행시 `sh -c '{입력받은 커맨드}'`를 통해 실행하도록 수정해서 && || 와 같은 입력에서도 애플리케이션 내부에서 명령을 실행할 수 있도록 수정
* 커맨드가 실행되는 경로를 기본 경로로 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 명령 실행 로직이 개선되어 더 복잡한 명령어 실행이 가능해졌습니다.

- **버그 수정**
	- 기존 명령어 실행 방식에서 쉘 환경을 고려한 명령어 실행 방식으로 변경되었습니다.

- **테스트**
	- 명령어 실행 테스트가 업데이트되어 새로운 명령어 실행 환경을 반영했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->