### PR TITLE
🔀 :: [#420] - 회원가입 테스트 리펙토링

### DIFF
--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/SignupUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/SignupUseCaseTest.kt
@@ -52,6 +52,21 @@ class SignupUseCaseTest(
             }
         }
 
+        `when`("같은 유저가 존재할때") {
+            val emailAuth = EmailAuth(
+                email = testEmail,
+                certificate = true
+            )
+            commandEmailAuthPort.save(emailAuth)
+            val request = SignUpReqDto(testEmail, testPassword, testName)
+
+            then("AlreadyExistsUserException이 발생해야함") {
+                shouldThrow<AlreadyExistsUserException> {
+                    signUpUseCase.execute(request)
+                }
+            }
+        }
+
         `when`("같은 유저가 없을때 실행") {
             every { queryUserPort.existsByEmail(request.email) } returns false
             every { securityService.encodePassword(request.password) } returns "encodedPassword"

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/SignupUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/SignupUseCaseTest.kt
@@ -24,11 +24,19 @@ class SignupUseCaseTest(
     private val queryUserPort: QueryUserPort
 ) : BehaviorSpec({
 
-class SignupUseCaseTest : BehaviorSpec({
-    val queryUserPort = mockk<QueryUserPort>()
-    val commandUserPort = mockk<CommandUserPort>()
-    val securityService = mockk<SecurityService>()
-    val signUpUseCase = SignUpUseCase(securityService, commandUserPort, queryUserPort)
+    val targetEmail = "targetEmail"
+
+    beforeSpec {
+        val emailAuth = EmailAuth(
+            email = targetEmail,
+            certificate = true
+        )
+        commandEmailAuthPort.save(emailAuth)
+    }
+
+    afterSpec {
+        emailAuthRepository.deleteAll()
+    }
 
     given("signupRequest가 주어지고") {
         val testEmail = "testEmail"

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/SignupUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/SignupUseCaseTest.kt
@@ -42,11 +42,11 @@ class SignupUseCaseTest(
         val testEmail = "testEmail"
         val testName = "testName"
         val testPassword = "testPassword"
-        val request = SignUpReqDto(testEmail, testPassword, testName)
-        `when`("이미 같은 유저가 있을때 실행") {
-            every { queryUserPort.existsByEmail(request.email) } returns true
-            then("AlreadyExistsUserException이 발생해야함") {
-                shouldThrow<AlreadyExistsUserException> {
+
+        `when`("이메일 인증을 하지 않은 유저가 실행할때") {
+            val request = SignUpReqDto(testEmail, testPassword, testName)
+            then("NotCertificateEmailException이 발생해야함") {
+                shouldThrow<NotCertificateEmailException> {
                     signUpUseCase.execute(request)
                 }
             }

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/SignupUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/SignupUseCaseTest.kt
@@ -1,15 +1,28 @@
 package com.dcd.server.core.domain.auth.usecase
 
-import com.dcd.server.core.common.service.SecurityService
+import com.dcd.server.core.common.aop.exception.NotCertificateEmailException
 import com.dcd.server.core.domain.auth.dto.request.SignUpReqDto
 import com.dcd.server.core.domain.auth.exception.AlreadyExistsUserException
-import com.dcd.server.core.domain.user.spi.CommandUserPort
+import com.dcd.server.core.domain.auth.model.EmailAuth
+import com.dcd.server.core.domain.auth.spi.CommandEmailAuthPort
 import com.dcd.server.core.domain.user.spi.QueryUserPort
+import com.dcd.server.persistence.auth.repository.EmailAuthRepository
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.verify
+import io.kotest.matchers.shouldNotBe
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class SignupUseCaseTest(
+    private val signUpUseCase: SignUpUseCase,
+    private val commandEmailAuthPort: CommandEmailAuthPort,
+    private val emailAuthRepository: EmailAuthRepository,
+    private val queryUserPort: QueryUserPort
+) : BehaviorSpec({
 
 class SignupUseCaseTest : BehaviorSpec({
     val queryUserPort = mockk<QueryUserPort>()


### PR DESCRIPTION
## 개요
* 회원가입 테스트 케이스를 리펙토링합니다.
## 작업내용
* 기존 SignupUseCaseTest를 SpringBootTest로 수정
* beforeSpec afterSpec 추가
* 인증안된 유저가 실행할때 에러 발생 검증 테스트 케이스 추가
* 같은 유저가 존재할때 에러 발생 검증 테스트 케이스 추가
* 정상적으로 실행됐을때 테스트 케이스 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 이메일 인증 없이 회원가입을 시도할 경우 `NotCertificateEmailException` 예외가 발생하도록 테스트 로직 수정.
  
- **테스트**
	- 통합 테스트 방식으로 전환하여 실제 데이터베이스 및 서비스 레이어와의 상호작용을 검증.
	- 사용자 저장 시 이메일, 이름, 비밀번호 인코딩 속성에 대한 검증 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->