### PR TITLE
🔀 :: [#384] - dcd 실행에 필요한 도커 컴포즈 파일 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,10 @@
 version: "3.8"
 
+networks:
+  default:
+    external:
+      name: dcd
+
 services:
   db:
     container_name: dcd-db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3.8"
+
+services:
+  db:
+    container_name: dcd-db
+    image: mariadb
+    env_file: dcd-db.env
+    ports:
+      - 3307:3306

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,12 @@ services:
     env_file: dcd-db.env
     ports:
       - 3307:3306
+  redis:
+    container_name: dcd-redis
+    image: redis
+    env_file: dcd-redis.env
+    environment:
+      - REDIS_DISABLE_COMMANDS=FLUSHDB,FLUSHALL
+    ports:
+      - 6378:6379
+    command: ["redis-server", "--requirepass", "$$REDIS_PASSWORD"]


### PR DESCRIPTION
## 개요
* dcd 실행에 필요한 도커 컴포즈 파일을 추가합니다.
## 작업내용
* db 설정 추가
* redis 설정 추가
* 네트워크 설정 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 다중 컨테이너 Docker 애플리케이션을 위한 새로운 `docker-compose.yml` 구성 파일 추가.
	- MariaDB 및 Redis 서비스 설정.
	- MariaDB는 호스트의 3307 포트를 컨테이너의 3306 포트에 매핑.
	- Redis는 호스트의 6378 포트를 컨테이너의 6379 포트에 매핑하고 비밀번호 요구 사항 설정.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->