### PR TITLE
🔀 :: [#440] - 워크스페이스 조회 테스트 케이스 리펙토링

### DIFF
--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/GetWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/GetWorkspaceUseCaseTest.kt
@@ -49,13 +49,15 @@ class GetWorkspaceUseCaseTest(
                 result.applicationList.isEmpty() shouldBe true
             }
         }
+    }
 
-        `when`("해당 id를 가진 workspace가 없을때") {
-            every { queryWorkspacePort.findById(workspaceId) } returns null
-            then("WorkspaceNotFoundException이 발생해야함") {
+    given("workspace가 주어지지 않고") {
+
+        `when`("유스케이스를 실행할때") {
+
+            then("에러가 발생해야함") {
                 shouldThrow<WorkspaceNotFoundException> {
                     getWorkspaceUseCase.execute(workspaceId)
-                    verify { queryWorkspacePort.findById(workspaceId) }
                 }
             }
         }

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/GetWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/GetWorkspaceUseCaseTest.kt
@@ -37,14 +37,11 @@ class GetWorkspaceUseCaseTest(
     }
 
         val workspace = WorkspaceGenerator.generateWorkspace(id = workspaceId, user = user)
+        commandWorkspacePort.save(workspace)
 
         `when`("해당 id를 가진 workspace가 있을때") {
-            every { queryWorkspacePort.findById(workspaceId) } returns workspace
-            every { queryApplicationPort.findAllByWorkspace(workspace) } returns listOf()
             val result = getWorkspaceUseCase.execute(workspaceId)
-            then("queryWorkspacePort가 실행되어야함") {
-                verify { queryWorkspacePort.findById(workspaceId) }
-            }
+
             then("result는 워크스페이스의 정보를 담고 있어야함") {
                 result.id shouldBe workspaceId
                 result.title shouldBe workspace.title

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/GetWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/GetWorkspaceUseCaseTest.kt
@@ -27,15 +27,14 @@ class GetWorkspaceUseCaseTest(
     val userId = "user1"
     val workspaceId = "testWorkspaceId"
 
-    given("workspaceId, workspace가 주어지고") {
-        val workspaceId = UUID.randomUUID().toString()
-        val user = UserGenerator.generateUser()
     beforeContainer {
         val userDetails = authDetailsService.loadUserByUsername(userId)
         val authenticationToken = UsernamePasswordAuthenticationToken(userDetails, "", userDetails.authorities)
         SecurityContextHolder.getContext().authentication = authenticationToken
     }
 
+    given("workspace가 주어지고") {
+        val user = queryUserPort.findById(userId)!!
         val workspace = WorkspaceGenerator.generateWorkspace(id = workspaceId, user = user)
         commandWorkspacePort.save(workspace)
 

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/GetWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/GetWorkspaceUseCaseTest.kt
@@ -30,6 +30,12 @@ class GetWorkspaceUseCaseTest(
     given("workspaceId, workspace가 주어지고") {
         val workspaceId = UUID.randomUUID().toString()
         val user = UserGenerator.generateUser()
+    beforeContainer {
+        val userDetails = authDetailsService.loadUserByUsername(userId)
+        val authenticationToken = UsernamePasswordAuthenticationToken(userDetails, "", userDetails.authorities)
+        SecurityContextHolder.getContext().authentication = authenticationToken
+    }
+
         val workspace = WorkspaceGenerator.generateWorkspace(id = workspaceId, user = user)
 
         `when`("해당 id를 가진 workspace가 있을때") {

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/GetWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/GetWorkspaceUseCaseTest.kt
@@ -1,23 +1,31 @@
 package com.dcd.server.core.domain.workspace.usecase
 
-import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.user.dto.extension.toDto
+import com.dcd.server.core.domain.user.spi.QueryUserPort
 import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
-import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
+import com.dcd.server.core.domain.workspace.spi.CommandWorkspacePort
+import com.dcd.server.infrastructure.global.security.auth.AuthDetailsService
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.verify
-import com.dcd.server.infrastructure.test.user.UserGenerator
 import com.dcd.server.infrastructure.test.workspace.WorkspaceGenerator
-import java.util.*
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
 
-class GetWorkspaceUseCaseTest : BehaviorSpec({
-    val queryWorkspacePort = mockk<QueryWorkspacePort>()
-    val queryApplicationPort = mockk<QueryApplicationPort>()
-    val getWorkspaceUseCase = GetWorkspaceUseCase(queryWorkspacePort, queryApplicationPort)
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class GetWorkspaceUseCaseTest(
+    private val getWorkspaceUseCase: GetWorkspaceUseCase,
+    private val authDetailsService: AuthDetailsService,
+    private val queryUserPort: QueryUserPort,
+    private val commandWorkspacePort: CommandWorkspacePort
+) : BehaviorSpec({
+    val userId = "user1"
+    val workspaceId = "testWorkspaceId"
 
     given("workspaceId, workspace가 주어지고") {
         val workspaceId = UUID.randomUUID().toString()


### PR DESCRIPTION
## 개요
* 워크스페이스 조회 테스트 케이스를 리펙토링합니다.
## 작업내용
* 기존 테스트에서 SpringBootTest를 사용하도록 수정
* beforeContainer 추가
* 기존에 스터빙하던 부분 제거
* 기존 given절 문구 수정
* 워크스페이스가 존재하지 않는 테스트 케이스를 given절로 분리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트**
	- 워크스페이스 조회 테스트 케이스의 통합 테스트 접근 방식으로 변경
	- 스프링 부트 테스트 어노테이션 및 의존성 주입 방식 업데이트
	- 인증 컨텍스트 설정 및 테스트 로직 재구성

<!-- end of auto-generated comment: release notes by coderabbit.ai -->