### PR TITLE
🔀 :: [#446] - 전역 환경변수 삭제 유스케이스 테스트 리펙토링

### DIFF
--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteGlobalEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteGlobalEnvUseCaseTest.kt
@@ -58,14 +58,13 @@ class DeleteGlobalEnvUseCaseTest(
         }
 
         `when`("해당 워크스페이스가 존재하고, 해당 환경변수가 존재하지 않을때") {
-            val user = UserGenerator.generateUser()
-            val workspace = spyk(WorkspaceGenerator.generateWorkspace(id = workspaceId, user = user))
-            every { getCurrentUserService.getCurrentUser() } returns user
-            every { queryWorkspacePort.findById(workspaceId) } returns workspace
+            val user = queryUserPort.findById(userId)!!
+            val workspace = WorkspaceGenerator.generateWorkspace(id = targetWorkspaceId, user = user)
+            commandWorkspacePort.save(workspace)
 
             then("GlobalEnvNotFoundException이 발생해야함") {
                 shouldThrow<GlobalEnvNotFoundException> {
-                    deleteGlobalEnvUseCase.execute(workspaceId, key)
+                    deleteGlobalEnvUseCase.execute(targetWorkspaceId, key)
                 }
             }
         }

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteGlobalEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteGlobalEnvUseCaseTest.kt
@@ -83,4 +83,18 @@ class DeleteGlobalEnvUseCaseTest(
             }
         }
     }
