### PR TITLE
🔀 :: [#450] - 단일 애플리케이션 조회 유스케이스 테스트 리펙토링

### DIFF
--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCaseTest.kt
@@ -2,19 +2,27 @@ package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.domain.application.dto.extenstion.toDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
-import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import com.dcd.server.core.domain.application.spi.CommandApplicationPort
+import com.dcd.server.core.domain.user.spi.QueryUserPort
+import com.dcd.server.core.domain.workspace.spi.CommandWorkspacePort
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
-import io.mockk.every
-import io.mockk.mockk
 import com.dcd.server.infrastructure.test.application.ApplicationGenerator
-import com.dcd.server.infrastructure.test.user.UserGenerator
 import com.dcd.server.infrastructure.test.workspace.WorkspaceGenerator
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
 
-class GetOneApplicationUseCaseTest : BehaviorSpec({
-    val queryApplicationPort = mockk<QueryApplicationPort>()
-    val getOneApplicationUseCase = GetOneApplicationUseCase(queryApplicationPort)
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class GetOneApplicationUseCaseTest(
+    private val getOneApplicationUseCase: GetOneApplicationUseCase,
+    private val commandApplicationPort: CommandApplicationPort,
+    private val queryUserPort: QueryUserPort,
+    private val commandWorkspacePort: CommandWorkspacePort
+) : BehaviorSpec({
 
     given("애플리케이션이 주어지고") {
         val user = UserGenerator.generateUser()

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCaseTest.kt
@@ -7,9 +7,9 @@ import com.dcd.server.core.domain.user.spi.QueryUserPort
 import com.dcd.server.core.domain.workspace.spi.CommandWorkspacePort
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
-import io.kotest.matchers.shouldBe
 import com.dcd.server.infrastructure.test.application.ApplicationGenerator
 import com.dcd.server.infrastructure.test.workspace.WorkspaceGenerator
+import io.kotest.matchers.equality.shouldBeEqualToComparingFields
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
@@ -25,13 +25,17 @@ class GetOneApplicationUseCaseTest(
 ) : BehaviorSpec({
 
     given("애플리케이션이 주어지고") {
-        val user = UserGenerator.generateUser()
-        val application = ApplicationGenerator.generateApplication(workspace = WorkspaceGenerator.generateWorkspace(user = user))
+        val user = queryUserPort.findById("user2")!!
+        val workspace = WorkspaceGenerator.generateWorkspace(user = user)
+        commandWorkspacePort.save(workspace)
+        val application = ApplicationGenerator.generateApplication(workspace = workspace)
+        commandApplicationPort.save(application)
+
         `when`("해당 애플리케이션이 있을때") {
-            every { queryApplicationPort.findById(application.id) } returns application
             val result = getOneApplicationUseCase.execute(application.id)
+
             then("result는 application의 내용이랑 같아야함") {
-                result shouldBe application.toDto()
+                result shouldBeEqualToComparingFields application.toDto()
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCaseTest.kt
@@ -34,12 +34,15 @@ class GetOneApplicationUseCaseTest(
                 result shouldBe application.toDto()
             }
         }
-        `when`("해당 애플리케이션이 없을때") {
-            every { queryApplicationPort.findById(application.id) } returns null
+    }
 
-            then("result는 application의 내용이랑 같아야함") {
+    given("애플리케이션이 주어지지 않고") {
+
+        `when`("유스케이스를 실행하면") {
+
+            then("에러가 발생해야함") {
                 shouldThrow<ApplicationNotFoundException> {
-                    getOneApplicationUseCase.execute(application.id)
+                    getOneApplicationUseCase.execute("notFoundId")
                 }
             }
         }


### PR DESCRIPTION
## 개요
* 단일 애플리케이션을 조회하는 유스케이스 테스트를 리펙토링합니다.
## 작업내용
* 기존 테스트에서 SpringBootTest를 사용하도록 수정
* 애플리케이션이 주어지지 않는 테스트 케이스를 다른 given절로 분리
* 애플리케이션이 조회되는 테스트 케이스 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트 개선**
	- 애플리케이션 조회 테스트 케이스의 테스트 방식을 개선했습니다.
	- 모킹 대신 실제 포트와 의존성 주입을 사용하여 테스트 안정성을 높였습니다.
	- 엔티티 조회 및 예외 처리 로직을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->