### PR TITLE
🔀 :: [#414] - 인증 메일 검증 유스케이스 테스트  코드 리펙토링

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
@@ -37,7 +37,7 @@ enum class ErrorCode(
     APPLICATION_ENV_NOT_FOUND("해당 환경변수를 찾을 수 없음", 404),
     GLOBAL_ENV_NOT_FOUND("해당 환경변수를 찾을 수 없음", 404),
     WORKSPACE_NOT_FOUND("해당 워크스페이스를 찾을 수 없음", 404),
-    AUTH_CODE_NOT_FOUND("인증 코드를 찾을 수 업습니다. 코드를 다시 전송 해주세요.", 404),
+    AUTH_CODE_NOT_FOUND("인증 코드를 찾을 수 없습니다. 코드를 다시 전송 해주세요.", 404),
 
     CONFLICT("해당 요청은 서버의 상태와 충돌됩니다.", 409),
     CAN_NOT_DEPLOY_APPLICATION("애플리케이션을 배포할 수 없습니다. 애플리케이션을 정지시킨 후 실행해주세요.", 409),

--- a/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
@@ -37,6 +37,7 @@ enum class ErrorCode(
     APPLICATION_ENV_NOT_FOUND("해당 환경변수를 찾을 수 없음", 404),
     GLOBAL_ENV_NOT_FOUND("해당 환경변수를 찾을 수 없음", 404),
     WORKSPACE_NOT_FOUND("해당 워크스페이스를 찾을 수 없음", 404),
+    AUTH_CODE_NOT_FOUND("인증 코드를 찾을 수 업습니다. 코드를 다시 전송 해주세요.", 404),
 
     CONFLICT("해당 요청은 서버의 상태와 충돌됩니다.", 409),
     CAN_NOT_DEPLOY_APPLICATION("애플리케이션을 배포할 수 없습니다. 애플리케이션을 정지시킨 후 실행해주세요.", 409),

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/exception/NotFoundAuthCodeException.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/exception/NotFoundAuthCodeException.kt
@@ -1,0 +1,7 @@
+package com.dcd.server.core.domain.auth.exception
+
+import com.dcd.server.core.common.error.BasicException
+import com.dcd.server.core.common.error.ErrorCode
+
+class NotFoundAuthCodeException : BasicException(ErrorCode.AUTH_CODE_NOT_FOUND) {
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/service/impl/VerifyEmailAuthServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/service/impl/VerifyEmailAuthServiceImpl.kt
@@ -2,6 +2,7 @@ package com.dcd.server.core.domain.auth.service.impl
 
 import com.dcd.server.core.domain.auth.exception.ExpiredCodeException
 import com.dcd.server.core.domain.auth.exception.InvalidAuthCodeException
+import com.dcd.server.core.domain.auth.exception.NotFoundAuthCodeException
 import com.dcd.server.core.domain.auth.service.VerifyEmailAuthService
 import com.dcd.server.core.domain.auth.spi.CommandEmailAuthPort
 import com.dcd.server.core.domain.auth.spi.QueryEmailAuthPort
@@ -16,6 +17,8 @@ class VerifyEmailAuthServiceImpl(
         if (!queryEmailAuthPort.existsByCodeAndEmail(email, code))
             if (queryEmailAuthPort.existsByEmail(email))
                 throw InvalidAuthCodeException()
+            else
+                throw NotFoundAuthCodeException()
         val emailAuth = (queryEmailAuthPort.findByCode(code)
             ?: throw ExpiredCodeException())
         commandEmailAuthPort.save(emailAuth.copy(certificate = true))

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/service/impl/VerifyEmailAuthServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/service/impl/VerifyEmailAuthServiceImpl.kt
@@ -14,11 +14,11 @@ class VerifyEmailAuthServiceImpl(
     private val commandEmailAuthPort: CommandEmailAuthPort
 ) : VerifyEmailAuthService {
     override fun verifyCode(email: String, code: String) {
-        if (!queryEmailAuthPort.existsByCodeAndEmail(email, code))
+        if (!queryEmailAuthPort.existsByCodeAndEmail(email, code)) {
             if (queryEmailAuthPort.existsByEmail(email))
                 throw InvalidAuthCodeException()
-            else
-                throw NotFoundAuthCodeException()
+            throw NotFoundAuthCodeException()
+        }
         val emailAuth = (queryEmailAuthPort.findByCode(code)
             ?: throw ExpiredCodeException())
         commandEmailAuthPort.save(emailAuth.copy(certificate = true))

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/service/VerifyEmailAuthServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/service/VerifyEmailAuthServiceImplTest.kt
@@ -2,6 +2,7 @@ package com.dcd.server.core.domain.auth.service
 
 import com.dcd.server.core.domain.auth.exception.ExpiredCodeException
 import com.dcd.server.core.domain.auth.exception.InvalidAuthCodeException
+import com.dcd.server.core.domain.auth.exception.NotFoundAuthCodeException
 import com.dcd.server.core.domain.auth.model.EmailAuth
 import com.dcd.server.core.domain.auth.service.impl.VerifyEmailAuthServiceImpl
 import com.dcd.server.core.domain.auth.spi.CommandEmailAuthPort
@@ -26,13 +27,13 @@ class VerifyEmailAuthServiceImplTest : BehaviorSpec({
             every { queryEmailAuthPort.existsByEmail(testEmail) } returns false
             every { queryEmailAuthPort.findByCode(testCode) } returns null
             then("코드가 만료되었다면 ExpiredEmailAuthCodeException이 throw되야함") {
-                shouldThrow<ExpiredCodeException> {
+                shouldThrow<NotFoundAuthCodeException> {
                     serviceImpl.verifyCode(testEmail, testCode)
                 }
             }
 
             every { queryEmailAuthPort.existsByEmail(testEmail) } returns true
-            then("코드가 옳바르지 않으면 InvalidAuthCodeException이 throw되야함") {
+            then("코드가 올바르지 않으면 InvalidAuthCodeException이 throw되야함") {
                 shouldThrow<InvalidAuthCodeException> {
                     serviceImpl.verifyCode(testEmail, testCode)
                 }
@@ -42,7 +43,7 @@ class VerifyEmailAuthServiceImplTest : BehaviorSpec({
             every { queryEmailAuthPort.findByCode(testCode) } returns EmailAuth(testEmail, testCode, false)
             every { commandEmailAuthPort.save(any()) } answers { callOriginal() }
             serviceImpl.verifyCode(testEmail, testCode)
-            then("코드도 옳바르면 업데이트 되야함") {
+            then("코드도 올바르면 업데이트 되야함") {
                 verify { commandEmailAuthPort.save(any()) }
             }
         }

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/AuthenticateMailUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/AuthenticateMailUseCaseTest.kt
@@ -1,26 +1,55 @@
 package com.dcd.server.core.domain.auth.usecase
 
+import com.dcd.server.ServerApplication
 import com.dcd.server.core.domain.auth.dto.request.CertificateMailReqDto
+import com.dcd.server.core.domain.auth.exception.ExpiredCodeException
+import com.dcd.server.core.domain.auth.exception.InvalidAuthCodeException
+import com.dcd.server.core.domain.auth.exception.NotFoundAuthCodeException
+import com.dcd.server.core.domain.auth.model.EmailAuth
 import com.dcd.server.core.domain.auth.service.VerifyEmailAuthService
+import com.dcd.server.core.domain.auth.spi.CommandEmailAuthPort
+import com.dcd.server.core.domain.auth.spi.QueryEmailAuthPort
+import com.ninjasquad.springmockk.SpykBean
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 
-class AuthenticateMailUseCaseTest : BehaviorSpec({
-    val verifyEmailAuthService = mockk<VerifyEmailAuthService>()
-    val useCase = AuthenticateMailUseCase(verifyEmailAuthService)
+@ActiveProfiles("test")
+@SpringBootTest(classes = [ServerApplication::class])
+class AuthenticateMailUseCaseTest(
+    private val authenticateMailUseCase: AuthenticateMailUseCase,
+    private val queryEmailAuthPort: QueryEmailAuthPort,
+    private val commandEmailAuthPort: CommandEmailAuthPort
+) : BehaviorSpec({
+    val targetEmail = "testEmail"
+    val targetCode = "testCode"
 
-    given("CertificateMailRequestDto가 주어지고") {
-        val testEmail = "testEmail"
-        val testCode = "testCode"
-        val request = CertificateMailReqDto(testEmail, testCode)
+    beforeContainer {
+        val emailAuth = EmailAuth(email = targetEmail, code = targetCode)
+        commandEmailAuthPort.save(emailAuth)
+    }
+
+    afterContainer {
+        commandEmailAuthPort.deleteByCode(targetCode)
+    }
+
+    given("이메일, 발급받은 코드가 주어지고") {
+        val request = CertificateMailReqDto(targetEmail, targetCode)
 
         `when`("실행할때") {
-            every { verifyEmailAuthService.verifyCode(request.email, request.code) } returns Unit
-            useCase.execute(request)
-            then("verifyEmailAuthService의 verifyCode가 실행되어야함") {
-                verify { verifyEmailAuthService.verifyCode(testEmail, testCode) }
+            authenticateMailUseCase.execute(request)
+
+            then("이메일 인증 엔티티의 인증 상태가 true로 변경되어야함") {
+                val expectedEmailAuth = queryEmailAuthPort.findByCode(targetCode)
+                expectedEmailAuth shouldNotBe  null
+                expectedEmailAuth?.certificate shouldBe true
+                expectedEmailAuth?.email shouldBe targetEmail
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/AuthenticateMailUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/AuthenticateMailUseCaseTest.kt
@@ -67,4 +67,18 @@ class AuthenticateMailUseCaseTest(
             }
         }
     }
+
+    given("코드를 요청하지 않은 이메일이 주어지고") {
+        val invalidEmail = "invalidEmail"
+        val request = CertificateMailReqDto(invalidEmail, targetCode)
+
+        `when`("실행할때") {
+
+            then("NotFoundAuthCodeException이 발생해야함") {
+                shouldThrow<NotFoundAuthCodeException> {
+                    authenticateMailUseCase.execute(request)
+                }
+            }
+        }
+    }
 })

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/AuthenticateMailUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/AuthenticateMailUseCaseTest.kt
@@ -53,4 +53,18 @@ class AuthenticateMailUseCaseTest(
             }
         }
     }
+
+    given("발급받지 않은 코드가 주어지고") {
+        val invalidCode = "invalidCode"
+        val request = CertificateMailReqDto(targetEmail, invalidCode)
+
+        `when`("실행할때") {
+
+            then("InvalidAuthCodeException이 발생해야함") {
+                shouldThrow<InvalidAuthCodeException> {
+                    authenticateMailUseCase.execute(request)
+                }
+            }
+        }
+    }
 })


### PR DESCRIPTION
## 개요
* 인증 메일 코드를 검증하는 유스케이스 테스트 케이스를 리펙토링합니다.
## 작업내용
* 기존 메일 인증 테스트 케이스 리펙토링
* 발급받지 않은 코드가 주어지는 테스트 케이스 추가
* 코드를 요청하지 않은 메일이 주어지는 테스트 케이스 추가
* 이메일 인증 코드 검증 로직 수정
* VerifyEmailAuthServiceImpl 구현 변경에따른 테스트 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **신규 기능**
	- 인증 코드가 없을 경우에 대한 구체적인 오류 코드 `AUTH_CODE_NOT_FOUND` 추가.
	- 새로운 예외 클래스 `NotFoundAuthCodeException` 도입.
	- 이메일 인증 코드 검증 로직 개선.

- **버그 수정**
	- 이메일 인증 코드 검증 시 적절한 예외 처리 로직 추가.

- **테스트**
	- 예외 처리 시나리오 업데이트 및 테스트 케이스 수정.
	- 새로운 테스트 케이스 추가로 오류 처리 강화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->