### PR TITLE
🔀 :: [#372] - 애플리케이션 생성후 생성된 애플리케이션의 아이디를 반환하도록 수정

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/response/CreateApplicationResDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/response/CreateApplicationResDto.kt
@@ -1,0 +1,5 @@
+package com.dcd.server.core.domain.application.dto.response
+
+data class CreateApplicationResDto(
+    val applicationId: String
+)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCase.kt
@@ -3,6 +3,7 @@ package com.dcd.server.core.domain.application.usecase
 import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.domain.application.dto.extenstion.toEntity
 import com.dcd.server.core.domain.application.dto.request.CreateApplicationReqDto
+import com.dcd.server.core.domain.application.dto.response.CreateApplicationResDto
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.*
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
@@ -24,7 +25,7 @@ class CreateApplicationUseCase(
     private val createContainerService: CreateContainerService,
     private val deleteApplicationDirectoryService: DeleteApplicationDirectoryService
 ) : CoroutineScope by CoroutineScope(Dispatchers.IO) {
-    fun execute(workspaceId: String, createApplicationReqDto: CreateApplicationReqDto) {
+    fun execute(workspaceId: String, createApplicationReqDto: CreateApplicationReqDto): CreateApplicationResDto {
         val workspace = queryWorkspacePort.findById(workspaceId)
             ?: throw WorkspaceNotFoundException()
 
@@ -51,5 +52,7 @@ class CreateApplicationUseCase(
 
             deleteApplicationDirectoryService.deleteApplicationDirectory(application)
         }
+
+        return CreateApplicationResDto(application.id)
     }
 }

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
@@ -38,7 +38,7 @@ class ApplicationWebAdapter(
         @Validated @RequestBody createApplicationRequest: CreateApplicationRequest
     ): ResponseEntity<CreateApplicationResponse> =
         createApplicationUseCase.execute(workspaceId, createApplicationRequest.toDto())
-            .let { ResponseEntity.ok(it.toResponse()) }
+            .run { ResponseEntity(toResponse(), HttpStatus.CREATED) }
 
     @PostMapping("/{applicationId}/run")
     @WorkspaceOwnerVerification

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
@@ -36,9 +36,9 @@ class ApplicationWebAdapter(
     fun createApplication(
         @PathVariable workspaceId: String,
         @Validated @RequestBody createApplicationRequest: CreateApplicationRequest
-    ): ResponseEntity<Void> =
+    ): ResponseEntity<CreateApplicationResponse> =
         createApplicationUseCase.execute(workspaceId, createApplicationRequest.toDto())
-            .run { ResponseEntity(HttpStatus.CREATED) }
+            .let { ResponseEntity.ok(it.toResponse()) }
 
     @PostMapping("/{applicationId}/run")
     @WorkspaceOwnerVerification

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationResponseDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationResponseDataExtension.kt
@@ -58,3 +58,8 @@ fun CommandResultResDto.toResponse(): CommandResultResponse =
     CommandResultResponse(
         result = this.result
     )
+
+fun CreateApplicationResDto.toResponse(): CreateApplicationResponse =
+    CreateApplicationResponse(
+        applicationId = this.applicationId
+    )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/response/CreateApplicationResponse.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/response/CreateApplicationResponse.kt
@@ -1,0 +1,5 @@
+package com.dcd.server.presentation.domain.application.data.response
+
+data class CreateApplicationResponse(
+    val applicationId: String
+)

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -55,7 +55,7 @@ class ApplicationWebAdapterTest : BehaviorSpec({
             val result = applicationWebAdapter.createApplication(testWorkspaceId, request)
             then("상태코드가 201이여야함") {
                 verify { createApplicationUseCase.execute(testWorkspaceId, any()) }
-                result.statusCode shouldBe HttpStatus.OK
+                result.statusCode shouldBe HttpStatus.CREATED
             }
             then("응답은 생성된 애플리케이션 아이디를 반환해야함") {
                 result.body?.applicationId shouldBe "testApplicationId"

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -51,10 +51,14 @@ class ApplicationWebAdapterTest : BehaviorSpec({
         )
 
         `when`("createApplication 메서드를 실행할때") {
-            every { createApplicationUseCase.execute(testWorkspaceId, any()) } returns Unit
+            every { createApplicationUseCase.execute(testWorkspaceId, any()) } returns CreateApplicationResDto("testApplicationId")
             val result = applicationWebAdapter.createApplication(testWorkspaceId, request)
             then("상태코드가 201이여야함") {
-                result.statusCode shouldBe HttpStatus.CREATED
+                verify { createApplicationUseCase.execute(testWorkspaceId, any()) }
+                result.statusCode shouldBe HttpStatus.OK
+            }
+            then("응답은 생성된 애플리케이션 아이디를 반환해야함") {
+                result.body?.applicationId shouldBe "testApplicationId"
             }
         }
     }


### PR DESCRIPTION
## 개요
* 애플리케이션 생성후 생성된 애플리케이션의 아이디를 반환하도록 수정합니다.
## 작업내용
* CreateApplicationResDto 추가
* 애플리케이션 생성후 생성된 애플리케이션 아이디를 반환하도록 수정
* CreateApplicationResponse추가
* 애플리케이션 생성 엔드포인트에서 CreateApplicationResponse를 반환하도록 수정
* 애플리케이션 생성 엔드포인트 테스트 코드 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- 새로운 응답 데이터 클래스 `CreateApplicationResponse` 추가: 애플리케이션 생성 시 응답 구조를 제공.
	- `CreateApplicationResDto` 클래스 추가: 애플리케이션 ID를 포함하는 응답 DTO.
	- `createApplication` 메서드가 `CreateApplicationResponse`를 반환하도록 변경.
	- `execCommand` 메서드가 `CommandResultResponse`를 반환하도록 변경.

- **Bug Fixes**
	- 테스트 케이스에서 응답 상태 코드 및 본문 검증을 업데이트하여 일관성 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->