+
+    given("워크스페이스가 존재하지 않을때") {
+        val notFoundWorkspaceId = "notFoundWorkspaceId"
+        val key = "testEnvKey"
+
+        `when`("유스케이스를 실행하면") {
+
+            then("에러가 발생해야함") {
+                shouldThrow<WorkspaceNotFoundException> {
+                    deleteGlobalEnvUseCase.execute(notFoundWorkspaceId, key)
+                }
+            }
+        }
+    }
 })

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteGlobalEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteGlobalEnvUseCaseTest.kt
@@ -71,13 +71,14 @@ class DeleteGlobalEnvUseCaseTest(
 
         `when`("해당 워크스페이스의 유저가 로그인된 유저가 아닐때") {
             val user = UserGenerator.generateUser()
-            val workspace = spyk(WorkspaceGenerator.generateWorkspace(id = workspaceId))
-            every { getCurrentUserService.getCurrentUser() } returns user
-            every { queryWorkspacePort.findById(workspaceId) } returns workspace
+            commandUserPort.save(user)
+            val userDetails = authDetailsService.loadUserByUsername(user.id)
+            val authenticationToken = UsernamePasswordAuthenticationToken(userDetails, "", userDetails.authorities)
+            SecurityContextHolder.getContext().authentication = authenticationToken
 
             then("WorkspaceOwnerNotSameException이 발생해야함") {
                 shouldThrow<WorkspaceOwnerNotSameException> {
-                    deleteGlobalEnvUseCase.execute(workspaceId, key)
+                    deleteGlobalEnvUseCase.execute(targetWorkspaceId, key)
                 }
             }
         }

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteGlobalEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteGlobalEnvUseCaseTest.kt
@@ -44,22 +44,16 @@ class DeleteGlobalEnvUseCaseTest(
         commandWorkspacePort.save(workspace)
     }
 
-    given("workspaceId, 삭제할 환경변수의 키값이 주어지고") {
-        val workspaceId = UUID.randomUUID().toString()
+    given("삭제할 환경변수의 키값이 주어지고") {
         val key = "testEnvKey"
 
-        `when`("해당 워크스페이스가 존재하고, 해당 환경변수가 존재할때") {
-            val env = mapOf(key to "testValue")
-            val user = UserGenerator.generateUser()
-            val workspace = spyk(WorkspaceGenerator.generateWorkspace(id = workspaceId, globalEnv = env, user = user))
-            every { getCurrentUserService.getCurrentUser() } returns user
-            every { queryWorkspacePort.findById(workspaceId) } returns workspace
+        `when`("유스케이스를 실행할때") {
+            deleteGlobalEnvUseCase.execute(targetWorkspaceId, key)
 
-            deleteGlobalEnvUseCase.execute(workspaceId, key)
-
-            then("해당 키가 삭제된 워크스페이스를 저장해야함") {
-                verify { workspace.copy(globalEnv = mapOf()) }
-                verify { commandWorkspacePort.save(any() as Workspace) }
+            then("해당 키를 가진 전역 환경변수가 삭제되야함") {
+                val result = queryWorkspacePort.findById(targetWorkspaceId)
+                result shouldNotBe null
+                result?.globalEnv?.get(key) shouldBe null
             }
         }
 

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteGlobalEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteGlobalEnvUseCaseTest.kt
@@ -1,23 +1,39 @@
 package com.dcd.server.core.domain.workspace.usecase
 
-import com.dcd.server.core.domain.user.service.GetCurrentUserService
+import com.dcd.server.core.domain.user.spi.CommandUserPort
+import com.dcd.server.core.domain.user.spi.QueryUserPort
 import com.dcd.server.core.domain.workspace.exception.GlobalEnvNotFoundException
 import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
 import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameException
-import com.dcd.server.core.domain.workspace.model.Workspace
 import com.dcd.server.core.domain.workspace.spi.CommandWorkspacePort
 import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
+import com.dcd.server.infrastructure.global.security.auth.AuthDetailsService
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.spyk
-import io.mockk.verify
 import com.dcd.server.infrastructure.test.user.UserGenerator
 import com.dcd.server.infrastructure.test.workspace.WorkspaceGenerator
-import java.util.*
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
 
-class DeleteGlobalEnvUseCaseTest : BehaviorSpec({
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class DeleteGlobalEnvUseCaseTest(
+    private val deleteGlobalEnvUseCase: DeleteGlobalEnvUseCase,
+    private val authDetailsService: AuthDetailsService,
+    private val queryUserPort: QueryUserPort,
+    private val commandWorkspacePort: CommandWorkspacePort,
+    private val queryWorkspacePort: QueryWorkspacePort,
+    private val commandUserPort: CommandUserPort
+) : BehaviorSpec({
+    val userId = "user2"
+    val targetWorkspaceId = "testWorkspaceId"
+
     val queryWorkspacePort = mockk<QueryWorkspacePort>(relaxUnitFun = true)
     val getCurrentUserService = mockk<GetCurrentUserService>()
     val commandWorkspacePort = mockk<CommandWorkspacePort>(relaxUnitFun = true)

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteGlobalEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteGlobalEnvUseCaseTest.kt
@@ -34,10 +34,15 @@ class DeleteGlobalEnvUseCaseTest(
     val userId = "user2"
     val targetWorkspaceId = "testWorkspaceId"
 
-    val queryWorkspacePort = mockk<QueryWorkspacePort>(relaxUnitFun = true)
-    val getCurrentUserService = mockk<GetCurrentUserService>()
-    val commandWorkspacePort = mockk<CommandWorkspacePort>(relaxUnitFun = true)
-    val deleteGlobalEnvUseCase = DeleteGlobalEnvUseCase(queryWorkspacePort, getCurrentUserService, commandWorkspacePort)
+    beforeContainer {
+        val userDetails = authDetailsService.loadUserByUsername(userId)
+        val authenticationToken = UsernamePasswordAuthenticationToken(userDetails, "", userDetails.authorities)
+        SecurityContextHolder.getContext().authentication = authenticationToken
+
+        val user = queryUserPort.findById(userId)!!
+        val workspace = WorkspaceGenerator.generateWorkspace(id = targetWorkspaceId, user = user, globalEnv = mapOf("testEnvKey" to "test"))
+        commandWorkspacePort.save(workspace)
+    }
 
     given("workspaceId, 삭제할 환경변수의 키값이 주어지고") {
         val workspaceId = UUID.randomUUID().toString()

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteGlobalEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteGlobalEnvUseCaseTest.kt
@@ -69,18 +69,6 @@ class DeleteGlobalEnvUseCaseTest(
             }
         }
 
-        `when`("해당 워크스페이스가 존재하지 않을때") {
-            val user = UserGenerator.generateUser()
-            every { getCurrentUserService.getCurrentUser() } returns user
-            every { queryWorkspacePort.findById(workspaceId) } returns null
-
-            then("WorkspaceNotFoundException이 발생해야함") {
-                shouldThrow<WorkspaceNotFoundException> {
-                    deleteGlobalEnvUseCase.execute(workspaceId, key)
-                }
-            }
-        }
-
         `when`("해당 워크스페이스의 유저가 로그인된 유저가 아닐때") {
             val user = UserGenerator.generateUser()
             val workspace = spyk(WorkspaceGenerator.generateWorkspace(id = workspaceId))


### PR DESCRIPTION
## 개요
* 전역 환경변수 삭제 유스케이스 테스트를 리펙토링합니다.
## 작업내용
* 기존 테스트에서 SpringBootTest를 사용하도록 수정
* beforeContainer 추가
* 전역 환경변수가 삭제됐는지 검증하는 테스트 케이스 수정
* 삭제할 키를 가진 전역 환경변수가 존재하지 않을때 에러가 발생하는지 검증하는 테스트 케이스 수정
* 워크스페이스가 존재하지 않는 테스트 케이스 삭제
* 워크스페이스의 소유자가 일치하지 않을때 에러가 발생하는지 검증하는 테스트 케이스 수정
* 워크스페이스가 주어지지않는 given절 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트 개선**
	- 테스트 클래스의 의존성 및 구조를 업데이트했습니다.
	- 모의 객체(mock) 대신 실제 서비스 구현을 사용하도록 테스트 접근 방식을 변경했습니다.
	- 예외 처리 및 테스트 시나리오를 더욱 현실적으로 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->