### PR TITLE
🔀 :: [#466] - SecurityService 테스트 리펙토링

### DIFF
--- a/src/test/kotlin/com/dcd/server/core/common/service/SecurityServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/common/service/SecurityServiceImplTest.kt
@@ -30,12 +30,12 @@ class SecurityServiceImplTest(
     }
 
     given("현재 유저 id가 주어지고") {
-        val testUserId = "testUserId"
-        every { securityPort.getCurrentUserId() } returns testUserId
-        `when`("securityPort에서 주어진 id를 반환할때") {
+
+        `when`("현재 로그인된 유저의 아이디를 조회할때") {
             val result = securityServiceImpl.getCurrentUserId()
+
             then("결과값은 반환된 유저 id여야함") {
-                result shouldBe testUserId
+                result shouldBe targetUserId
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/core/common/service/SecurityServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/common/service/SecurityServiceImplTest.kt
@@ -2,16 +2,26 @@ package com.dcd.server.core.common.service
 
 import com.dcd.server.core.common.service.exception.PasswordNotCorrectException
 import com.dcd.server.core.common.service.impl.SecurityServiceImpl
-import com.dcd.server.core.common.spi.SecurityPort
+import com.dcd.server.infrastructure.global.security.auth.AuthDetailsService
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
-import io.mockk.every
-import io.mockk.mockk
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
 
-class SecurityServiceImplTest : BehaviorSpec({
-    val securityPort = mockk<SecurityPort>()
-    val securityServiceImpl = SecurityServiceImpl(securityPort)
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class SecurityServiceImplTest(
+    private val securityServiceImpl: SecurityServiceImpl,
+    private val authDetailsService: AuthDetailsService,
+    private val passwordEncoder: PasswordEncoder
+) : BehaviorSpec({
+    val targetUserId = "user2"
 
     given("현재 유저 id가 주어지고") {
         val testUserId = "testUserId"

--- a/src/test/kotlin/com/dcd/server/core/common/service/SecurityServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/common/service/SecurityServiceImplTest.kt
@@ -42,12 +42,12 @@ class SecurityServiceImplTest(
 
     given("rawPassword가 주어지고") {
         val rawPassword = "rawPassword"
-        val encodedPassword = "encodedPassword"
-        every { securityPort.encodeRawPassword(rawPassword) } returns encodedPassword
+
         `when`("securityPort에서 인코딩된 패스워드를 반환할때") {
             val result = securityServiceImpl.encodePassword(rawPassword)
+
             then("결과값은 encodedPassword여야함") {
-                result shouldBe encodedPassword
+                passwordEncoder.matches(rawPassword, result) shouldBe true
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/core/common/service/SecurityServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/common/service/SecurityServiceImplTest.kt
@@ -23,6 +23,12 @@ class SecurityServiceImplTest(
 ) : BehaviorSpec({
     val targetUserId = "user2"
 
+    beforeContainer {
+        val userDetails = authDetailsService.loadUserByUsername(targetUserId)
+        val authenticationToken = UsernamePasswordAuthenticationToken(userDetails, "", userDetails.authorities)
+        SecurityContextHolder.getContext().authentication = authenticationToken
+    }
+
     given("현재 유저 id가 주어지고") {
         val testUserId = "testUserId"
         every { securityPort.getCurrentUserId() } returns testUserId

--- a/src/test/kotlin/com/dcd/server/core/common/service/SecurityServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/common/service/SecurityServiceImplTest.kt
@@ -52,19 +52,26 @@ class SecurityServiceImplTest(
         }
     }
 
-    given("rawPassword와 encodedPassword가 주어지고") {
+    given("일반 패스워드와 암호화된 패스워드가 주어지고") {
         val rawPassword = "rawPassword"
-        val encodedPassword = "encodedPassword"
-        every { securityPort.isCorrectPassword(rawPassword, encodedPassword) } returns true
-        `when`("securityPort에서 true를 반환하면") {
+        val encodedPassword = passwordEncoder.encode(rawPassword)
+
+        `when`("패스워드가 일치하는지 검사하면") {
             val result = securityServiceImpl.matchPassword(rawPassword, encodedPassword)
-            then("결과값은 Unit이여야함") {
+
+            then("에러없이 Unit을 반환해야함") {
                 result shouldBe Unit
             }
         }
-        every { securityPort.isCorrectPassword(rawPassword, encodedPassword) } returns false
-        `when`("securityPort에서 false를 반환하면") {
-            then("PasswordNotCorrectException이 발생해야함") {
+    }
+
+    given("일반 패스워드와 암호화되지 않은 패스워드가 주어지고") {
+        val rawPassword = "rawPassword"
+        val encodedPassword = "incorrectPassword"
+
+        `when`("패스워드가 일치하는지 검사하면") {
+
+            then("에러가 발생해야함") {
                 shouldThrow<PasswordNotCorrectException> {
                     securityServiceImpl.matchPassword(rawPassword, encodedPassword)
                 }


### PR DESCRIPTION
## 개요
* SecurityService 테스트를 리펙토링합니다.
## 작업내용
* 기존 테스트에서 SpringBootTest를 사용하도록 수정
* beforeContainer 추가
* 로그인된 유저를 조회하는 테스트 케이스 수정
* 패스워드 암호화 메서드의 테스트 케이스 수정
* 패스워드가 일치하는지 검증하는 메서드의 테스트 케이스 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트 개선**
	- 보안 서비스 테스트 케이스의 통합 테스트 방식으로 전환
	- 실제 서비스 구현체를 사용한 테스트 로직 개선
	- 비밀번호 인코딩 및 사용자 인증 테스트 강화
	- Spring 테스트 프레임워크 활용하여 테스트 환경 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->