### PR TITLE
🔀 :: [#468] - CreateNetworkService 테스트 리펙토링

### DIFF
--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/service/CreateNetworkServiceTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/service/CreateNetworkServiceTest.kt
@@ -2,13 +2,19 @@ package com.dcd.server.core.domain.workspace.service
 
 import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.domain.workspace.service.impl.CreateNetworkServiceImpl
+import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.BehaviorSpec
-import io.mockk.mockk
 import io.mockk.verify
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
 
 class CreateNetworkServiceTest : BehaviorSpec({
     val commandPort = mockk<CommandPort>(relaxed = true)
     val createNetworkService = CreateNetworkServiceImpl(commandPort)
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
 
     given("생성할 네트워크 제목을 주어지고") {
         val testNetworkTitle = "test network"

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/service/CreateNetworkServiceTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/service/CreateNetworkServiceTest.kt
@@ -9,12 +9,14 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
 
-class CreateNetworkServiceTest : BehaviorSpec({
-    val commandPort = mockk<CommandPort>(relaxed = true)
-    val createNetworkService = CreateNetworkServiceImpl(commandPort)
 @Transactional
 @SpringBootTest
 @ActiveProfiles("test")
+class CreateNetworkServiceTest(
+    private val createNetworkService: CreateNetworkServiceImpl,
+    @MockkBean(relaxed = true)
+    private val commandPort: CommandPort
+) : BehaviorSpec({
 
     given("생성할 네트워크 제목을 주어지고") {
         val testNetworkTitle = "test network"


### PR DESCRIPTION
## 개요
* CreateNetworkService 테스트를 리펙토링합니다.
## 작업내용
* 기존 테스트에서 SpringBootTest를 사용하도록 수정
* MockkBean을 사용해서 테스트하도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트**
	- 네트워크 생성 서비스 테스트 클래스의 종속성 주입 및 모킹 방식 개선
	- 스프링 부트 테스트 환경 설정 업데이트
	- 테스트 프로필 및 트랜잭션 지원 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->