### PR TITLE
🔀 :: [#474] - 애플리케이션 정지 유스케이스 테스트 리펙토링

### DIFF
--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCaseTest.kt
@@ -36,7 +36,6 @@ class RunApplicationUseCaseTest(
     val targetApplicationId = "testApplicationId"
 
     beforeSpec {
-        println("test")
         val user = UserGenerator.generateUser()
         val workspace = WorkspaceGenerator.generateWorkspace(user = user)
         val application = ApplicationGenerator.generateApplication(id = targetApplicationId, workspace = workspace)

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
@@ -74,16 +74,14 @@ class StopApplicationUseCaseTest(
         }
     }
 
+    given("존재하지 않는 애플리케이션이 주어지고") {
+        val notFoundApplicationId = "notFoundApplicationId"
+
+        `when`("유스케이스를 실행할때") {
+
+            then("에러가 발생해야함") {
                 shouldThrow<ApplicationNotFoundException> {
-                    stopApplicationUseCase.execute(applicationId)
-                }
-            }
-        }
-        `when`("해당 애플리케이션이 이미 정지된 있는 상태일때") {
-            every { queryApplicationPort.findById(applicationId) } returns application.copy(status = ApplicationStatus.STOPPED)
-            then("AlreadyStoppedException이 발생해야됨") {
-                shouldThrow<AlreadyStoppedException> {
-                    stopApplicationUseCase.execute(applicationId)
+                    stopApplicationUseCase.execute(notFoundApplicationId)
                 }
             }
         }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
@@ -35,6 +35,15 @@ class StopApplicationUseCaseTest(
 ) : BehaviorSpec({
     val targetApplicationId = "testApplicationId"
 
+    beforeSpec {
+        val user = UserGenerator.generateUser()
+        val workspace = WorkspaceGenerator.generateWorkspace(user = user)
+        val application = ApplicationGenerator.generateApplication(id = targetApplicationId, workspace = workspace, status = ApplicationStatus.RUNNING)
+
+        commandUserPort.save(user)
+        commandWorkspacePort.save(workspace)
+        commandApplicationPort.save(application)
+    }
 
     given("애플리케이션 Id가 주어지고") {
         val applicationId = "testApplicationId"

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
@@ -60,11 +60,20 @@ class StopApplicationUseCaseTest(
         }
     }
 
+    given("애플리케이션이 정지되어있고") {
+        val target = queryApplicationPort.findById(targetApplicationId)!!
+        commandApplicationPort.save(target.copy(status = ApplicationStatus.STOPPED))
+
+        `when`("유스케이스를 실행할때") {
+
+            then("에러가 발생해야함") {
+                shouldThrow<AlreadyStoppedException> {
+                    stopApplicationUseCase.execute(targetApplicationId)
+                }
             }
         }
-        `when`("해당 애플리케이션이 존재하지 않을때") {
-            every { queryApplicationPort.findById(applicationId) } returns null
-            then("ApplicationNotFoundException이 발생해야함") {
+    }
+
                 shouldThrow<ApplicationNotFoundException> {
                     stopApplicationUseCase.execute(applicationId)
                 }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
@@ -1,29 +1,40 @@
 package com.dcd.server.core.domain.application.usecase
 
-import com.dcd.server.core.common.data.WorkspaceInfo
+import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.domain.application.exception.AlreadyStoppedException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
-import com.dcd.server.core.domain.application.service.ChangeApplicationStatusService
-import com.dcd.server.core.domain.application.service.StopContainerService
+import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import com.dcd.server.core.domain.user.spi.CommandUserPort
+import com.dcd.server.core.domain.workspace.spi.CommandWorkspacePort
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.coVerify
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.verify
 import com.dcd.server.infrastructure.test.application.ApplicationGenerator
 import com.dcd.server.infrastructure.test.user.UserGenerator
 import com.dcd.server.infrastructure.test.workspace.WorkspaceGenerator
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
 
-class StopApplicationUseCaseTest : BehaviorSpec({
-    val queryApplicationPort = mockk<QueryApplicationPort>()
-    val stopContainerService = mockk<StopContainerService>(relaxUnitFun = true)
-    val changeApplicationStatusService = mockk<ChangeApplicationStatusService>(relaxUnitFun = true)
-    val workspaceInfo = WorkspaceInfo()
-    val stopApplicationUseCase =
-        StopApplicationUseCase(queryApplicationPort, stopContainerService, changeApplicationStatusService, workspaceInfo)
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class StopApplicationUseCaseTest(
+    private val stopApplicationUseCase: StopApplicationUseCase,
+    @MockkBean(relaxed = true)
+    private val commandPort: CommandPort,
+    private val queryApplicationPort: QueryApplicationPort,
+    private val commandUserPort: CommandUserPort,
+    private val commandWorkspacePort: CommandWorkspacePort,
+    private val commandApplicationPort: CommandApplicationPort
+) : BehaviorSpec({
+    val targetApplicationId = "testApplicationId"
+
 
     given("애플리케이션 Id가 주어지고") {
         val applicationId = "testApplicationId"


### PR DESCRIPTION
## 개요
* 애플리케이션 정지 유스케이스 테스트를 리펙토링합니다.
## 작업내용
* 기존 테스트에서 SpringBootTest를 사용하도록 수정
* beforeSpec 추가
* 기존 컨테이너 정지 검증 테스트 수정
* 애플리케이션이 정지되어있는 애플리케이션이 주어지는 테스트 케이스 수정
* 존재하지 않는 애플리케이션 아이디가 주어지는 테스트 케이스 수정
* 필요없는 print 제거

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트**
	- `RunApplicationUseCaseTest`에서 디버그용 출력 라인 제거
	- `StopApplicationUseCaseTest`의 테스트 구조 및 종속성 업데이트
	- 의존성 주입 및 모킹 접근 방식 개선
	- 애플리케이션 상태 테스트 시나리오 리팩토링

<!-- end of auto-generated comment: release notes by coderabbit.ai -->