### PR TITLE
🔀 :: [#470] - ValidateWorkspaceOwnerService 테스트 리펙토링

### DIFF
--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/service/ValidateWorkspaceOwnerServiceTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/service/ValidateWorkspaceOwnerServiceTest.kt
@@ -70,6 +70,8 @@ class ValidateWorkspaceOwnerServiceTest(
                 result shouldBe Unit
             }
         }
+
+        SecurityContextHolder.getContext().authentication = null
     }
 
     given("시큐리티 컨텍스트에 소유자가 아닌 유저가 주어지고") {
@@ -85,5 +87,7 @@ class ValidateWorkspaceOwnerServiceTest(
                 }
             }
         }
+
+        SecurityContextHolder.getContext().authentication = null
     }
 })

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/service/ValidateWorkspaceOwnerServiceTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/service/ValidateWorkspaceOwnerServiceTest.kt
@@ -71,4 +71,19 @@ class ValidateWorkspaceOwnerServiceTest(
             }
         }
     }
+
+    given("시큐리티 컨텍스트에 소유자가 아닌 유저가 주어지고") {
+        val userDetails = authDetailsService.loadUserByUsername(otherUser.id)
+        val authenticationToken = UsernamePasswordAuthenticationToken(userDetails, "", userDetails.authorities)
+        SecurityContextHolder.getContext().authentication = authenticationToken
+
+        `when`("validateOwner 메서드를 실행하면") {
+
+            then("에러가 발생해야함") {
+                shouldThrow<WorkspaceOwnerNotSameException> {
+                    validateWorkspaceOwnerServiceImpl.validateOwner(workspace)
+                }
+            }
+        }
+    }
 })

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/service/ValidateWorkspaceOwnerServiceTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/service/ValidateWorkspaceOwnerServiceTest.kt
@@ -57,4 +57,18 @@ class ValidateWorkspaceOwnerServiceTest(
             }
         }
     }
+
+    given("시큐리티 컨텍스트에 소유자가 주어지고") {
+        val userDetails = authDetailsService.loadUserByUsername(owner.id)
+        val authenticationToken = UsernamePasswordAuthenticationToken(userDetails, "", userDetails.authorities)
+        SecurityContextHolder.getContext().authentication = authenticationToken
+
+        `when`("validateOwner 메서드를 실행하면") {
+            val result = validateWorkspaceOwnerServiceImpl.validateOwner(workspace)
+
+            then("결과값은 Unit이여야함") {
+                result shouldBe Unit
+            }
+        }
+    }
 })

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/service/ValidateWorkspaceOwnerServiceTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/service/ValidateWorkspaceOwnerServiceTest.kt
@@ -29,6 +29,11 @@ class ValidateWorkspaceOwnerServiceTest(
     val otherUser = UserGenerator.generateUser()
     val workspace = WorkspaceGenerator.generateWorkspace(user = owner)
 
+    beforeContainer {
+        commandUserPort.save(owner)
+        commandUserPort.save(otherUser)
+        commandWorkspacePort.save(workspace)
+    }
 
     given("user와 workspace가 주어지고") {
         val user = UserGenerator.generateUser()

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/service/ValidateWorkspaceOwnerServiceTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/service/ValidateWorkspaceOwnerServiceTest.kt
@@ -45,4 +45,16 @@ class ValidateWorkspaceOwnerServiceTest(
             }
         }
     }
+
+    given("워크스페이스 소유주가 아닌 유저와 워크스페이스가 주어지고") {
+
+        `when`("validateOwner 메서드를 실행하면") {
+
+            then("에러가 발생해야함") {
+                shouldThrow<WorkspaceOwnerNotSameException> {
+                    validateWorkspaceOwnerServiceImpl.validateOwner(otherUser, workspace)
+                }
+            }
+        }
+    }
 })

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/service/ValidateWorkspaceOwnerServiceTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/service/ValidateWorkspaceOwnerServiceTest.kt
@@ -1,21 +1,34 @@
 package com.dcd.server.core.domain.workspace.service
 
