### PR TITLE
🔀 :: [#442] - 모든 워크스페이스 조회 테스트 케이스 리펙토링

### DIFF
--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/GetAllWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/GetAllWorkspaceUseCaseTest.kt
@@ -1,25 +1,34 @@
 package com.dcd.server.core.domain.workspace.usecase
 
-import com.dcd.server.core.domain.application.spi.QueryApplicationPort
-import com.dcd.server.core.domain.user.service.GetCurrentUserService
-import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
+import com.dcd.server.core.domain.user.spi.QueryUserPort
+import com.dcd.server.core.domain.workspace.spi.CommandWorkspacePort
+import com.dcd.server.infrastructure.global.security.auth.AuthDetailsService
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
-import io.mockk.every
-import io.mockk.mockk
-import com.dcd.server.infrastructure.test.user.UserGenerator
 import com.dcd.server.infrastructure.test.workspace.WorkspaceGenerator
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
 import java.util.*
-
-class GetAllWorkspaceUseCaseTest : BehaviorSpec({
-    val getCurrentUserService = mockk<GetCurrentUserService>()
-    val queryWorkspacePort = mockk<QueryWorkspacePort>()
-    val queryApplicationPort = mockk<QueryApplicationPort>()
-    val getAllWorkspaceUseCase = GetAllWorkspaceUseCase(getCurrentUserService, queryWorkspacePort, queryApplicationPort)
 
     given("workspaceId, workspace, workspaceList, user가 주어지고") {
         val user = UserGenerator.generateUser()
         val firstWorkspaceId = UUID.randomUUID().toString()
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class GetAllWorkspaceUseCaseTest(
+    private val getAllWorkspaceUseCase: GetAllWorkspaceUseCase,
+    private val authDetailsService: AuthDetailsService,
+    private val queryUserPort: QueryUserPort,
+    private val commandWorkspacePort: CommandWorkspacePort
+) : BehaviorSpec({
+    val userId = "user2"
+    val firstWorkspaceId = UUID.randomUUID().toString()
+    val secondWorkspaceId = UUID.randomUUID().toString()
+
         val firstWorkspace = WorkspaceGenerator.generateWorkspace(id = firstWorkspaceId, user = user)
         val secondWorkspaceId = UUID.randomUUID().toString()
         val secondWorkspace = WorkspaceGenerator.generateWorkspace(id = secondWorkspaceId, user = user)

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/GetAllWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/GetAllWorkspaceUseCaseTest.kt
@@ -41,19 +41,16 @@ class GetAllWorkspaceUseCaseTest(
             commandWorkspacePort.save(it)
         }
 
-        `when`("해당 user가 workspace를 여러개 가지고 있을때") {
-            every { getCurrentUserService.getCurrentUser() } returns user
-            every { queryWorkspacePort.findByUser(user) } returns workspaceList
-            every { queryApplicationPort.findAllByWorkspace(firstWorkspace) } returns listOf()
-            every { queryApplicationPort.findAllByWorkspace(secondWorkspace) } returns listOf()
-
+        `when`("유스케이스를 실행할때") {
             val result = getAllWorkspaceUseCase.execute()
+
             then("주어진 workspace가 전부 반환되어야함") {
                 val firstWorkspaceResult = result.list[0]
                 firstWorkspaceResult.id shouldBe firstWorkspaceId
                 firstWorkspaceResult.title shouldBe firstWorkspace.title
                 firstWorkspaceResult.description shouldBe firstWorkspace.description
                 firstWorkspaceResult.applicationList.isEmpty() shouldBe true
+
                 val secondWorkspaceResult = result.list[1]
                 secondWorkspaceResult.id shouldBe secondWorkspaceId
                 secondWorkspaceResult.title shouldBe secondWorkspace.title

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/GetAllWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/GetAllWorkspaceUseCaseTest.kt
@@ -60,4 +60,14 @@ class GetAllWorkspaceUseCaseTest(
         }
     }
 
+    given("워크스페이스가 하나도 주어지지 않고") {
+
+        `when`("유스케이스를 실행할때") {
+            val result = getAllWorkspaceUseCase.execute()
+
+            then("아무것도 조회되지 않아야함") {
+                result.list.isEmpty() shouldBe true
+            }
+        }
+    }
 })

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/GetAllWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/GetAllWorkspaceUseCaseTest.kt
@@ -32,6 +32,8 @@ class GetAllWorkspaceUseCaseTest(
         SecurityContextHolder.getContext().authentication = authenticationToken
     }
 
+    given("2개의 워크스페이스가 주어지고") {
+        val user = queryUserPort.findById(userId)!!
         val firstWorkspace = WorkspaceGenerator.generateWorkspace(id = firstWorkspaceId, user = user)
         val secondWorkspaceId = UUID.randomUUID().toString()
         val secondWorkspace = WorkspaceGenerator.generateWorkspace(id = secondWorkspaceId, user = user)

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/GetAllWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/GetAllWorkspaceUseCaseTest.kt
@@ -13,9 +13,6 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
 import java.util.*
 
-    given("workspaceId, workspace, workspaceList, user가 주어지고") {
-        val user = UserGenerator.generateUser()
-        val firstWorkspaceId = UUID.randomUUID().toString()
 @Transactional
 @SpringBootTest
 @ActiveProfiles("test")
@@ -28,6 +25,12 @@ class GetAllWorkspaceUseCaseTest(
     val userId = "user2"
     val firstWorkspaceId = UUID.randomUUID().toString()
     val secondWorkspaceId = UUID.randomUUID().toString()
+
+    beforeContainer {
+        val userDetails = authDetailsService.loadUserByUsername(userId)
+        val authenticationToken = UsernamePasswordAuthenticationToken(userDetails, "", userDetails.authorities)
+        SecurityContextHolder.getContext().authentication = authenticationToken
+    }
 
         val firstWorkspace = WorkspaceGenerator.generateWorkspace(id = firstWorkspaceId, user = user)
         val secondWorkspaceId = UUID.randomUUID().toString()

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/GetAllWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/GetAllWorkspaceUseCaseTest.kt
@@ -35,9 +35,11 @@ class GetAllWorkspaceUseCaseTest(
     given("2개의 워크스페이스가 주어지고") {
         val user = queryUserPort.findById(userId)!!
         val firstWorkspace = WorkspaceGenerator.generateWorkspace(id = firstWorkspaceId, user = user)
-        val secondWorkspaceId = UUID.randomUUID().toString()
         val secondWorkspace = WorkspaceGenerator.generateWorkspace(id = secondWorkspaceId, user = user)
         val workspaceList = listOf(firstWorkspace, secondWorkspace)
+        workspaceList.forEach {
+            commandWorkspacePort.save(it)
+        }
 
         `when`("해당 user가 workspace를 여러개 가지고 있을때") {
             every { getCurrentUserService.getCurrentUser() } returns user


### PR DESCRIPTION
## 개요
* 모든 워크스페이스를 조회하는 유스케이스의 테스트 케이스를 리펙토링합니다.
## 작업내용
* 기존 테스트 코드를 SpringBootTest를 사용하도록 수정
* beforeContainer 추가
* 기존 given절 문구 수정
* 워크스페이스를 저장하는 로직 추가
* 기존 목객체에서 스터빙하는 로직 제거
* 워크스페이스가 주어지지않는 테스트 케이스 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트 개선**
	- 워크스페이스 관련 테스트 케이스 업데이트
	- 통합 테스트 접근 방식으로 전환
	- 보안 컨텍스트 설정 추가
	- 엣지 케이스 테스트 포함 (빈 워크스페이스 시나리오)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->