### PR TITLE
🔀 :: [#476] - 애플리케이션 로그 조회 유스케이스 테스트 리펙토링

### DIFF
--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCaseTest.kt
@@ -51,19 +51,16 @@ class GetApplicationLogUseCaseTest(
                 result.logs shouldContain "test logs"
             }
         }
+    }
 
-        `when`("해당 애플리케이션이 존재하고, 로그인된 유저가 워크스페이스의 권한을 가지고 있을때") {
-            val logs = listOf("testLogs")
+    given("존재하지 않는 애플리케이션 id가 주어지고") {
+        val notFoundApplicationId = "notFoundApplicationId"
+        `when`("유스케이스를 실행할때") {
 
-            every { queryApplicationPort.findById(appId) } returns application
-            every { getContainerLogService.getLogs(application) } returns logs
-
-            val response = getApplicationLogUseCase.execute(appId)
-            then("유스케이스의 반환값은 logs를 가지고 있어야함") {
-                response.logs shouldBe logs
-            }
-            then("유스케이스는 getContainerLogService를 실행해야함") {
-                verify { getContainerLogService.getLogs(application) }
+            then("에러가 발생해야함") {
+                shouldThrow<ApplicationNotFoundException> {
+                    getApplicationLogUseCase.execute(notFoundApplicationId)
+                }
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCaseTest.kt
@@ -1,25 +1,35 @@
 package com.dcd.server.core.domain.application.usecase
 
+import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
-import com.dcd.server.core.domain.application.service.GetContainerLogService
-import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import com.dcd.server.core.domain.application.spi.CommandApplicationPort
+import com.dcd.server.core.domain.user.spi.CommandUserPort
+import com.dcd.server.core.domain.workspace.spi.CommandWorkspacePort
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
-import io.kotest.matchers.shouldBe
 import io.mockk.every
-import io.mockk.mockk
-import io.mockk.verify
 import com.dcd.server.infrastructure.test.application.ApplicationGenerator
 import com.dcd.server.infrastructure.test.user.UserGenerator
 import com.dcd.server.infrastructure.test.workspace.WorkspaceGenerator
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.matchers.collections.shouldContain
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
 
-class GetApplicationLogUseCaseTest : BehaviorSpec({
-    val getContainerLogService = mockk<GetContainerLogService>()
-    val queryApplicationPort = mockk<QueryApplicationPort>()
-    val getApplicationLogUseCase = GetApplicationLogUseCase(
-        getContainerLogService,
-        queryApplicationPort
-    )
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class GetApplicationLogUseCaseTest(
+    private val getApplicationLogUseCase: GetApplicationLogUseCase,
+    @MockkBean
+    private val commandPort: CommandPort,
+    private val commandUserPort: CommandUserPort,
+    private val commandWorkspacePort: CommandWorkspacePort,
+    private val commandApplicationPort: CommandApplicationPort
+) : BehaviorSpec({
+    val targetApplicationId = "testApplicationId"
+
 
     given("애플리케이션 id가 주어지고") {
         val appId = "testApplicationId"

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCaseTest.kt
@@ -47,7 +47,7 @@ class GetApplicationLogUseCaseTest(
         `when`("유스케이스를 실행할때") {
             val result = getApplicationLogUseCase.execute(targetApplicationId)
 
-            then("유스케이스 실행시 ApplicationNotFoundException이 발생해야함") {
+            then("로그가 조회되어야함") {
                 result.logs shouldContain "test logs"
             }
         }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCaseTest.kt
@@ -30,6 +30,17 @@ class GetApplicationLogUseCaseTest(
 ) : BehaviorSpec({
     val targetApplicationId = "testApplicationId"
 
+    beforeSpec {
+        val user = UserGenerator.generateUser()
+        val workspace = WorkspaceGenerator.generateWorkspace(user = user)
+        val application = ApplicationGenerator.generateApplication(id = targetApplicationId, workspace = workspace)
+        val expectedResult = listOf("test logs")
+        every { commandPort.executeShellCommandWithResult("docker logs ${application.name.lowercase()}") } returns expectedResult
+
+        commandUserPort.save(user)
+        commandWorkspacePort.save(workspace)
+        commandApplicationPort.save(application)
+    }
 
     given("애플리케이션 id가 주어지고") {
         val appId = "testApplicationId"

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCaseTest.kt
@@ -43,18 +43,12 @@ class GetApplicationLogUseCaseTest(
     }
 
     given("애플리케이션 id가 주어지고") {
-        val appId = "testApplicationId"
-        val owner = UserGenerator.generateUser()
-        val workspace = WorkspaceGenerator.generateWorkspace(user = owner)
-        val application = ApplicationGenerator.generateApplication(id = appId, workspace = workspace)
 
-        `when`("해당 애플리케이션이 존재하지 않을때") {
-            every { queryApplicationPort.findById(appId) } returns null
+        `when`("유스케이스를 실행할때") {
+            val result = getApplicationLogUseCase.execute(targetApplicationId)
 
             then("유스케이스 실행시 ApplicationNotFoundException이 발생해야함") {
-                shouldThrow<ApplicationNotFoundException> {
-                    getApplicationLogUseCase.execute(appId)
-                }
+                result.logs shouldContain "test logs"
             }
         }
 


### PR DESCRIPTION
## 개요
* 애플리케이션 로그를 조회하는 유스케이스 테스트를 리펙토링합니다.
## 작업내용
* 기존 테스트에서 SpringBootTest를 사용하도록 수정
* beforeSpec 추가
* 기존 애플리케이션 로그 조회 검증 테스트 수정
* 애플리케이션이 존재하지 않는 테스트 케이스 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **테스트 개선**
	- 애플리케이션 로그 테스트 클래스의 아키텍처를 명령 기반 접근 방식으로 리팩토링
	- 새로운 커맨드 포트를 사용하여 테스트 로직 업데이트
	- 스프링 부트 테스트 환경 구성 개선
	- 테스트 케이스가 직접 실행 결과에 초점을 맞추도록 재구성
<!-- end of auto-generated comment: release notes by coderabbit.ai -->