### PR TITLE
🔀 :: [#396] - 도커 베이스 이미지 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk
+FROM eclipse-temurin:17-jdk
 ARG JAR_FILE=build/libs/server-0.0.1-SNAPSHOT.jar
 COPY ${JAR_FILE} dcd-server.jar
 ENV TZ=Asia/Seoul


### PR DESCRIPTION
## 개요
* dcd의 베이스 32bit 환경에서 이미지가 정상적으로 동작하도록 수정합니다.
## 작업내용
* openjdk 대신 eclipse-temurin 이미지를 사용하도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 애플리케이션 실행 환경의 기본 이미지가 `openjdk:17-jdk`에서 `eclipse-temurin:17-jdk`로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->