### PR TITLE
🔀 :: [#392] - 애플리케이션 및 워크스페이스 이름 중복시 에러

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
@@ -17,7 +17,8 @@ enum class ErrorCode(
     INVALID_CMD("올바르지 않은 커맨드 형식", 400),
     INVALID_DOMAIN_FORMAT("도매인 포맷이 올바르지 않음", 400),
     FAILURE_HTTP_CONFIG("Http 설정 생성에 실패함", 400),
-    ALREADY_EXISTS_APPLICATION("이미 존재하는 이름의 애플리케이션임", 400),
+    ALREADY_EXISTS_APPLICATION("이미 존재하는 이름의 애플리케이션", 400),
+    ALREADY_EXISTS_WORKSPACE("이미 존재하는 워크스페이스", 400),
 
     UNAUTHORIZED("권한이 없음", 401),
     EXPIRED_TOKEN("토큰이 만료됨", 401),

--- a/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
@@ -17,6 +17,7 @@ enum class ErrorCode(
     INVALID_CMD("올바르지 않은 커맨드 형식", 400),
     INVALID_DOMAIN_FORMAT("도매인 포맷이 올바르지 않음", 400),
     FAILURE_HTTP_CONFIG("Http 설정 생성에 실패함", 400),
+    ALREADY_EXISTS_APPLICATION("이미 존재하는 이름의 애플리케이션임", 400),
 
     UNAUTHORIZED("권한이 없음", 401),
     EXPIRED_TOKEN("토큰이 만료됨", 401),

--- a/src/main/kotlin/com/dcd/server/core/domain/application/exception/AlreadyExistsApplicationException.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/exception/AlreadyExistsApplicationException.kt
@@ -1,0 +1,8 @@
+package com.dcd.server.core.domain.application.exception
+
+import com.dcd.server.core.common.error.BasicException
+import com.dcd.server.core.common.error.ErrorCode
+
+class AlreadyExistsApplicationException : BasicException(ErrorCode.ALREADY_EXISTS_APPLICATION) {
+
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/spi/QueryApplicationPort.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/spi/QueryApplicationPort.kt
@@ -10,4 +10,5 @@ interface QueryApplicationPort {
     fun findById(id: String): Application?
     fun existsByExternalPort(externalPort: Int): Boolean
     fun findAllByStatus(status: ApplicationStatus): List<Application>
+    fun existsByName(name: String): Boolean
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/exception/AlreadyExistsWorkspaceException.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/exception/AlreadyExistsWorkspaceException.kt
@@ -1,0 +1,8 @@
+package com.dcd.server.core.domain.workspace.exception
+
+import com.dcd.server.core.common.error.BasicException
+import com.dcd.server.core.common.error.ErrorCode
+
+class AlreadyExistsWorkspaceException : BasicException(ErrorCode.ALREADY_EXISTS_WORKSPACE) {
+
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/spi/QueryWorkspacePort.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/spi/QueryWorkspacePort.kt
@@ -7,5 +7,5 @@ interface QueryWorkspacePort {
     fun findById(id: String): Workspace?
     fun findAll(): List<Workspace>
     fun findByUser(user: User): List<Workspace>
-    fun existsByTitle(name: String): Boolean
+    fun existsByTitle(title: String): Boolean
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/spi/QueryWorkspacePort.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/spi/QueryWorkspacePort.kt
@@ -6,6 +6,6 @@ import com.dcd.server.core.domain.workspace.model.Workspace
 interface QueryWorkspacePort {
     fun findById(id: String): Workspace?
     fun findAll(): List<Workspace>
-
     fun findByUser(user: User): List<Workspace>
+    fun existsByTitle(name: String): Boolean
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/CreateWorkspaceUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/CreateWorkspaceUseCase.kt
@@ -5,17 +5,23 @@ import com.dcd.server.core.domain.user.service.GetCurrentUserService
 import com.dcd.server.core.domain.workspace.dto.extension.toEntity
 import com.dcd.server.core.domain.workspace.dto.request.CreateWorkspaceReqDto
 import com.dcd.server.core.domain.workspace.dto.response.CreateWorkspaceResDto
+import com.dcd.server.core.domain.workspace.exception.AlreadyExistsWorkspaceException
 import com.dcd.server.core.domain.workspace.service.CreateNetworkService
 import com.dcd.server.core.domain.workspace.spi.CommandWorkspacePort
+import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
 
 @UseCase
 class CreateWorkspaceUseCase(
     private val commandWorkspacePort: CommandWorkspacePort,
+    private val queryWorkspacePort: QueryWorkspacePort,
     private val currentUserService: GetCurrentUserService,
     private val createNetworkService: CreateNetworkService
 ) {
     fun execute(createWorkspaceReqDto: CreateWorkspaceReqDto): CreateWorkspaceResDto {
         val currentUser = currentUserService.getCurrentUser()
+
+        if (queryWorkspacePort.existsByTitle(createWorkspaceReqDto.title))
+            throw AlreadyExistsWorkspaceException()
 
         val workspace = createWorkspaceReqDto.toEntity(currentUser)
         commandWorkspacePort.save(workspace)

--- a/src/main/kotlin/com/dcd/server/persistence/application/ApplicationPersistenceAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/application/ApplicationPersistenceAdapter.kt
@@ -48,4 +48,7 @@ class ApplicationPersistenceAdapter(
     override fun findAllByStatus(status: ApplicationStatus): List<Application> =
         applicationRepository.findAllByStatus(status)
             .map { it.toDomain() }
+
+    override fun existsByName(name: String): Boolean =
+        applicationRepository.existsByName(name)
 }

--- a/src/main/kotlin/com/dcd/server/persistence/application/repository/ApplicationRepository.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/application/repository/ApplicationRepository.kt
@@ -16,4 +16,5 @@ interface ApplicationRepository : JpaRepository<ApplicationJpaEntity, String> {
     ): List<ApplicationJpaEntity>
     fun existsByExternalPort(externalPort: Int): Boolean
     fun findAllByStatus(status: ApplicationStatus): List<ApplicationJpaEntity>
+    fun existsByName(name: String): Boolean
 }

--- a/src/main/kotlin/com/dcd/server/persistence/workspace/WorkspacePersistenceAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/workspace/WorkspacePersistenceAdapter.kt
@@ -28,6 +28,9 @@ class WorkspacePersistenceAdapter(
         return workspaceRepository.findAllByOwner(user.toEntity()).map { it.toDomain() }
     }
 
+    override fun existsByTitle(title: String): Boolean =
+        workspaceRepository.existsByTitle(title)
+
     override fun save(workspace: Workspace) {
         workspaceRepository.save(workspace.toEntity())
     }

--- a/src/main/kotlin/com/dcd/server/persistence/workspace/repository/WorkspaceRepository.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/workspace/repository/WorkspaceRepository.kt
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface WorkspaceRepository : JpaRepository<WorkspaceJpaEntity, String> {
     fun findAllByOwner(user: UserJpaEntity): List<WorkspaceJpaEntity>
+    fun existsByTitle(title: String): Boolean
 }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
@@ -6,6 +6,7 @@ import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.*
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
+import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.auth.exception.UserNotFoundException
 import com.dcd.server.core.domain.auth.model.Role
 import com.dcd.server.core.domain.user.model.User
@@ -25,6 +26,7 @@ import java.util.*
 
 class CreateApplicationUseCaseTest : BehaviorSpec({
     val commandApplicationPort = mockk<CommandApplicationPort>()
+    val queryApplicationPort = mockk<QueryApplicationPort>()
     val queryUserPort = mockk<QueryUserPort>()
     val securityService = mockk<SecurityService>()
     val queryWorkspacePort = mockk<QueryWorkspacePort>()
@@ -37,6 +39,7 @@ class CreateApplicationUseCaseTest : BehaviorSpec({
     val deleteApplicationDirectoryService = mockk<DeleteApplicationDirectoryService>(relaxUnitFun = true)
     val createApplicationUseCase = CreateApplicationUseCase(
         commandApplicationPort,
+        queryApplicationPort,
         queryWorkspacePort,
         cloneApplicationByUrlService,
         modifyGradleService,
@@ -63,6 +66,7 @@ class CreateApplicationUseCaseTest : BehaviorSpec({
         val id = user.id
         `when`("usecase를 실행하면") {
             every { securityService.getCurrentUserId() } returns id
+            every { queryApplicationPort.existsByName(request.name) } returns false
             every { queryUserPort.findById(id) } returns user
             every { commandApplicationPort.save(any()) } answers { callOriginal() }
             every { queryWorkspacePort.findById(workspace.id) } returns workspace

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/CreateWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/CreateWorkspaceUseCaseTest.kt
@@ -7,6 +7,7 @@ import com.dcd.server.core.domain.workspace.dto.request.CreateWorkspaceReqDto
 import com.dcd.server.core.domain.workspace.model.Workspace
 import com.dcd.server.core.domain.workspace.service.CreateNetworkService
 import com.dcd.server.core.domain.workspace.spi.CommandWorkspacePort
+import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
 import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.every
 import io.mockk.mockk
@@ -15,10 +16,11 @@ import util.user.UserGenerator
 
 class CreateWorkspaceUseCaseTest : BehaviorSpec({
     val commandWorkspacePort = mockk<CommandWorkspacePort>(relaxed = true)
+    val queryWorkspacePort = mockk<QueryWorkspacePort>()
     val getCurrentUserService = mockk<GetCurrentUserService>(relaxed = true)
     val createNetworkService = mockk<CreateNetworkService>(relaxed = true)
     val createWorkspaceUseCase =
-        CreateWorkspaceUseCase(commandWorkspacePort, getCurrentUserService, createNetworkService)
+        CreateWorkspaceUseCase(commandWorkspacePort, queryWorkspacePort, getCurrentUserService, createNetworkService)
 
     given("request가 주어지고") {
         val createWorkspaceReqDto = CreateWorkspaceReqDto(
@@ -28,6 +30,7 @@ class CreateWorkspaceUseCaseTest : BehaviorSpec({
         `when`("useCase를 실행할때") {
             val user = UserGenerator.generateUser()
             every { getCurrentUserService.getCurrentUser() } returns user
+            every { queryWorkspacePort.existsByTitle(createWorkspaceReqDto.title) } returns false
             createWorkspaceUseCase.execute(createWorkspaceReqDto)
             then("워크스페이스를 저장하고 네트워크를 생성해야함") {
                 verify { getCurrentUserService.getCurrentUser() }


### PR DESCRIPTION
## 개요
* 애플리케이션 및 워크스페이스 이름 중복시 에러를 발생시키도록 수정합니다.
## 작업내용
* AlreadyExistsApplicationException 추가
* existsByName 메서드 추가
* 애플리케이션 생성시 애플리케이션 이름을 검증하는 로직 추가
* AlreadyExistsWorkspaceException 추가
* existsByTitle 메서드 추가
* 워크스페이스 생성시 워크스페이스 이름을 검증하는 로직 추가
* 테스트 코드 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 애플리케이션 및 워크스페이스의 이름 중복 체크 기능 추가.
	- `QueryApplicationPort` 및 `QueryWorkspacePort` 인터페이스에 존재 여부 확인 메서드 추가.
- **예외 처리**
	- 애플리케이션 및 워크스페이스 중복 생성 시 발생하는 예외 클래스 추가.
- **버그 수정**
	- 애플리케이션 및 워크스페이스 생성 로직에 중복 체크 로직 추가로 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->