### PR TITLE
🔀 :: [#410] - SignOutUseCaseTest 리펙토링

### DIFF
--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/SignOutUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/SignOutUseCaseTest.kt
@@ -21,10 +21,19 @@ import util.TestInitializer
 @SpringBootTest(classes = [ServerApplication::class])
 class SignOutUseCaseTest(
     private val signOutUseCase: SignOutUseCase,
+    @MockkBean
+    private val securityService: SecurityService,
+    private val commandRefreshTokenPort: CommandRefreshTokenPort,
     private val queryRefreshTokenPort: QueryRefreshTokenPort
 ) : BehaviorSpec({
 
     val targetUserId = "user1"
+
+    beforeContainer {
+        every { securityService.getCurrentUserId() } returns targetUserId
+        val refreshToken = RefreshToken(userId = targetUserId, token = "testToken", refreshTTL = 10L)
+        commandRefreshTokenPort.save(refreshToken)
+    }
 
     given("targetUserId가 주어지고") {
         `when`("useCase를 실행할때") {

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/SignOutUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/SignOutUseCaseTest.kt
@@ -35,6 +35,10 @@ class SignOutUseCaseTest(
         commandRefreshTokenPort.save(refreshToken)
     }
 
+    afterContainer {
+        commandRefreshTokenPort.delete(queryRefreshTokenPort.findByUserId(targetUserId))
+    }
+
     given("targetUserId가 주어지고") {
         `when`("useCase를 실행할때") {
             signOutUseCase.execute()

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/SignOutUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/SignOutUseCaseTest.kt
@@ -1,32 +1,36 @@
 package com.dcd.server.core.domain.auth.usecase
 
+import com.dcd.server.ServerApplication
 import com.dcd.server.core.common.service.SecurityService
 import com.dcd.server.core.domain.auth.model.RefreshToken
 import com.dcd.server.core.domain.auth.spi.CommandRefreshTokenPort
 import com.dcd.server.core.domain.auth.spi.QueryRefreshTokenPort
+import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
+import util.TestInitializer
 
-class SignOutUseCaseTest : BehaviorSpec({
-    val commandRefreshTokenPort = mockk<CommandRefreshTokenPort>()
-    val queryRefreshTokenPort = mockk<QueryRefreshTokenPort>()
-    val securityService = mockk<SecurityService>()
-    val signOutUseCase = SignOutUseCase(commandRefreshTokenPort, queryRefreshTokenPort, securityService)
+@ActiveProfiles("test")
+@Import(TestInitializer::class)
+@SpringBootTest(classes = [ServerApplication::class])
+class SignOutUseCaseTest(
+    private val signOutUseCase: SignOutUseCase,
+    private val queryRefreshTokenPort: QueryRefreshTokenPort
+) : BehaviorSpec({
 
-    given("userId, RefreshToken이 주어지고") {
-        val userId = "testUserId"
-        val testToken = "testToken"
-        val refreshToken = RefreshToken(userId = userId, token = testToken, refreshTTL = 10L)
+    val targetUserId = "user1"
+
+    given("targetUserId가 주어지고") {
         `when`("useCase를 실행할때") {
-            val tokenList = listOf(refreshToken)
-            every { queryRefreshTokenPort.findByUserId(userId) } returns tokenList
-            every { commandRefreshTokenPort.delete(tokenList) } returns Unit
-            every { securityService.getCurrentUserId() } returns userId
             signOutUseCase.execute()
-            then("commandRefreshTokenPort의 delete메서드를 실행해야함") {
-                verify { commandRefreshTokenPort.delete(tokenList) }
+            then("targetUserId를 가진 refreshToken이 없어야함") {
+                queryRefreshTokenPort.findByUserId(targetUserId).isEmpty() shouldBe true
             }
         }
 


### PR DESCRIPTION
## 개요
* SignOutUseCaseTest를 리펙토링합니다.
## 작업내용
* SignOutUseCaseTest 테스트 케이스 수정
* 미리 테스트 컨테이너 시작전에 리프레시 토큰을 저장하도록 수정
* 컨테이너 동작후 남아있는 리프레시 토큰을 제거하도록 수정