### PR TITLE
🔀 :: [#480] - 도매인 모델의 equals 메서드를 오버라이딩

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/aop/OwnerValidateAspect.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/aop/OwnerValidateAspect.kt
@@ -28,7 +28,7 @@ class OwnerValidateAspect(
             ?: throw WorkspaceNotFoundException())
 
         val owner = workspace.owner
-        if (owner.id != user.id)
+        if (owner != user)
             throw WorkspaceOwnerNotSameException()
 
         workspaceInfo.workspace = workspace

--- a/src/main/kotlin/com/dcd/server/core/domain/application/model/Application.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/model/Application.kt
@@ -23,4 +23,8 @@ data class Application(
         if (other !is Application) return false
         return this.id == other.id
     }
+
+    override fun hashCode(): Int {
+        return this.id.hashCode()
+    }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/model/Application.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/model/Application.kt
@@ -20,8 +20,7 @@ data class Application(
     val labels: List<String>
 ) {
     override fun equals(other: Any?): Boolean {
-        val application = (other as? Application
-            ?: return false)
-        return this.id == application.id
+        if (other !is Application) return false
+        return this.id == other.id
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/model/Application.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/model/Application.kt
@@ -18,4 +18,10 @@ data class Application(
     val externalPort: Int,
     val status: ApplicationStatus,
     val labels: List<String>
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        val application = (other as? Application
+            ?: return false)
+        return this.id == application.id
+    }
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/user/model/User.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/user/model/User.kt
@@ -11,4 +11,10 @@ data class User(
     val name: String,
     val roles: MutableList<Role>,
     val status: Status
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        val user = (other as? User
+            ?: return false)
+        return this.id == user.id
+    }
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/user/model/User.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/user/model/User.kt
@@ -16,4 +16,8 @@ data class User(
         if (other !is User) return false
         return this.id == other.id
     }
+
+    override fun hashCode(): Int {
+        return this.id.hashCode()
+    }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/user/model/User.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/user/model/User.kt
@@ -13,8 +13,7 @@ data class User(
     val status: Status
 ) {
     override fun equals(other: Any?): Boolean {
-        val user = (other as? User
-            ?: return false)
-        return this.id == user.id
+        if (other !is User) return false
+        return this.id == other.id
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/model/Workspace.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/model/Workspace.kt
@@ -14,4 +14,8 @@ data class Workspace(
         if (other !is Workspace) return false
         return this.id == other.id
     }
+
+    override fun hashCode(): Int {
+        return this.id.hashCode()
+    }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/model/Workspace.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/model/Workspace.kt
@@ -9,4 +9,11 @@ data class Workspace(
     val description: String,
     val globalEnv: Map<String, String> = mapOf(),
     val owner: User
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        val workspace = other as? Workspace
+            ?: return false
+
+        return this.id == workspace.id
+    }
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/model/Workspace.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/model/Workspace.kt
@@ -11,9 +11,7 @@ data class Workspace(
     val owner: User
 ) {
     override fun equals(other: Any?): Boolean {
-        val workspace = other as? Workspace
-            ?: return false
-
-        return this.id == workspace.id
+        if (other !is Workspace) return false
+        return this.id == other.id
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/service/impl/ValidateWorkspaceOwnerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/service/impl/ValidateWorkspaceOwnerServiceImpl.kt
@@ -12,13 +12,13 @@ class ValidateWorkspaceOwnerServiceImpl(
     private val getCurrentUserService: GetCurrentUserService
 ) : ValidateWorkspaceOwnerService{
     override fun validateOwner(user: User, workspace: Workspace) {
-        if (user.id != workspace.owner.id)
+        if (user != workspace.owner)
             throw WorkspaceOwnerNotSameException()
     }
 
     override fun validateOwner(workspace: Workspace) {
         val user = getCurrentUserService.getCurrentUser()
-        if (user.id != workspace.owner.id)
+        if (user != workspace.owner)
             throw WorkspaceOwnerNotSameException()
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/AddGlobalEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/AddGlobalEnvUseCase.kt
@@ -1,26 +1,23 @@
 package com.dcd.server.core.domain.workspace.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
-import com.dcd.server.core.domain.user.service.GetCurrentUserService
 import com.dcd.server.core.domain.workspace.dto.request.AddGlobalEnvReqDto
 import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
-import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameException
+import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 import com.dcd.server.core.domain.workspace.spi.CommandWorkspacePort
 import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
 
 @UseCase
 class AddGlobalEnvUseCase(
     private val queryWorkspacePort: QueryWorkspacePort,
-    private val getCurrentUserService: GetCurrentUserService,
-    private val commandWorkspacePort: CommandWorkspacePort
+    private val commandWorkspacePort: CommandWorkspacePort,
+    private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService
 ) {
     fun execute(workspaceId: String, addGlobalEnvReqDto: AddGlobalEnvReqDto) {
         val workspace = (queryWorkspacePort.findById(workspaceId)
             ?: throw WorkspaceNotFoundException())
-        val currentUser = getCurrentUserService.getCurrentUser()
 
-        if (workspace.owner.id != currentUser.id)
-            throw WorkspaceOwnerNotSameException()
+        validateWorkspaceOwnerService.validateOwner(workspace)
 
         val updatedGlobalEnv = workspace.globalEnv.toMutableMap()
         updatedGlobalEnv.putAll(addGlobalEnvReqDto.envList)

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteGlobalEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteGlobalEnvUseCase.kt
@@ -1,26 +1,23 @@
 package com.dcd.server.core.domain.workspace.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
-import com.dcd.server.core.domain.user.service.GetCurrentUserService
 import com.dcd.server.core.domain.workspace.exception.GlobalEnvNotFoundException
 import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
-import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameException
+import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 import com.dcd.server.core.domain.workspace.spi.CommandWorkspacePort
 import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
 
 @UseCase
 class DeleteGlobalEnvUseCase(
     private val queryWorkspacePort: QueryWorkspacePort,
-    private val getCurrentUserService: GetCurrentUserService,
-    private val commandWorkspacePort: CommandWorkspacePort
+    private val commandWorkspacePort: CommandWorkspacePort,
+    private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService
 ) {
     fun execute(workspaceId: String, key: String) {
         val workspace = (queryWorkspacePort.findById(workspaceId)
             ?: throw WorkspaceNotFoundException())
-        val currentUser = getCurrentUserService.getCurrentUser()
 
-        if (workspace.owner.id != currentUser.id)
-            throw WorkspaceOwnerNotSameException()
+        validateWorkspaceOwnerService.validateOwner(workspace)
 
         if (workspace.globalEnv.contains(key).not())
             throw GlobalEnvNotFoundException()

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteWorkspaceUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteWorkspaceUseCase.kt
@@ -1,9 +1,7 @@
 package com.dcd.server.core.domain.workspace.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
-import com.dcd.server.core.domain.user.service.GetCurrentUserService
 import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
-import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameException
 import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 import com.dcd.server.core.domain.workspace.spi.CommandWorkspacePort
 import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
@@ -12,14 +10,14 @@ import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
 class DeleteWorkspaceUseCase(
     private val commandWorkspacePort: CommandWorkspacePort,
     private val queryWorkspacePort: QueryWorkspacePort,
-    private val getCurrentUserService: GetCurrentUserService,
     private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService
 ) {
     fun execute(workspaceId: String) {
         val workspace = (queryWorkspacePort.findById(workspaceId)
             ?: throw WorkspaceNotFoundException())
-        val currentUser = getCurrentUserService.getCurrentUser()
-        validateWorkspaceOwnerService.validateOwner(currentUser, workspace)
+
+        validateWorkspaceOwnerService.validateOwner(workspace)
+
         commandWorkspacePort.delete(workspace)
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/UpdateWorkspaceUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/UpdateWorkspaceUseCase.kt
@@ -1,10 +1,9 @@
 package com.dcd.server.core.domain.workspace.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
-import com.dcd.server.core.domain.user.service.GetCurrentUserService
 import com.dcd.server.core.domain.workspace.dto.request.UpdateWorkspaceReqDto
 import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
-import com.dcd.server.core.domain.workspace.exception.WorkspaceOwnerNotSameException
+import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 import com.dcd.server.core.domain.workspace.spi.CommandWorkspacePort
 import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
 
@@ -12,15 +11,13 @@ import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
 class UpdateWorkspaceUseCase(
     private val commandWorkspacePort: CommandWorkspacePort,
     private val queryWorkspacePort: QueryWorkspacePort,
-    private val getCurrentUserService: GetCurrentUserService
+    private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService
 ) {
     fun execute(workspaceId: String, updateWorkspaceReqDto: UpdateWorkspaceReqDto) {
         val workspace = (queryWorkspacePort.findById(workspaceId)
             ?: throw WorkspaceNotFoundException())
-        val currentUser = getCurrentUserService.getCurrentUser()
 
-        if (workspace.owner.id != currentUser.id)
-            throw WorkspaceOwnerNotSameException()
+        validateWorkspaceOwnerService.validateOwner(workspace)
 
         val updatedWorkspace = workspace.copy(title = updateWorkspaceReqDto.title, description = updateWorkspaceReqDto.description)
         commandWorkspacePort.save(updatedWorkspace)


### PR DESCRIPTION
## 개요
* 도메인 모델의 equals 메서드를 오바라이딩합니다.
## 작업내용
* Workspace 객체의 equals 메서드 오버라이딩
* Application 객체의 equals 메서드 오버라이딩
* User 객체의 equals 메서드 오버라이딩
* 워크스페이스 소유주 검증 서비스에서 유저의 equals를 사용하도록 수정
* 워크스페이스 관련 유스케이스에서 소유주 검증 서비스를 사용하도록 수정
* 워크스페이스 소유주 검증 Aspect에서 equals 메서드를 사용하도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **리팩토링**
    - 워크스페이스 소유자 검증 로직 개선
    - 모델 클래스(`Application`, `User`, `Workspace`)에 사용자 정의 동등성 메서드 추가
    - 현재 사용자 서비스 대신 워크스페이스 소유자 검증 서비스로 대체

- **버그 수정**
    - 객체 비교 방식을 ID 기반에서 참조 동등성 기반으로 변경
    - 소유자 검증 프로세스 간소화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->