### PR TITLE
🔀 :: [#422] - 토큰 재발급 테스트 케이스 리펙토링

### DIFF
--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/ReissueTokenUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/ReissueTokenUseCaseTest.kt
@@ -43,18 +43,13 @@ class ReissueTokenUseCaseTest(
 
 
         `when`("아무 문제 없이 실행될때") {
-            every { queryRefreshTokenPort.findByToken(token) } returns refreshToken
-            every { queryUserPort.findById(userId) } returns user
-            every { commandRefreshTokenPort.delete(refreshToken) } returns Unit
-            every { jwtPort.generateToken(user.id) } returns tokenResDto
             every { parseTokenAdapter.getJwtType(token) } returns ParseTokenAdapter.JwtPrefix.REFRESH
+            every { jwtPort.generateToken("user2") } returns targetTokenResDto
+            refreshTokenPort.save(refreshToken)
 
             val result = reissueTokenUseCase.execute(token)
             then("jwtPort에서 생성한 dto가 반환되어야함") {
-                verify { queryRefreshTokenPort.findByToken(token) }
-                verify { queryUserPort.findById(userId) }
-                verify { commandRefreshTokenPort.delete(refreshToken) }
-                result shouldBe tokenResDto
+                result shouldBe targetTokenResDto
             }
         }
 

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/ReissueTokenUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/ReissueTokenUseCaseTest.kt
@@ -6,29 +6,30 @@ import com.dcd.server.core.domain.auth.exception.UserNotFoundException
 import com.dcd.server.core.domain.auth.model.RefreshToken
 import com.dcd.server.core.domain.auth.spi.CommandRefreshTokenPort
 import com.dcd.server.core.domain.auth.spi.JwtPort
-import com.dcd.server.core.domain.auth.spi.QueryRefreshTokenPort
-import com.dcd.server.core.domain.user.spi.QueryUserPort
 import com.dcd.server.infrastructure.global.jwt.adapter.ParseTokenAdapter
 import com.dcd.server.infrastructure.global.jwt.exception.TokenTypeNotValidException
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
-import io.mockk.mockk
-import io.mockk.verify
-import com.dcd.server.infrastructure.test.user.UserGenerator
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 
-class ReissueTokenUseCaseTest : BehaviorSpec({
-    val queryRefreshTokenPort = mockk<QueryRefreshTokenPort>()
-    val commandRefreshTokenPort = mockk<CommandRefreshTokenPort>()
-    val jwtPort = mockk<JwtPort>()
-    val queryUserPort = mockk<QueryUserPort>()
-    val parseTokenAdapter = mockk<ParseTokenAdapter>(relaxUnitFun = true)
-    val reissueTokenUseCase =
-        ReissueTokenUseCase(queryRefreshTokenPort, commandRefreshTokenPort, jwtPort, queryUserPort, parseTokenAdapter)
-
-    val userId = "testUserId"
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class ReissueTokenUseCaseTest(
+    private val reissueTokenUseCase: ReissueTokenUseCase,
+    @MockkBean
+    private val jwtPort: JwtPort,
+    @MockkBean
+    private val parseTokenAdapter: ParseTokenAdapter,
+    private val refreshTokenPort: CommandRefreshTokenPort
+) : BehaviorSpec({
+    val userId = "user2"
     val token = "testRefreshToken"
     val ttl = 1L
     val user = UserGenerator.generateUser()

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/ReissueTokenUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/ReissueTokenUseCaseTest.kt
@@ -31,12 +31,16 @@ class ReissueTokenUseCaseTest(
 ) : BehaviorSpec({
     val userId = "user2"
     val token = "testRefreshToken"
-    val ttl = 1L
-    val user = UserGenerator.generateUser()
-    val tokenResDto = TokenResDto("newAccessToken", LocalDateTime.of(2023, 9, 7, 8, 30), "newRefreshToken", LocalDateTime.of(2023, 9, 7, 8, 30))
+    val ttl = 10000L
 
     given("리프레시 토큰이 주어지고") {
+        val expectedAccessToken = "accessToken"
         val refreshToken = RefreshToken(userId, token, ttl)
+        val accessTokenExp = LocalDateTime.of(2023, 9, 5, 8, 3)
+        val refreshTokenExp = LocalDateTime.of(2023, 9, 5, 8, 3)
+
+        val targetTokenResDto = TokenResDto(expectedAccessToken, accessTokenExp, token, refreshTokenExp)
+
 
         `when`("아무 문제 없이 실행될때") {
             every { queryRefreshTokenPort.findByToken(token) } returns refreshToken

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/ReissueTokenUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/ReissueTokenUseCaseTest.kt
@@ -74,11 +74,8 @@ class ReissueTokenUseCaseTest(
         }
 
         `when`("해당 토큰이 REFRESH 타입이 아닐때") {
-            every { queryRefreshTokenPort.findByToken(token) } returns refreshToken
-            every { queryUserPort.findById(userId) } returns user
-            every { commandRefreshTokenPort.delete(refreshToken) } returns Unit
-            every { jwtPort.generateToken(user.id) } returns tokenResDto
-            every { parseTokenAdapter.getJwtType(token) } returns "ACCESS"
+            every { parseTokenAdapter.getJwtType(token) } returns ParseTokenAdapter.JwtPrefix.ACCESS
+
             then("TokenTypeNotValidException이 발생해야함") {
                 shouldThrow<TokenTypeNotValidException> {
                     reissueTokenUseCase.execute(token)


### PR DESCRIPTION
## 개요
* 토큰 재발급 테스트 케이스를 리펙토링합니다.
## 작업내용
* 기존 테스트 코드를 SpringBootTest를 이용하도록 수정
* given에서 주어지는 객체 수정
* 아무 문제없이 실행될때 jwtPort에서 생성한 응답을 반환하는지 검증하는 테스트 케이스 수정
* 토큰으로 파싱된 유저가 없을때 에러 발생 검증 테스트 케이스 수정
* 토큰 타입이 올바르지 않은 테스트 케이스 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트**
	- 테스트 클래스의 구조가 Spring 테스트 프레임워크를 활용하도록 재구성되었습니다.
	- 의존성 주입 방식으로 변경되어 MockkBean을 사용하여 의존성을 주입받습니다.
	- 테스트 로직이 업데이트되어 토큰 재발급 관련 시나리오와 예외 처리 방식이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->