### PR TITLE
🔀 :: [#436] - 워크스페이스 삭제 테스트 케이스 리펙토링

### DIFF
--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteWorkspaceUseCaseTest.kt
@@ -1,25 +1,32 @@
 package com.dcd.server.core.domain.workspace.usecase
 
-import com.dcd.server.core.domain.user.service.GetCurrentUserService
+import com.dcd.server.core.domain.user.spi.QueryUserPort
 import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
-import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 import com.dcd.server.core.domain.workspace.spi.CommandWorkspacePort
 import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
+import com.dcd.server.infrastructure.global.security.auth.AuthDetailsService
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.verify
-import com.dcd.server.infrastructure.test.user.UserGenerator
 import com.dcd.server.infrastructure.test.workspace.WorkspaceGenerator
-import java.util.*
+import io.kotest.matchers.shouldBe
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
 
-class DeleteWorkspaceUseCaseTest : BehaviorSpec({
-    val commandWorkspacePort = mockk<CommandWorkspacePort>(relaxUnitFun = true)
-    val queryWorkspacePort = mockk<QueryWorkspacePort>()
-    val getCurrentUserService = mockk<GetCurrentUserService>()
-    val validateWorkspaceOwnerService = mockk<ValidateWorkspaceOwnerService>(relaxUnitFun = true)
-    val deleteWorkspaceUseCase = DeleteWorkspaceUseCase(commandWorkspacePort, queryWorkspacePort, getCurrentUserService, validateWorkspaceOwnerService)
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class DeleteWorkspaceUseCaseTest(
+    private val deleteWorkspaceUseCase: DeleteWorkspaceUseCase,
+    private val authDetailsService: AuthDetailsService,
+    private val queryWorkspacePort: QueryWorkspacePort,
+    private val commandWorkspacePort: CommandWorkspacePort,
+    private val queryUserPort: QueryUserPort
+) : BehaviorSpec({
+    val userId = "user1"
+    val workspaceId = "testWorkspaceId"
 
     given("workspaceId가 주어지고") {
         val workspaceId = UUID.randomUUID().toString()

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteWorkspaceUseCaseTest.kt
@@ -34,16 +34,16 @@ class DeleteWorkspaceUseCaseTest(
         SecurityContextHolder.getContext().authentication = authenticationToken
     }
 
-        `when`("해당 id를 가진 workspace가 있을때") {
-            val user = UserGenerator.generateUser()
-            val workspace = WorkspaceGenerator.generateWorkspace(user = user)
+    given("워크스페이스 아이디를 가진 워크스페이스가 주어지고") {
+        val user = queryUserPort.findById(userId)!!
+        val workspace = WorkspaceGenerator.generateWorkspace(id = workspaceId, user = user)
+        commandWorkspacePort.save(workspace)
 
-            every { getCurrentUserService.getCurrentUser() } returns user
-            every { queryWorkspacePort.findById(workspaceId) } returns workspace
-
+        `when`("유스케이스를 실행하면") {
             deleteWorkspaceUseCase.execute(workspaceId)
-            then("delete 메서드를 호출해야함") {
-                verify { commandWorkspacePort.delete(workspace) }
+
+            then("워크스페이스가 조회되지 않아야함") {
+                queryWorkspacePort.findById(workspaceId) shouldBe null
             }
         }
 

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteWorkspaceUseCaseTest.kt
@@ -46,16 +46,15 @@ class DeleteWorkspaceUseCaseTest(
                 queryWorkspacePort.findById(workspaceId) shouldBe null
             }
         }
+    }
 
-        `when`("해당 id를 가진 workspace가 없을때") {
-            every { queryWorkspacePort.findById(workspaceId) } returns null
-
+    given("워크스페이스 아이디를 가진 워크스페이스가 주어지지 않고") {
+        `when`("유스케이스를 실행할때") {
             then("WorkspaceNotFoundException이 발생해야함") {
                 shouldThrow<WorkspaceNotFoundException> {
                     deleteWorkspaceUseCase.execute(workspaceId)
                 }
             }
         }
-
     }
 })

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteWorkspaceUseCaseTest.kt
@@ -28,8 +28,11 @@ class DeleteWorkspaceUseCaseTest(
     val userId = "user1"
     val workspaceId = "testWorkspaceId"
 
-    given("workspaceId가 주어지고") {
-        val workspaceId = UUID.randomUUID().toString()
+    beforeContainer {
+        val userDetails = authDetailsService.loadUserByUsername(userId)
+        val authenticationToken = UsernamePasswordAuthenticationToken(userDetails, "", userDetails.authorities)
+        SecurityContextHolder.getContext().authentication = authenticationToken
+    }
 
         `when`("해당 id를 가진 workspace가 있을때") {
             val user = UserGenerator.generateUser()


### PR DESCRIPTION
## 개요
* 워크스페이스 삭제 테스트 케이스 리펙토링합니다.
## 작업내용
* 기존 테스트를 SpringBootTest를 사용하도록 수정
* beforeContainer 추가
* 기존에 삭제됐는지 검증하는 테스트 케이스 수정
* 워크스페이스가 없는 테스트 케이스의 given절 분리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트 개선**
	- Spring Boot 통합 테스트로 전환
	- 종속성 관리 및 인증 컨텍스트 설정 강화
	- 워크스페이스 삭제 테스트 로직 개선
	- 사용자 인증 및 예외 처리 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->