### PR TITLE
🔀 :: [#386] - 도커 컴포즈 파일을 실행할 수 없는 현상 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ networks:
 
 services:
   db:
-    platform: linux/arm/v7
     container_name: dcd-db
     image: linuxserver/mariadb:arm32v7-latest
     env_file: dcd-db.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
   db:
     container_name: dcd-db
     image: mariadb:11.7-rc
-    platform: linux/arm64
     env_file: dcd-db.env
     ports:
       - 3307:3306
@@ -17,7 +16,6 @@ services:
     container_name: dcd-redis
     image: redis:7.4.1-alpine
     env_file: dcd-redis.env
-    platform: linux/arm64
     environment:
       - REDIS_DISABLE_COMMANDS=FLUSHDB,FLUSHALL
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,12 +7,14 @@ networks:
 
 services:
   db:
+    platform: linux/arm/v7
     container_name: dcd-db
     image: mariadb:11.7-rc
     env_file: dcd-db.env
     ports:
       - 3307:3306
   redis:
+    platform: linux/arm/v7
     container_name: dcd-redis
     image: redis:7.4.1-alpine
     env_file: dcd-redis.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - 3307:3306
   redis:
     container_name: dcd-redis
-    image: redis
+    image: redis:7.4.1-alpine
     env_file: dcd-redis.env
     platform: linux/arm64
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ networks:
 services:
   db:
     container_name: dcd-db
-    image: mariadb
+    image: mariadb:11.7-rc
     platform: linux/arm64
     env_file: dcd-db.env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,8 @@ networks:
 services:
   db:
     container_name: dcd-db
-    image: linuxserver/mariadb:arm32v7-latest
+    image: yobasystems/alpine-mariadb:latest
+    platform: "linux/arm"
     env_file: dcd-db.env
     ports:
       - 3307:3306

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
   db:
     platform: linux/arm/v7
     container_name: dcd-db
-    image: mariadb:11.7-rc
+    image: linuxserver/mariadb:arm32v7-latest
     env_file: dcd-db.env
     ports:
       - 3307:3306


### PR DESCRIPTION
## 개요
* 도커 컴포즈 파일을 실행할 수 없는 현상 수정을 수정합니다.
## 작업내용
* dcd-db 이미지 버전 지정
* dcd-redis 이미지 버전 지정
* 서비스의 platform 제거
* 서비스 플랫폼 수정
* db 이미지 수정
* db에서 platform 제거
* db에서 사용하는 이미지 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 데이터베이스 및 Redis 서비스의 이미지와 플랫폼 업데이트.
	- MariaDB와 Redis의 특정 버전으로 전환.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->