### PR TITLE
🔀 :: [#370] - 커맨드 실행의 제약조건 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
@@ -14,6 +14,7 @@ enum class ErrorCode(
     APPLICATION_ALREADY_RUNNING("해당 애플리케이션은 이미 실행중임", 400),
     APPLICATION_ALREADY_STOPPED("해당 애플리케이션은 이미 정지됨", 400),
     ALREADY_EXISTS_APPLICATION_ENV("해당 키값을 가지는 환경변수가 이미 존재함", 400),
+    INVALID_CMD("올바르지 않은 커맨드 형식", 400),
 
     UNAUTHORIZED("권한이 없음", 401),
     EXPIRED_TOKEN("토큰이 만료됨", 401),

--- a/src/main/kotlin/com/dcd/server/core/domain/application/exception/InvalidCmdException.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/exception/InvalidCmdException.kt
@@ -1,0 +1,7 @@
+package com.dcd.server.core.domain.application.exception
+
+import com.dcd.server.core.common.error.BasicException
+import com.dcd.server.core.common.error.ErrorCode
+
+class InvalidCmdException : BasicException(ErrorCode.INVALID_CMD) {
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCase.kt
@@ -24,6 +24,8 @@ class ExecuteCommandUseCase(
     private val commandPort: CommandPort
 ) {
     fun execute(applicationId: String, executeCommandReqDto: ExecuteCommandReqDto): CommandResultResDto {
+        validateCmd(executeCommandReqDto.command)
+
         val application = (queryApplicationPort.findById(applicationId)
             ?: throw ApplicationNotFoundException())
 
@@ -37,6 +39,8 @@ class ExecuteCommandUseCase(
     }
 
     fun execute(applicationId: String, session: WebSocketSession, cmd: String) {
+        validateCmd(cmd)
+
         val accessToken = (session.attributes["accessToken"] as? String
             ?: throw InvalidConnectionInfoException("세션에 인증 정보가 존재하지 않음", CloseStatus.PROTOCOL_ERROR))
 

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCase.kt
@@ -6,6 +6,7 @@ import com.dcd.server.core.domain.application.dto.request.ExecuteCommandReqDto
 import com.dcd.server.core.domain.application.dto.response.CommandResultResDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.exception.InvalidApplicationStatusException
+import com.dcd.server.core.domain.application.exception.InvalidCmdException
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.service.ExecContainerService
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
@@ -51,5 +52,13 @@ class ExecuteCommandUseCase(
             throw WorkspaceOwnerNotSameException()
 
         execContainerService.execCmd(application, session, cmd)
+    }
+
+    private fun validateCmd(cmd: String) {
+        val forbiddenPatterns = listOf(";", "`", "$")
+        if (cmd.length > 100)
+            throw InvalidCmdException()
+        else if (forbiddenPatterns.any { cmd.contains(it) })
+            throw InvalidCmdException()
     }
 }


### PR DESCRIPTION
## 개요
* 커맨드 실행의 제약조건을 추가합니다.
## 작업내용
* InvalidCmdException 추가
* validateCmd 메서드 추가
* cmd 실행 로직에서 validateCmd를 호출하도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 명령 유효성 검사를 위한 `InvalidCmdException` 예외 클래스 추가.
	- 새로운 오류 코드 `INVALID_CMD` 추가로 명령 유효성 관련 오류 처리 개선.
	- 명령 실행 전 유효성 검사를 수행하는 기능 강화.

- **버그 수정**
	- 잘못된 명령어 형식에 대한 오류 처리를 통해 보안 문제 및 실행 오류 예방.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->