### PR TITLE
🔀 :: [#478] - 애플리케이션 배포 유스케이스 테스트 리펙토링

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
@@ -38,12 +38,11 @@ class DeployApplicationUseCase(
         if (application.status == ApplicationStatus.RUNNING || application.status == ApplicationStatus.PENDING)
             throw CanNotDeployApplicationException()
 
-            executionScope.launch {
-                deployApplication(application)
-            }
+        executionScope.launch {
+            deployApplication(application)
+        }
 
-            eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.PENDING, application))
-
+        eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.PENDING, application))
     }
 
     fun execute(labels: List<String>) {

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCaseTest.kt
@@ -37,6 +37,15 @@ class DeployApplicationUseCaseTest(
 ) : BehaviorSpec({
     val targetApplicationId = "testApplicationId"
 
+    beforeSpec {
+        val user = UserGenerator.generateUser()
+        val workspace = WorkspaceGenerator.generateWorkspace(user = user)
+        val application = ApplicationGenerator.generateApplication(id = targetApplicationId, workspace = workspace)
+
+        commandUserPort.save(user)
+        commandWorkspacePort.save(workspace)
+        commandApplicationPort.save(application)
+    }
 
     given("애플리케이션 id가 주어지고") {
         val applicationId = "testApplicationId"

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCaseTest.kt
@@ -72,73 +72,16 @@ class DeployApplicationUseCaseTest(
                 coVerify { commandPort.executeShellCommand("rm -rf ${result.name}") }
             }
         }
+    }
 
-        `when`("주어진 id의 애플리케이션이 MYSQL 타입의 애플리케이션일때") {
-            val application = ApplicationGenerator.generateApplication(
-                id = applicationId,
-                applicationType = ApplicationType.MYSQL
-            )
-            every { queryApplicationPort.findById(applicationId) } returns application
+    given("존재하지 않는 애플리케이션의 아이디가 주어지고") {
+        val notFoundApplicationId = "notFoundApplicationId"
 
-            deployApplicationUseCase.execute(applicationId)
+        `when`("유스케이스를 실행할때") {
 
-            then("이미지와 컨테이너를 삭제하는 서비스를 실행해야함") {
-                coVerify { deleteContainerService.deleteContainer(application) }
-                coVerify { deleteImageService.deleteImage(application) }
-            }
-            then("도커파일을 생성하고, 이미지를 빌드하고, 컨테이너를 생성해야함") {
-                coVerify { createDockerFileService.createFileToApplication(application, application.version) }
-                coVerify { buildDockerImageService.buildImageByApplication(application) }
-                coVerify { createContainerService.createContainer(application, application.externalPort) }
-            }
-            then("생성된 애플리케이션 디렉토리를 제거해야함") {
-                coVerify { deleteApplicationDirectoryService.deleteApplicationDirectory(application) }
-            }
-        }
-
-        `when`("주어진 id의 애플리케이션이 REDIS 타입의 애플리케이션일때") {
-            val application = ApplicationGenerator.generateApplication(
-                id = applicationId,
-                applicationType = ApplicationType.REDIS
-            )
-            every { queryApplicationPort.findById(applicationId) } returns application
-
-            deployApplicationUseCase.execute(applicationId)
-
-            then("이미지와 컨테이너를 삭제하는 서비스를 실행해야함") {
-                coVerify { deleteContainerService.deleteContainer(application) }
-                coVerify { deleteImageService.deleteImage(application) }
-            }
-            then("도커파일을 생성하고, 이미지를 빌드하고, 컨테이너를 생성해야함") {
-                coVerify { createDockerFileService.createFileToApplication(application, application.version) }
-                coVerify { buildDockerImageService.buildImageByApplication(application) }
-                coVerify { createContainerService.createContainer(application, application.externalPort) }
-            }
-            then("생성된 애플리케이션 디렉토리를 제거해야함") {
-                coVerify { deleteApplicationDirectoryService.deleteApplicationDirectory(application) }
-            }
-        }
-
-        `when`("주어진 id의 애플리케이션이 실행중인 애플리케이션일때") {
-            val application = ApplicationGenerator.generateApplication(
-                id = applicationId,
-                status = ApplicationStatus.RUNNING
-            )
-            every { queryApplicationPort.findById(applicationId) } returns application
-
-            then("CanNotDeployApplicationException이 발생해야함") {
-                shouldThrow<CanNotDeployApplicationException> {
-                    deployApplicationUseCase.execute(applicationId)
-                }
-            }
-        }
-
-        `when`("주어진 id를 가진 애플리케이션이 존재하지 않을때") {
-            every { queryApplicationPort.findById(applicationId) } returns null
-
-            then("ApplicationNotFoundException이 발생해야함") {
+            then("에러가 발생해야함") {
                 shouldThrow<ApplicationNotFoundException> {
-                    deployApplicationUseCase.execute(applicationId)
+                    deployApplicationUseCase.execute(notFoundApplicationId)
                 }
             }
         }


### PR DESCRIPTION
## 개요
* 애플리케이션 배포 유스케이스의 테스트를 리펙토링합니다.
## 작업내용
* 기존 테스트에서 SpringBootTest를 사용하도록 수정
* beforeSpec 추가
* 기존 배포 과정을 검증하는 테스트 케이스 수정
* 존재하지 않는 애플리케이션 아이디가 주어지는 테스트 케이스 추가
* 애플리케이션 상태가 올바르지 않은 테스트 케이스 추가
* DeployApplicationUseCase 가독성 개선

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트 개선**
	- 애플리케이션 배포 테스트 케이스를 새로운 명령 기반 아키텍처에 맞게 업데이트
	- Docker 관련 명령 실행에 대한 테스트 로직 재구성
	- 애플리케이션 배포 시 오류 처리 강화

- **아키텍처 변경**
	- 테스트 클래스에 트랜잭션 및 스프링 부트 테스트 어노테이션 추가
	- 명령 포트 기반의 테스트 접근 방식으로 전환

<!-- end of auto-generated comment: release notes by coderabbit.ai -->