### PR TITLE
🔀 :: [#424] - 패스워드 변경 유스케이스 테스트 케이스 리펙토링

### DIFF
--- a/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangePasswordUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangePasswordUseCaseTest.kt
@@ -46,8 +46,6 @@ class ChangePasswordUseCaseTest(
         }
 
         `when`("password가 일치하지 않을때") {
-            every { getCurrentUserService.getCurrentUser() } returns user
-            every { passwordEncoder.matches(passwordChangeReqDto.existingPassword, user.password) } returns false
 
             then("PasswordNotCorrectException이 발생해야함") {
                 shouldThrow<PasswordNotCorrectException> {

--- a/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangePasswordUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangePasswordUseCaseTest.kt
@@ -2,16 +2,15 @@ package com.dcd.server.core.domain.user.usecase
 
 import com.dcd.server.core.common.service.exception.PasswordNotCorrectException
 import com.dcd.server.core.domain.user.dto.request.PasswordChangeReqDto
-import com.dcd.server.core.domain.user.service.GetCurrentUserService
-import com.dcd.server.core.domain.user.spi.CommandUserPort
+import com.dcd.server.core.domain.user.spi.QueryUserPort
+import com.dcd.server.infrastructure.global.security.auth.AuthDetailsService
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.verify
 import org.springframework.security.crypto.password.PasswordEncoder
-import com.dcd.server.infrastructure.test.user.UserGenerator
+import io.kotest.matchers.shouldNotBe
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
 
@@ -19,8 +18,17 @@ import org.springframework.transaction.annotation.Transactional
 @SpringBootTest
 @ActiveProfiles("test")
 class ChangePasswordUseCaseTest(
-    private val changePasswordUseCase: ChangePasswordUseCase
+    private val changePasswordUseCase: ChangePasswordUseCase,
+    private val queryUserPort: QueryUserPort,
+    private val passwordEncoder: PasswordEncoder,
+    private val authDetailsService: AuthDetailsService
 ) : BehaviorSpec({
+    beforeTest {
+        val userId = "user2"
+        val userDetails = authDetailsService.loadUserByUsername(userId)
+        val authenticationToken = UsernamePasswordAuthenticationToken(userDetails, "", userDetails.authorities)
+        SecurityContextHolder.getContext().authentication = authenticationToken
+    }
 
     given("User, PasswordChangeReqDto가 주어지고") {
         val user = UserGenerator.generateUser()

--- a/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangePasswordUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangePasswordUseCaseTest.kt
@@ -11,12 +11,16 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.springframework.security.crypto.password.PasswordEncoder
 import com.dcd.server.infrastructure.test.user.UserGenerator
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
 
-class ChangePasswordUseCaseTest : BehaviorSpec({
-    val getCurrentUserService = mockk<GetCurrentUserService>()
-    val commandUserPort = mockk<CommandUserPort>(relaxUnitFun = true)
-    val passwordEncoder = mockk<PasswordEncoder>()
-    val changePasswordUseCase = ChangePasswordUseCase(getCurrentUserService, commandUserPort, passwordEncoder)
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class ChangePasswordUseCaseTest(
+    private val changePasswordUseCase: ChangePasswordUseCase
+) : BehaviorSpec({
 
     given("User, PasswordChangeReqDto가 주어지고") {
         val user = UserGenerator.generateUser()

--- a/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangePasswordUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangePasswordUseCaseTest.kt
@@ -31,22 +31,17 @@ class ChangePasswordUseCaseTest(
     }
 
     given("User, PasswordChangeReqDto가 주어지고") {
-        val user = UserGenerator.generateUser()
         val passwordChangeReqDto = PasswordChangeReqDto(
-            existingPassword = "existingPassword",
+            existingPassword = "testPassword",
             newPassword = "newPassword"
         )
 
         `when`("usecase를 실행할때") {
-            every { getCurrentUserService.getCurrentUser() } returns user
-            every { passwordEncoder.matches(passwordChangeReqDto.existingPassword, user.password) } returns true
-            every { passwordEncoder.encode(passwordChangeReqDto.newPassword) } returns passwordChangeReqDto.newPassword
-
             changePasswordUseCase.execute(passwordChangeReqDto)
             then("passwordChangeReqDto의 새 패스워드를 가진 유저를 저장해야함") {
-                verify {
-                    commandUserPort.save(user.copy(password = passwordChangeReqDto.newPassword))
-                }
+                val user = queryUserPort.findById("user2")
+                user shouldNotBe null
+                passwordEncoder.matches(passwordChangeReqDto.newPassword, user?.password)
             }
         }
 


### PR DESCRIPTION
## 개요
* 패스워드 변경 유스케이스 테스트 케이스를 리펙토링합니다.
## 작업내용
* 기존 테스트를 SpringBootTest로 수정
* beforeTest 추가
* 정상적으로 실행된 테스트 케이스 수정
* password 일치하지 않은 테스트 케이스 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트**
	- 비밀번호 변경 사용 사례에 대한 통합 테스트 접근 방식으로 변경.
	- 실제 서비스 구현 및 데이터베이스 상호작용을 활용하여 테스트 로직 수정.
	- 비밀번호 변경 후 사용자 정보 검증 로직 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->