### PR TITLE
🔀 :: [#426] - 유저 상태 변경 유스케이스 테스트 리펙토링

### DIFF
--- a/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangeUserStatusUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangeUserStatusUseCaseTest.kt
@@ -32,15 +32,5 @@ class ChangeUserStatusUseCaseTest(
                 result?.status shouldBe status
             }
         }
-
-        `when`("해당 userId를 가진 유저가 없을때") {
-            every { queryUserPort.findById(userId) } returns null
-
-            then("UserNotFoundException이 발생해야함") {
-                shouldThrow<UserNotFoundException> {
-                    changeUserStatusUseCase.execute(userId, status)
-                }
-            }
-        }
     }
 })

--- a/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangeUserStatusUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangeUserStatusUseCaseTest.kt
@@ -33,4 +33,17 @@ class ChangeUserStatusUseCaseTest(
             }
         }
     }
+
+    given("존재하지 않는 유저의 아이디가 주어지고") {
+        val userId = "notFoundUser"
+        val status = Status.PENDING
+
+        `when`("유스케케이스를 실행할때") {
+            then("UserNotFoundException이 발생해야함") {
+                shouldThrow<UserNotFoundException> {
+                    changeUserStatusUseCase.execute(userId, status)
+                }
+            }
+        }
+    }
 })

--- a/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangeUserStatusUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangeUserStatusUseCaseTest.kt
@@ -19,16 +19,17 @@ class ChangeUserStatusUseCaseTest(
     private val queryUserPort: QueryUserPort
 ) : BehaviorSpec({
 
-        `when`("해당 유저가 존재할때") {
-            val user = UserGenerator.generateUser()
+    given("존재하는 유저의 아이디가 주어지고") {
+        val userId = "user1"
+        val status = Status.PENDING
 
-            every { queryUserPort.findById(userId) } returns user
-
+        `when`("유스케이스를 실행할때") {
             changeUserStatusUseCase.execute(userId, status)
 
-            then("user가 수정되고 저장됐는지 검사") {
-                verify { queryUserPort.findById(userId) }
-                verify { commandUserPort.save(user.copy(status = status)) }
+            then("유저의 상태는 PENDING으로 변경되어야함") {
+                val result = queryUserPort.findById(userId)
+                result shouldNotBe null
+                result?.status shouldBe status
             }
         }
 

--- a/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangeUserStatusUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangeUserStatusUseCaseTest.kt
@@ -2,23 +2,22 @@ package com.dcd.server.core.domain.user.usecase
 
 import com.dcd.server.core.domain.auth.exception.UserNotFoundException
 import com.dcd.server.core.domain.user.model.enums.Status
-import com.dcd.server.core.domain.user.spi.CommandUserPort
 import com.dcd.server.core.domain.user.spi.QueryUserPort
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.verify
-import com.dcd.server.infrastructure.test.user.UserGenerator
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
 
-class ChangeUserStatusUseCaseTest : BehaviorSpec({
-    val queryUserPort = mockk<QueryUserPort>()
-    val commandUserPort = mockk<CommandUserPort>(relaxUnitFun = true)
-    val changeUserStatusUseCase = ChangeUserStatusUseCase(queryUserPort, commandUserPort)
-
-    given("userId, 변경할 status가 주어지고") {
-        val userId = "testUserId"
-        val status = Status.CREATED
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class ChangeUserStatusUseCaseTest(
+    private val changeUserStatusUseCase: ChangeUserStatusUseCase,
+    private val queryUserPort: QueryUserPort
+) : BehaviorSpec({
 
         `when`("해당 유저가 존재할때") {
             val user = UserGenerator.generateUser()


### PR DESCRIPTION
## 개요
* 유저의 상태를 변경하는 유스케이스 테스트를 리펙토링합니다.
## 작업내용
* ChangeUserStatusUseCaseTest에 SpringBootTest를 적용
* 기존 테스트 케이스를 존재하는 유저의 아이디를 제공하는 테스트 케이스로 수정
* 주어진 유저 아이디를 가진 유저가 존재하지 않는 테스트 케이스 제거
* 존재하지 않는 유저의 아이디가 주어지는 given절 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트 개선**
	- 사용자 상태 변경 사용 사례에 대한 테스트 방식 업데이트
	- 스프링 통합 테스트 접근 방식으로 전환
	- 존재하지 않는 사용자 ID에 대한 새로운 테스트 시나리오 추가
	- 의존성 주입 및 테스트 선언적 접근 방식으로 변경

<!-- end of auto-generated comment: release notes by coderabbit.ai -->