### PR TITLE
🔀 :: [#390] - 애플리케이션의 컨테이너 생성시 부모 네트워크에 연결하는 로직 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateContainerServiceImpl.kt
@@ -24,6 +24,12 @@ class CreateContainerServiceImpl(
                 .also {exitValue ->
                     checkExitValuePort.checkApplicationExitValue(exitValue, application, this)
                 }
+
+            val dcdNetworkConnectCmd = "docker network connect dcd ${application.name.lowercase()}"
+            commandPort.executeShellCommand(dcdNetworkConnectCmd)
+                .also {exitValue ->
+                    checkExitValuePort.checkApplicationExitValue(exitValue, application, this)
+                }
         }
     }
 }


### PR DESCRIPTION
## 개요
* 애플리케이션의 컨테이너를 생성할때 부모 네트워크에 속해있도록 하는 로직을 추가합니다.
## 작업내용
* dcd 네트워크에 생성되는 컨테이너를 연결하는 로직 추가