### PR TITLE
🔀 :: [#376] - 워크스페이스 수정 API의 엔드포인트에대한 접근권한이 없음

### DIFF
--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
@@ -78,6 +78,7 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.GET, "/workspace").authenticated()
                 it.requestMatchers(HttpMethod.GET, "/workspace/{workspaceId}").authenticated()
                 it.requestMatchers(HttpMethod.DELETE, "/workspace/{workspaceId}").authenticated()
+                it.requestMatchers(HttpMethod.PUT, "/workspace/{workspaceId}").authenticated()
                 it.requestMatchers(HttpMethod.POST, "/workspace/{workspaceId}/env").authenticated()
                 it.requestMatchers(HttpMethod.DELETE, "/workspace/{workspaceId}/env").authenticated()
                 it.requestMatchers(HttpMethod.PATCH, "/workspace/{workspaceId}/env").authenticated()


### PR DESCRIPTION
## 개요
* 워크스페이스 수정 API의 엔드포인트에대한 접근권한이 없음
## 작업내용
* 워크스페이스 수정 엔드포인트에대한 접근 권한 설정 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- `/workspace/{workspaceId}` 엔드포인트에 대한 HTTP PUT 요청에 대해 인증이 필요하도록 보안 구성이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->