### PR TITLE
🔀 :: [#432] - 테스트 세팅 리펙토링

### DIFF
--- a/src/test/kotlin/TestConfig.kt
+++ b/src/test/kotlin/TestConfig.kt
@@ -1,0 +1,7 @@
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.extensions.spring.SpringTestExtension
+import io.kotest.extensions.spring.SpringTestLifecycleMode
+
+class TestConfig : AbstractProjectConfig() {
+    override fun extensions() = listOf(SpringTestExtension(SpringTestLifecycleMode.Root))
+}

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/AuthMailSendUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/AuthMailSendUseCaseTest.kt
@@ -3,16 +3,10 @@ package com.dcd.server.core.domain.auth.usecase
 import com.dcd.server.ServerApplication
 import com.dcd.server.core.domain.auth.dto.request.EmailSendReqDto
 import com.dcd.server.core.domain.auth.service.EmailSendService
-import com.dcd.server.core.domain.auth.spi.QueryEmailAuthPort
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.BehaviorSpec
-import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.mockk
-import io.mockk.verify
-import jakarta.mail.internet.MimeMessage
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.test.context.ActiveProfiles
 
 @ActiveProfiles("test")

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/AuthenticateMailUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/AuthenticateMailUseCaseTest.kt
@@ -9,8 +9,6 @@ import com.dcd.server.core.domain.auth.spi.CommandEmailAuthPort
 import com.dcd.server.core.domain.auth.spi.QueryEmailAuthPort
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
-import io.kotest.extensions.spring.SpringTestExtension
-import io.kotest.extensions.spring.SpringTestLifecycleMode
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import org.springframework.boot.test.context.SpringBootTest
@@ -25,7 +23,6 @@ class AuthenticateMailUseCaseTest(
     private val queryEmailAuthPort: QueryEmailAuthPort,
     private val commandEmailAuthPort: CommandEmailAuthPort
 ) : BehaviorSpec({
-    extensions(listOf(SpringTestExtension(SpringTestLifecycleMode.Root)))
     val targetEmail = "testEmail"
     val targetCode = "testCode"
 

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/SignupUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/SignupUseCaseTest.kt
@@ -5,7 +5,6 @@ import com.dcd.server.core.domain.auth.dto.request.SignUpReqDto
 import com.dcd.server.core.domain.auth.exception.AlreadyExistsUserException
 import com.dcd.server.core.domain.auth.model.EmailAuth
 import com.dcd.server.core.domain.auth.spi.CommandEmailAuthPort
-import com.dcd.server.core.domain.user.spi.CommandUserPort
 import com.dcd.server.core.domain.user.spi.QueryUserPort
 import com.dcd.server.persistence.auth.repository.EmailAuthRepository
 import io.kotest.assertions.throwables.shouldThrow
@@ -25,8 +24,7 @@ class SignupUseCaseTest(
     private val commandEmailAuthPort: CommandEmailAuthPort,
     private val emailAuthRepository: EmailAuthRepository,
     private val queryUserPort: QueryUserPort,
-    private val passwordEncoder: PasswordEncoder,
-    private val commandUserPort: CommandUserPort
+    private val passwordEncoder: PasswordEncoder
 ) : BehaviorSpec({
 
     val targetEmail = "targetEmail"
@@ -41,7 +39,6 @@ class SignupUseCaseTest(
 
     afterSpec {
         emailAuthRepository.deleteAll()
-        commandUserPort.delete(queryUserPort.findByEmail(targetEmail)!!)
     }
 
     given("signupRequest가 주어지고") {

--- a/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangeUserStatusUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangeUserStatusUseCaseTest.kt
@@ -48,11 +48,4 @@ class ChangeUserStatusUseCaseTest(
             }
         }
     }
-
-    afterSpec {
-        val userList = queryUserPort.findByStatus(Status.PENDING)
-        userList.forEach {
-            commandUserPort.save(it.copy(status = Status.CREATED))
-        }
-    }
 })

--- a/src/test/kotlin/com/dcd/server/core/domain/user/usecase/GetUserByStatusUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/user/usecase/GetUserByStatusUseCaseTest.kt
@@ -21,9 +21,6 @@ class GetUserByStatusUseCaseTest(
     beforeSpec {
         commandUserPort.save(pendingUser)
     }
-    afterSpec {
-        commandUserPort.delete(pendingUser)
-    }
 
     given("CREATED status가 주어지고") {
         val givenStatus = Status.CREATED


### PR DESCRIPTION
## 개요
* 테스트 세팅을 리펙토링합니다.
## 작업내용
* TestConfig 추가
* 테스트에서 따로 익스텐션을 사용하던 부분 제거
* ChangeUserStatusUseCaseTest에서 afterSpec 제거
* GetUserByStatusUseCaseTest에서 afterSpec 제거
* SignupUseCaseTest에서 유저를 제거하던 부분 제거

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트 구성**
	- 새로운 `TestConfig` 클래스 추가
	- 일부 테스트 클래스에서 Spring 테스트 확장 및 정리(cleanup) 로직 제거

- **테스트 변경사항**
	- 일부 테스트 클래스의 의존성 및 사후 처리 블록 제거
	- 테스트 환경 설정 간소화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->