### PR TITLE
🔀 :: [#382] - nginx를 재실행하는 서비스 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/RebootNginxService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/RebootNginxService.kt
@@ -1,0 +1,5 @@
+package com.dcd.server.core.domain.application.service
+
+interface RebootNginxService {
+    fun rebootNginx()
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/RebootNginxContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/RebootNginxContainerServiceImpl.kt
@@ -1,0 +1,19 @@
+package com.dcd.server.core.domain.application.service.impl
+
+import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.domain.application.service.RebootNginxService
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+@Service
+class RebootNginxContainerServiceImpl(
+    private val commandPort: CommandPort
+) : RebootNginxService {
+    private val log = LoggerFactory.getLogger(this::class.simpleName)
+
+    override fun rebootNginx() {
+        val exitValue = commandPort.executeShellCommand("docker restart dcd-nginx")
+        if (exitValue != 0)
+            log.error("nginx restart failure")
+    }
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/SetApplicationDomainUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/SetApplicationDomainUseCase.kt
@@ -5,6 +5,7 @@ import com.dcd.server.core.domain.application.dto.request.SetDomainReqDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.exception.InvalidDomainFormatException
 import com.dcd.server.core.domain.application.service.GenerateHttpConfigService
+import com.dcd.server.core.domain.application.service.RebootNginxService
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.user.service.GetCurrentUserService
 import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameException
@@ -13,7 +14,8 @@ import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameExcep
 class SetApplicationDomainUseCase(
     private val queryApplicationPort: QueryApplicationPort,
     private val getCurrentUserService: GetCurrentUserService,
-    private val generateHttpConfigService: GenerateHttpConfigService
+    private val generateHttpConfigService: GenerateHttpConfigService,
+    private val rebootNginxService: RebootNginxService
 ) {
     fun execute(applicationId: String, setDomainReqDto: SetDomainReqDto) {
         val domain = setDomainReqDto.domain
@@ -29,5 +31,6 @@ class SetApplicationDomainUseCase(
             throw WorkspaceOwnerNotSameException()
 
         generateHttpConfigService.generateWebServerConfig(application, domain)
+        rebootNginxService.rebootNginx()
     }
 }


### PR DESCRIPTION
## 개요
* 도메인 세팅후 nginx를 재실행하는 서비스를 추가합니다.
## 작업내용
* RebootNginxService 추가
* Nginx 컨테이너 재실행 서비스 추가
* 도메인 세팅 유스케이스에 nginx 재실행 적용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- Nginx 서비스를 재부팅하는 `RebootNginxService` 인터페이스 추가.
	- `RebootNginxContainerServiceImpl` 클래스가 Nginx 재부팅 기능을 구현.
	- 애플리케이션 도메인 설정 과정에 Nginx 재부팅 단계 추가.

- **버그 수정**
	- Nginx 재부팅 실패 시 오류 메시지 로깅 기능 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->