### PR TITLE
🔀 :: [#452] - 모든 애플리케이션 조회 유스케이스 테스트 리펙토링

### DIFF
--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCaseTest.kt
@@ -26,6 +26,11 @@ class GetAllApplicationUseCaseTest(
 ) : BehaviorSpec({
     val userId = "user1"
 
+    beforeContainer {
+        val userDetails = authDetailsService.loadUserByUsername(userId)
+        val authenticationToken = UsernamePasswordAuthenticationToken(userDetails, "", userDetails.authorities)
+        SecurityContextHolder.getContext().authentication = authenticationToken
+    }
 
     given("applicationList가 주어지고") {
         val user = UserGenerator.generateUser()

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCaseTest.kt
@@ -3,19 +3,29 @@ package com.dcd.server.core.domain.application.usecase
 import com.dcd.server.core.domain.application.dto.extenstion.toDto
 import com.dcd.server.core.domain.application.dto.response.ApplicationListResDto
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import com.dcd.server.core.domain.user.spi.QueryUserPort
 import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
+import com.dcd.server.infrastructure.global.security.auth.AuthDetailsService
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
-import io.mockk.every
-import io.mockk.mockk
-import com.dcd.server.infrastructure.test.application.ApplicationGenerator
-import com.dcd.server.infrastructure.test.user.UserGenerator
-import com.dcd.server.infrastructure.test.workspace.WorkspaceGenerator
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
 
-class GetAllApplicationUseCaseTest : BehaviorSpec({
-    val queryApplicationPort = mockk<QueryApplicationPort>()
-    val queryWorkspacePort = mockk<QueryWorkspacePort>()
-    val getAllApplicationUseCase = GetAllApplicationUseCase(queryApplicationPort, queryWorkspacePort)
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class GetAllApplicationUseCaseTest(
+    private val getAllApplicationUseCase: GetAllApplicationUseCase,
+    private val authDetailsService: AuthDetailsService,
+    private val queryWorkspacePort: QueryWorkspacePort,
+    private val queryUserPort: QueryUserPort,
+    private val queryApplicationPort: QueryApplicationPort
+) : BehaviorSpec({
+    val userId = "user1"
+
 
     given("applicationList가 주어지고") {
         val user = UserGenerator.generateUser()

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCaseTest.kt
@@ -33,13 +33,10 @@ class GetAllApplicationUseCaseTest(
     }
 
     given("applicationList가 주어지고") {
-        val user = UserGenerator.generateUser()
-        val workspace = WorkspaceGenerator.generateWorkspace(user = user)
-        val application = ApplicationGenerator.generateApplication(workspace = workspace)
-        val applicationList = listOf(application)
+        val workspace = queryWorkspacePort.findByUser(queryUserPort.findById(userId)!!).first()
+        val applicationList = queryApplicationPort.findAllByWorkspace(workspace)
+
         `when`("usecase를 실행할때") {
-            every { queryApplicationPort.findAllByWorkspace(workspace) } returns applicationList
-            every { queryWorkspacePort.findById(workspace.id) } returns workspace
             val result = getAllApplicationUseCase.execute(workspace.id, null)
             val target = ApplicationListResDto(applicationList.map { it.toDto() })
             then("result는 target이랑 같아야함") {


### PR DESCRIPTION
## 개요
* 모든 애플리케이션을 조회하는 유스케이스의 테스트에서 SpringBootTest를 사용하도록 리펙토링합니다.
## 작업내용
* 기존 테스트를 SpringBootTest를 사용하도록 수정
* beforeContainer 추가
* 검증 로직 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트 개선**
	- 테스트 클래스의 통합 테스트 접근 방식 업데이트
	- 스프링 부트 테스트 환경 구성
	- 실제 서비스 호출을 통한 데이터 검증 방식으로 변경
	- 보안 컨텍스트 초기화 로직 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->