### PR TITLE
🔀 :: [#464] - 애플리케이션 생성 유스케이스 테스트 리펙토링

### DIFF
--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
@@ -27,7 +27,7 @@ class CreateApplicationUseCaseTest(
 ) : BehaviorSpec({
     var targetWorkspaceId = ""
 
-    beforeSpec {
+    beforeContainer {
         val user = queryUserPort.findById("user2")!!
         val workspace = WorkspaceGenerator.generateWorkspace(user = user)
         commandWorkspacePort.save(workspace)

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
@@ -53,4 +53,26 @@ class CreateApplicationUseCaseTest(
             }
         }
     }
+
+    given("이미 존재하는 애플리케이션 이름이 주어지고") {
+        val existsApplicationRequest = CreateApplicationReqDto(
+            name = "testName",
+            description = "testDescription",
+            applicationType = ApplicationType.SPRING_BOOT,
+            env = mapOf(),
+            githubUrl = "testGithub",
+            version = "17",
+            port = 8080,
+            labels = listOf()
+        )
+
+        `when`("usecase를 실행하면") {
+
+            then("에러가 발생해야함") {
+                shouldThrow<AlreadyExistsApplicationException> {
+                    createApplicationUseCase.execute(targetWorkspaceId, existsApplicationRequest)
+                }
+            }
+        }
+    }
 })

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
@@ -75,4 +75,27 @@ class CreateApplicationUseCaseTest(
             }
         }
     }
+
+    given("존재하지 않는 워크스페이스 아이디가 주어지고") {
+        val notFoundWorkspaceId = "notFoundWorkspaceId"
+        val request = CreateApplicationReqDto(
+            name = "testCreateApplication",
+            description = "testDescription",
+            applicationType = ApplicationType.SPRING_BOOT,
+            env = mapOf(),
+            githubUrl = "testGithub",
+            version = "17",
+            port = 8080,
+            labels = listOf()
+        )
+
+        `when`("usecase를 실행하면") {
+
+            then("에러가 발생해야함") {
+                shouldThrow<WorkspaceNotFoundException> {
+                    createApplicationUseCase.execute(notFoundWorkspaceId, request)
+                }
+            }
+        }
+    }
 })

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
@@ -11,6 +11,7 @@ import io.kotest.core.spec.style.BehaviorSpec
 import com.dcd.server.infrastructure.test.workspace.WorkspaceGenerator
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.cancel
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
@@ -47,6 +48,7 @@ class CreateApplicationUseCaseTest(
 
         `when`("usecase를 실행하면") {
             createApplicationUseCase.execute(targetWorkspaceId, request)
+            createApplicationUseCase.coroutineContext.cancel()
 
             then("요청의 이름을 가진 애플리케이션이 존재해야함") {
                 queryApplicationPort.existsByName(request.name) shouldBe true

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
@@ -27,6 +27,13 @@ class CreateApplicationUseCaseTest(
     var targetWorkspaceId = ""
 
     given("CreateApplicationReqDto와 유저가 주어지고") {
+    beforeSpec {
+        val user = queryUserPort.findById("user2")!!
+        val workspace = WorkspaceGenerator.generateWorkspace(user = user)
+        commandWorkspacePort.save(workspace)
+        targetWorkspaceId = workspace.id
+    }
+
         val request = CreateApplicationReqDto(
             name = "testName",
             description = "testDescription",


### PR DESCRIPTION
## 개요
* 애플리케이션 생성 유스케이스 테스트를 리펙토링합니다.
## 작업내용
* 기존 테스트에서 SpringBootTest를 사용하도록 수정
* beforeSpec 추가
* 기존 애플리케이션 생성을 검증하던 테스트 케이스 수정
* 이미 존재하는 애플리케이션 이름이 주어지는 테스트 케이스 추가
* 존재하지 않는 워크스페이스 아이디가 주어지는 테스트 케이스 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **테스트 개선**
	- 통합 테스트 접근 방식으로 전환
	- 애플리케이션 생성 유스케이스에 대한 테스트 시나리오 확장
	- 예외 처리 검증 강화 (중복 애플리케이션, 존재하지 않는 워크스페이스 ID)
	- 데이터베이스 상호작용을 포함한 실제 서비스 구현 테스트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->