-import com.dcd.server.core.domain.auth.model.Role
-import com.dcd.server.core.domain.user.model.enums.Status
-import com.dcd.server.core.domain.user.model.User
-import com.dcd.server.core.domain.user.service.GetCurrentUserService
+import com.dcd.server.core.domain.user.spi.CommandUserPort
 import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameException
 import com.dcd.server.core.domain.workspace.service.impl.ValidateWorkspaceOwnerServiceImpl
+import com.dcd.server.core.domain.workspace.spi.CommandWorkspacePort
+import com.dcd.server.infrastructure.global.security.auth.AuthDetailsService
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
-import io.mockk.mockk
 import com.dcd.server.infrastructure.test.user.UserGenerator
 import com.dcd.server.infrastructure.test.workspace.WorkspaceGenerator
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
 
-class ValidateWorkspaceOwnerServiceTest : BehaviorSpec({
-    val getCurrentUserService = mockk<GetCurrentUserService>()
-    val service = ValidateWorkspaceOwnerServiceImpl(getCurrentUserService)
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class ValidateWorkspaceOwnerServiceTest(
+    private val validateWorkspaceOwnerServiceImpl: ValidateWorkspaceOwnerServiceImpl,
+    private val commandUserPort: CommandUserPort,
+    private val commandWorkspacePort: CommandWorkspacePort,
+    private val authDetailsService: AuthDetailsService
+) : BehaviorSpec({
+    val owner = UserGenerator.generateUser()
+    val otherUser = UserGenerator.generateUser()
+    val workspace = WorkspaceGenerator.generateWorkspace(user = owner)
+
 
     given("user와 workspace가 주어지고") {
         val user = UserGenerator.generateUser()

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/service/ValidateWorkspaceOwnerServiceTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/service/ValidateWorkspaceOwnerServiceTest.kt
@@ -35,22 +35,13 @@ class ValidateWorkspaceOwnerServiceTest(
         commandWorkspacePort.save(workspace)
     }
 
-    given("user와 workspace가 주어지고") {
-        val user = UserGenerator.generateUser()
-        val workspace = WorkspaceGenerator.generateWorkspace(user = user)
-        `when`("현재 인증된 유저가 workspace의 주인일때") {
-            val result = service.validateOwner(user, workspace)
+    given("워크스페이스 소유주와 워크스페이스가 주어지고") {
+
+        `when`("validateOwner 메서드를 실행하면") {
+            val result = validateWorkspaceOwnerServiceImpl.validateOwner(owner, workspace)
+
             then("결과값은 Unit이여야됨") {
                 result shouldBe Unit
-            }
-        }
-        `when`("현재 인증된 유저가 workspace의 주인이 아닐때") {
-            val another =
-                User(email = "another", password = "password", name = "another user", roles = mutableListOf(Role.ROLE_USER), status = Status.CREATED)
-            then("WorkspaceOwnerNotSameException이 발생해야함") {
-                shouldThrow<WorkspaceOwnerNotSameException> {
-                    service.validateOwner(another, workspace)
-                }
             }
         }
     }


### PR DESCRIPTION
## 개요
* ValidateWorkspaceOwnerService 테스트를 리펙토링합니다.
## 작업내용
* 기존 테스트에서 SpringBootTest를 사용하도록 수정
* beforeContainer 추가
* 워크스페이스 소유주와 워크스페이스가 주어지는 테스트 케이스 수정
* 소유주가 아닌 유저와 워크스페이스가 주어지는 테스트 케이스 추가
* 시큐리티 컨텍스트에 소유자가 주어지는 테스트 케이스 추가
* 시큐리티 컨텍스트에 소유자가 아닌 유저가 주어지는 테스트 케이스 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **테스트**
	- 워크스페이스 소유자 검증 서비스 테스트 방식 개선
	- 의존성 주입 및 통합 테스트 접근 방식으로 전환
	- 보안 컨텍스트 기반 소유자 인증 시나리오 추가
	- 테스트 케이스 구조 및 로직 재구성
	- 성공적인 검증 및 예외 상황을 포함한 포괄적인 테스트 케이스 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->