### PR TITLE
🔀 :: [#412] - 인증 메일 전송 유스케이스 테스트 코드 리펙토링

### DIFF
--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/AuthMailSendUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/AuthMailSendUseCaseTest.kt
@@ -1,22 +1,33 @@
 package com.dcd.server.core.domain.auth.usecase
 
+import com.dcd.server.ServerApplication
 import com.dcd.server.core.domain.auth.dto.request.EmailSendReqDto
 import com.dcd.server.core.domain.auth.service.EmailSendService
+import com.dcd.server.core.domain.auth.spi.QueryEmailAuthPort
+import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import io.mockk.verify
+import jakarta.mail.internet.MimeMessage
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.mail.javamail.JavaMailSender
+import org.springframework.test.context.ActiveProfiles
 
-class AuthMailSendUseCaseTest : BehaviorSpec({
-    val emailSendService = mockk<EmailSendService>()
-    val useCase = AuthMailSendUseCase(emailSendService)
+@ActiveProfiles("test")
+@SpringBootTest(classes = [ServerApplication::class])
+class AuthMailSendUseCaseTest(
+    private val authMailSendUseCase: AuthMailSendUseCase,
+    @MockkBean(relaxUnitFun = true)
+    private val emailSendService: EmailSendService
+) : BehaviorSpec({
 
     given("EmailSendRequestData가 주어지고") {
         val testEmail = "testEmail"
         val request = EmailSendReqDto(testEmail)
         `when`("execute메서드를 실행할때") {
-            coEvery { emailSendService.sendEmail(testEmail) } returns Unit
-            useCase.execute(request)
+            authMailSendUseCase.execute(request)
             then("emailSendService의 sendEmail메서드를 실행해아함") {
                 coVerify { emailSendService.sendEmail(testEmail) }
             }


### PR DESCRIPTION
## 개요
* 인증 메일 전송 유스케이스 테스트 코드를 리펙토링합니다.
## 작업내용
* AuthMailSendUseCaseTest 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트**
	- 테스트 클래스의 구조 및 종속성 수정.
	- Spring Boot 컨텍스트에서 통합 테스트를 위한 설정 추가.
	- 새로운 생성자 매개변수로 `authMailSendUseCase` 및 모의 `emailSendService` 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->