### PR TITLE
🔀 :: [#428] - 상태로 유저 조회 유스케이스 테스트 리펙토링

### DIFF
--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/SignupUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/SignupUseCaseTest.kt
@@ -5,6 +5,7 @@ import com.dcd.server.core.domain.auth.dto.request.SignUpReqDto
 import com.dcd.server.core.domain.auth.exception.AlreadyExistsUserException
 import com.dcd.server.core.domain.auth.model.EmailAuth
 import com.dcd.server.core.domain.auth.spi.CommandEmailAuthPort
+import com.dcd.server.core.domain.user.spi.CommandUserPort
 import com.dcd.server.core.domain.user.spi.QueryUserPort
 import com.dcd.server.persistence.auth.repository.EmailAuthRepository
 import io.kotest.assertions.throwables.shouldThrow
@@ -24,7 +25,8 @@ class SignupUseCaseTest(
     private val commandEmailAuthPort: CommandEmailAuthPort,
     private val emailAuthRepository: EmailAuthRepository,
     private val queryUserPort: QueryUserPort,
-    private val passwordEncoder: PasswordEncoder
+    private val passwordEncoder: PasswordEncoder,
+    private val commandUserPort: CommandUserPort
 ) : BehaviorSpec({
 
     val targetEmail = "targetEmail"
@@ -39,6 +41,7 @@ class SignupUseCaseTest(
 
     afterSpec {
         emailAuthRepository.deleteAll()
+        commandUserPort.delete(queryUserPort.findByEmail(targetEmail)!!)
     }
 
     given("signupRequest가 주어지고") {

--- a/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangeUserStatusUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangeUserStatusUseCaseTest.kt
@@ -2,6 +2,7 @@ package com.dcd.server.core.domain.user.usecase
 
 import com.dcd.server.core.domain.auth.exception.UserNotFoundException
 import com.dcd.server.core.domain.user.model.enums.Status
+import com.dcd.server.core.domain.user.spi.CommandUserPort
 import com.dcd.server.core.domain.user.spi.QueryUserPort
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
@@ -16,7 +17,8 @@ import org.springframework.transaction.annotation.Transactional
 @ActiveProfiles("test")
 class ChangeUserStatusUseCaseTest(
     private val changeUserStatusUseCase: ChangeUserStatusUseCase,
-    private val queryUserPort: QueryUserPort
+    private val queryUserPort: QueryUserPort,
+    private val commandUserPort: CommandUserPort
 ) : BehaviorSpec({
 
     given("존재하는 유저의 아이디가 주어지고") {
@@ -44,6 +46,13 @@ class ChangeUserStatusUseCaseTest(
                     changeUserStatusUseCase.execute(userId, status)
                 }
             }
+        }
+    }
+
+    afterSpec {
+        val userList = queryUserPort.findByStatus(Status.PENDING)
+        userList.forEach {
+            commandUserPort.save(it.copy(status = Status.CREATED))
         }
     }
 })

--- a/src/test/kotlin/com/dcd/server/core/domain/user/usecase/GetUserByStatusUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/user/usecase/GetUserByStatusUseCaseTest.kt
@@ -39,4 +39,19 @@ class GetUserByStatusUseCaseTest(
             }
         }
     }
+
+    given("PENDING status가 주어지고") {
+        val givenStatus = Status.PENDING
+
+        `when`("execute 메서드를 실행할때") {
+            val result = getUserByStatusUseCase.execute(givenStatus)
+
+            then("주어진 status를 가지고 있는 유저가 조회되어야함") {
+                result.list.size shouldBe 1
+                result.list.forEach {
+                    it.status shouldBe givenStatus
+                }
+            }
+        }
+    }
 })

--- a/src/test/kotlin/com/dcd/server/core/domain/user/usecase/GetUserByStatusUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/user/usecase/GetUserByStatusUseCaseTest.kt
@@ -1,18 +1,22 @@
 package com.dcd.server.core.domain.user.usecase
 
-import com.dcd.server.core.domain.user.dto.extension.toDto
 import com.dcd.server.core.domain.user.model.enums.Status
-import com.dcd.server.core.domain.user.spi.QueryUserPort
+import com.dcd.server.core.domain.user.spi.CommandUserPort
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.verify
 import com.dcd.server.infrastructure.test.user.UserGenerator
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
 
-class GetUserByStatusUseCaseTest : BehaviorSpec({
-    val queryUserPort = mockk<QueryUserPort>()
-    val getUserByStatusUseCase = GetUserByStatusUseCase(queryUserPort)
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class GetUserByStatusUseCaseTest(
+    private val getUserByStatusUseCase: GetUserByStatusUseCase,
+    private val commandUserPort: CommandUserPort
+) : BehaviorSpec({
+    val pendingUser = UserGenerator.generateUser(status = Status.PENDING)
 
     given("조회할 status가 주어지고") {
         val status = Status.CREATED

--- a/src/test/kotlin/com/dcd/server/core/domain/user/usecase/GetUserByStatusUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/user/usecase/GetUserByStatusUseCaseTest.kt
@@ -18,8 +18,6 @@ class GetUserByStatusUseCaseTest(
 ) : BehaviorSpec({
     val pendingUser = UserGenerator.generateUser(status = Status.PENDING)
 
-    given("조회할 status가 주어지고") {
-        val status = Status.CREATED
     beforeSpec {
         commandUserPort.save(pendingUser)
     }
@@ -27,15 +25,17 @@ class GetUserByStatusUseCaseTest(
         commandUserPort.delete(pendingUser)
     }
 
+    given("CREATED status가 주어지고") {
+        val givenStatus = Status.CREATED
 
         `when`("execute 메서드를 실행할때") {
-            val userList = listOf(UserGenerator.generateUser())
-            every { queryUserPort.findByStatus(status) } returns userList
-            val result = getUserByStatusUseCase.execute(status)
+            val result = getUserByStatusUseCase.execute(givenStatus)
 
-            then("result는 유저의 정보를 가지고 있어야함") {
-                verify { queryUserPort.findByStatus(status) }
-                result.list shouldBe userList.map { it.toDto() }
+            then("주어진 status를 가지고 있는 유저가 조회되어야함") {
+                result.list.size shouldBe 2
+                result.list.forEach {
+                    it.status shouldBe givenStatus
+                }
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/user/usecase/GetUserByStatusUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/user/usecase/GetUserByStatusUseCaseTest.kt
@@ -20,6 +20,13 @@ class GetUserByStatusUseCaseTest(
 
     given("조회할 status가 주어지고") {
         val status = Status.CREATED
+    beforeSpec {
+        commandUserPort.save(pendingUser)
+    }
+    afterSpec {
+        commandUserPort.delete(pendingUser)
+    }
+
 
         `when`("execute 메서드를 실행할때") {
             val userList = listOf(UserGenerator.generateUser())


### PR DESCRIPTION
## 개요
* 상태로 유저 조회 유스케이스 테스트를 리펙토링합니다.
## 작업내용
* 기존 테스트를 SpringBootTest로 수정
* beforeSpec, afterSpec 추가
* 기존 테스트 리펙토링
* PENDING status가 주어지는 테스트 케이스 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트 개선**
	- 사용자 상태 관리를 위한 테스트 환경 강화
	- 테스트 후 데이터 정리를 위한 `CommandUserPort` 종속성 추가
	- 테스트 클래스에 트랜잭션 및 프로필 설정 적용
	- 사용자 상태 검색 및 관리 테스트 로직 개선

- **테스트 클린업**
	- 테스트 실행 후 생성된 사용자 자동 삭제
	- 테스트 간 상호 영향 방지를 위한 환경 설정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->