### PR TITLE
🔀 :: [#398] - 웹 어뎁터 어노테이션 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/presentation/common/annotation/WebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/common/annotation/WebAdapter.kt
@@ -1,0 +1,12 @@
+package com.dcd.server.presentation.common.annotation
+
+import org.springframework.core.annotation.AliasFor
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping
+annotation class WebAdapter(
+    @get:AliasFor(annotation = RequestMapping::class)
+    val value: String = ""
+)

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
@@ -3,6 +3,7 @@ package com.dcd.server.presentation.domain.application
 import com.dcd.server.core.common.annotation.WorkspaceOwnerVerification
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.usecase.*
+import com.dcd.server.presentation.common.annotation.WebAdapter
 import com.dcd.server.presentation.domain.application.data.exetension.toDto
 import com.dcd.server.presentation.domain.application.data.exetension.toResponse
 import com.dcd.server.presentation.domain.application.data.request.*
@@ -12,8 +13,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
 
-@RestController
-@RequestMapping("/{workspaceId}/application")
+@WebAdapter("/{workspaceId}/application")
 class ApplicationWebAdapter(
     private val createApplicationUseCase: CreateApplicationUseCase,
     private val runApplicationUseCase: RunApplicationUseCase,

--- a/src/main/kotlin/com/dcd/server/presentation/domain/auth/AuthWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/auth/AuthWebAdapter.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.presentation.domain.auth
 
 import com.dcd.server.core.domain.auth.usecase.*
+import com.dcd.server.presentation.common.annotation.WebAdapter
 import com.dcd.server.presentation.domain.auth.data.exetension.toDto
 import com.dcd.server.presentation.domain.auth.data.exetension.toReissueResponse
 import com.dcd.server.presentation.domain.auth.data.exetension.toResponse
@@ -18,8 +19,7 @@ import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
-@RestController
-@RequestMapping("/auth")
+@WebAdapter("/auth")
 class AuthWebAdapter(
     private val authMailSendUseCase: AuthMailSendUseCase,
     private val signUpUseCase: SignUpUseCase,

--- a/src/main/kotlin/com/dcd/server/presentation/domain/user/UserWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/user/UserWebAdapter.kt
@@ -5,6 +5,7 @@ import com.dcd.server.core.domain.user.usecase.ChangePasswordUseCase
 import com.dcd.server.core.domain.user.usecase.ChangeUserStatusUseCase
 import com.dcd.server.core.domain.user.usecase.GetUserByStatusUseCase
 import com.dcd.server.core.domain.user.usecase.GetUserProfileUseCase
+import com.dcd.server.presentation.common.annotation.WebAdapter
 import com.dcd.server.presentation.domain.user.data.exetension.toDto
 import com.dcd.server.presentation.domain.user.data.exetension.toResponse
 import com.dcd.server.presentation.domain.user.data.request.PasswordChangeRequest
@@ -19,8 +20,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
-@RestController
-@RequestMapping("/user")
+@WebAdapter("/user")
 class UserWebAdapter(
     private val getUserProfileUseCase: GetUserProfileUseCase,
     private val changePasswordUseCase: ChangePasswordUseCase,

--- a/src/main/kotlin/com/dcd/server/presentation/domain/workspace/WorkspaceWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/workspace/WorkspaceWebAdapter.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.presentation.domain.workspace
 
 import com.dcd.server.core.domain.workspace.usecase.*
+import com.dcd.server.presentation.common.annotation.WebAdapter
 import com.dcd.server.presentation.domain.workspace.data.exetension.toDto
 import com.dcd.server.presentation.domain.workspace.data.exetension.toResponse
 import com.dcd.server.presentation.domain.workspace.data.request.AddGlobalEnvRequest
@@ -14,8 +15,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
-@RestController
-@RequestMapping("/workspace")
+@WebAdapter("/workspace")
 class WorkspaceWebAdapter(
     private val createWorkspaceUseCase: CreateWorkspaceUseCase,
     private val getAllWorkspaceUseCase: GetAllWorkspaceUseCase,


### PR DESCRIPTION
## 개요
* 웹 어뎁터 어노테이션을 추가합니다.
  * RestController, RequestMapping을 더한 어노테이션
## 작업내용
* WebAdapter 어노테이션 추가
* WorkspaceWebAdapter에 WebAdapter 어노테이션 적용
* UserWebAdapter에 WebAdapter 어노테이션 적용
* AuthWebAdapter에 WebAdapter 어노테이션 적용
* ApplicationWebAdapter에 WebAdapter 어노테이션 적용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- 새로운 `@WebAdapter` 애노테이션이 도입되어 웹 컨트롤러로서의 역할을 정의합니다.
  
- **변경 사항**
	- 기존의 `@RestController` 애노테이션이 `@WebAdapter`로 변경되었습니다.
	- 각 웹 어댑터 클래스에서 HTTP 요청 처리 방식에 변화가 있을 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->