### PR TITLE
🔀 :: [#430] - 유저 프로필 조회 테스트 리펙토링

### DIFF
--- a/src/test/kotlin/com/dcd/server/core/domain/user/usecase/GetUserProfileUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/user/usecase/GetUserProfileUseCaseTest.kt
@@ -3,24 +3,34 @@ package com.dcd.server.core.domain.user.usecase
 import com.dcd.server.core.domain.application.dto.extenstion.toProfileDto
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.user.dto.extension.toDto
-import com.dcd.server.core.domain.user.service.GetCurrentUserService
+import com.dcd.server.core.domain.user.spi.QueryUserPort
 import com.dcd.server.core.domain.workspace.dto.extension.toProfileDto
 import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
+import com.dcd.server.infrastructure.global.security.auth.AuthDetailsService
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.verify
-import com.dcd.server.infrastructure.test.application.ApplicationGenerator
-import com.dcd.server.infrastructure.test.user.UserGenerator
-import com.dcd.server.infrastructure.test.workspace.WorkspaceGenerator
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
 
-class GetUserProfileUseCaseTest : BehaviorSpec({
-    val getCurrentUserService = mockk<GetCurrentUserService>()
-    val queryWorkspacePort = mockk<QueryWorkspacePort>()
-    val queryApplicationPort = mockk<QueryApplicationPort>()
-
-    val getUserProfileUseCase = GetUserProfileUseCase(getCurrentUserService, queryWorkspacePort, queryApplicationPort)
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class GetUserProfileUseCaseTest(
+    private val getUserProfileUseCase: GetUserProfileUseCase,
+    private val authDetailsService: AuthDetailsService,
+    private val queryUserPort: QueryUserPort,
+    private val queryWorkspacePort: QueryWorkspacePort,
+    private val queryApplicationPort: QueryApplicationPort
+) : BehaviorSpec({
+    val userId = "user1"
+    beforeTest {
+        val userDetails = authDetailsService.loadUserByUsername(userId)
+        val authenticationToken = UsernamePasswordAuthenticationToken(userDetails, "", userDetails.authorities)
+        SecurityContextHolder.getContext().authentication = authenticationToken
+    }
 
     given("유저, 애플리케이션, 워크스페이스가 주어지고") {
         val user = UserGenerator.generateUser()

--- a/src/test/kotlin/com/dcd/server/core/domain/user/usecase/GetUserProfileUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/user/usecase/GetUserProfileUseCaseTest.kt
@@ -40,22 +40,6 @@ class GetUserProfileUseCaseTest(
                 val targetUser = queryUserPort.findById(userId)
                 val workspaceList = queryWorkspacePort.findByUser(targetUser!!)
 
-    given("유저가 주어지고") {
-        val user = UserGenerator.generateUser()
-
-        `when`("usecase를 실행할때") {
-            every { getCurrentUserService.getCurrentUser() } returns user
-            every { queryWorkspacePort.findByUser(user) } returns listOf()
-
-            val result = getUserProfileUseCase.execute()
-
-            then("워크스페이스를 조회해야함") {
-                verify { queryWorkspacePort.findByUser(user) }
-            }
-
-            then("결과값은 user의 값을 담고 있어야함") {
-                result.user shouldBe user.toDto()
-                result.workspaces shouldBe listOf()
                 result.user shouldBe targetUser.toDto()
                 result.workspaces shouldBe workspaceList.map {
                     it.toProfileDto(


### PR DESCRIPTION
## 개요
* 유저 프로필 조회 테스트를 리펙토링합니다.
## 작업내용
* 기존 테스트를 SpringBootTest로 수정
* 기존 유저, 애플리케이션, 워크스페이스가 주어지는 테스트 케이스 수정
* 유저만 주어지는 테스트 케이스 삭제

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트 개선**
	- 사용자 프로필 테스트 클래스의 종속성 주입 방식 업데이트
	- 스프링 테스트 프레임워크와의 통합 강화
	- 인증 및 사용자 데이터 조회 메커니즘 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->