### PR TITLE
🔀 :: [#418] - 패스워드 변경 테스트 케이스 리펙토링

### DIFF
--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/NonAuthChangePasswordUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/NonAuthChangePasswordUseCaseTest.kt
@@ -24,11 +24,14 @@ class NonAuthChangePasswordUseCaseTest(
 ) : BehaviorSpec({
     val targetEmail = "testEmail"
 
-class NonAuthChangePasswordUseCaseTest : BehaviorSpec({
-    val queryUserPort = mockk<QueryUserPort>()
-    val commandUserPort = mockk<CommandUserPort>(relaxUnitFun = true)
-    val passwordEncoder = mockk<PasswordEncoder>()
-    val nonAuthChangePasswordUseCase = NonAuthChangePasswordUseCase(queryUserPort, commandUserPort, passwordEncoder)
+    beforeSpec {
+        val emailAuth = EmailAuth(email = targetEmail, code = "testCode", certificate = true)
+        commandEmailAuthPort.save(emailAuth)
+    }
+
+    afterSpec {
+        commandEmailAuthPort.deleteByCode("testCode")
+    }
 
     given("유저와 NonAuthChangePasswordReqDto가 주어지고") {
         val user = UserGenerator.generateUser()

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/NonAuthChangePasswordUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/NonAuthChangePasswordUseCaseTest.kt
@@ -2,15 +2,27 @@ package com.dcd.server.core.domain.auth.usecase
 
 import com.dcd.server.core.domain.auth.dto.request.NonAuthChangePasswordReqDto
 import com.dcd.server.core.domain.auth.exception.UserNotFoundException
-import com.dcd.server.core.domain.user.spi.CommandUserPort
+import com.dcd.server.core.domain.auth.model.EmailAuth
+import com.dcd.server.core.domain.auth.spi.CommandEmailAuthPort
 import com.dcd.server.core.domain.user.spi.QueryUserPort
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.verify
 import org.springframework.security.crypto.password.PasswordEncoder
-import com.dcd.server.infrastructure.test.user.UserGenerator
+import io.kotest.matchers.shouldNotBe
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+@ActiveProfiles("test")
+@SpringBootTest
+class NonAuthChangePasswordUseCaseTest(
+    private val nonAuthChangePasswordUseCase: NonAuthChangePasswordUseCase,
+    private val queryUserPort: QueryUserPort,
+    private val passwordEncoder: PasswordEncoder,
+    private val commandEmailAuthPort: CommandEmailAuthPort
+) : BehaviorSpec({
+    val targetEmail = "testEmail"
 
 class NonAuthChangePasswordUseCaseTest : BehaviorSpec({
     val queryUserPort = mockk<QueryUserPort>()

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/NonAuthChangePasswordUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/NonAuthChangePasswordUseCaseTest.kt
@@ -34,22 +34,21 @@ class NonAuthChangePasswordUseCaseTest(
     }
 
     given("유저와 NonAuthChangePasswordReqDto가 주어지고") {
-        val user = UserGenerator.generateUser()
-        val nonAuthChangePasswordReqDto = NonAuthChangePasswordReqDto(email = "email", newPassword = "newPassword")
 
         `when`("유스케이스를 실행할때") {
-            every { queryUserPort.findByEmail(nonAuthChangePasswordReqDto.email) } returns user
-            every { passwordEncoder.encode(nonAuthChangePasswordReqDto.newPassword) } returns nonAuthChangePasswordReqDto.newPassword
-
+            val nonAuthChangePasswordReqDto = NonAuthChangePasswordReqDto(email = targetEmail, newPassword = "newPassword")
             nonAuthChangePasswordUseCase.execute(nonAuthChangePasswordReqDto)
 
             then("NonAuthChangePasswordReqDto의 새 패스워드를 가진 유저를 저장해야함") {
-                verify { commandUserPort.save(user.copy(password = nonAuthChangePasswordReqDto.newPassword)) }
+                val result = queryUserPort.findByEmail(targetEmail)
+                result shouldNotBe null
+                passwordEncoder.matches(nonAuthChangePasswordReqDto.newPassword, result?.password)
             }
         }
 
         `when`("해당 이메일을 가진 유저가 존재하지 않을때") {
-            every { queryUserPort.findByEmail(nonAuthChangePasswordReqDto.email) } returns null
+            val notFoundUserEmail = "notFoundUser"
+            val nonAuthChangePasswordReqDto = NonAuthChangePasswordReqDto(email = notFoundUserEmail, newPassword = "newPassword")
 
             then("UserNotFoundException이 발생해야함") {
                 shouldThrow<UserNotFoundException> {


### PR DESCRIPTION
## 개요
* 패스워드 변경 테스트 케이스를 리펙토링합니다.
## 작업내용
* Test 클래스에서 SpringBootTest를 사용하도록 수정
* beforeSpec, afterSpec 추가
* 각 테스트 케이스 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트**
	- 비밀번호 변경 비인증 사용 사례 테스트 구조 및 종속성 수정.
	- 의존성 주입을 통해 테스트 클래스 재구성.
	- 테스트 케이스 업데이트로 실제 애플리케이션 구성 요소와의 통합 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->