### PR TITLE
🔀 :: [#482] - 워크스페이스 삭제시 네트워크를 삭제하도록 수정

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/service/DeleteNetworkService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/service/DeleteNetworkService.kt
@@ -1,0 +1,5 @@
+package com.dcd.server.core.domain.workspace.service
+
+interface DeleteNetworkService {
+    fun deleteNetwork(networkTitle: String)
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/service/impl/DeleteNetworkServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/service/impl/DeleteNetworkServiceImpl.kt
@@ -1,0 +1,14 @@
+package com.dcd.server.core.domain.workspace.service.impl
+
+import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.domain.workspace.service.DeleteNetworkService
+import org.springframework.stereotype.Service
+
+@Service
+class DeleteNetworkServiceImpl(
+    private val commandPort: CommandPort
+) : DeleteNetworkService {
+    override fun deleteNetwork(networkTitle: String) {
+        commandPort.executeShellCommand("docker network rm ${networkTitle.replace(' ', '_')}")
+    }
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteWorkspaceUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteWorkspaceUseCase.kt
@@ -2,6 +2,7 @@ package com.dcd.server.core.domain.workspace.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
+import com.dcd.server.core.domain.workspace.service.DeleteNetworkService
 import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 import com.dcd.server.core.domain.workspace.spi.CommandWorkspacePort
 import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
@@ -10,13 +11,16 @@ import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
 class DeleteWorkspaceUseCase(
     private val commandWorkspacePort: CommandWorkspacePort,
     private val queryWorkspacePort: QueryWorkspacePort,
-    private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService
+    private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService,
+    private val deleteNetworkService: DeleteNetworkService
 ) {
     fun execute(workspaceId: String) {
         val workspace = (queryWorkspacePort.findById(workspaceId)
             ?: throw WorkspaceNotFoundException())
 
         validateWorkspaceOwnerService.validateOwner(workspace)
+
+        deleteNetworkService.deleteNetwork(workspace.title)
 
         commandWorkspacePort.delete(workspace)
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteWorkspaceUseCaseTest.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.core.domain.workspace.usecase
 
+import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.domain.user.spi.QueryUserPort
 import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
 import com.dcd.server.core.domain.workspace.spi.CommandWorkspacePort
@@ -8,6 +9,7 @@ import com.dcd.server.infrastructure.global.security.auth.AuthDetailsService
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import com.dcd.server.infrastructure.test.workspace.WorkspaceGenerator
+import com.ninjasquad.springmockk.MockkBean
 import io.kotest.matchers.shouldBe
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
@@ -23,7 +25,9 @@ class DeleteWorkspaceUseCaseTest(
     private val authDetailsService: AuthDetailsService,
     private val queryWorkspacePort: QueryWorkspacePort,
     private val commandWorkspacePort: CommandWorkspacePort,
-    private val queryUserPort: QueryUserPort
+    private val queryUserPort: QueryUserPort,
+    @MockkBean(relaxed = true)
+    private val commandPort: CommandPort
 ) : BehaviorSpec({
     val userId = "user1"
     val workspaceId = "testWorkspaceId"
@@ -44,6 +48,7 @@ class DeleteWorkspaceUseCaseTest(
 
             then("워크스페이스가 조회되지 않아야함") {
                 queryWorkspacePort.findById(workspaceId) shouldBe null
+                commandPort.executeShellCommand("docker network rm ${workspace.title.replace(" ", "_")}")
             }
         }
     }


### PR DESCRIPTION
## 개요
* 워크스페이스 삭제시 네트워크를 삭제하도록 리펙토링합니다.
## 작업내용
* DeleteNetworkService 인터페이스 추가
* DeleteNetworkService 구현체 추가
* 테스트 코드 수정
* 워크스페이스 삭제시 네트워크를 삭제하는 메서드를 호출하도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 작업 공간 삭제 시 연결된 Docker 네트워크를 자동으로 제거하는 기능 추가
	- 네트워크 삭제 서비스 도입

- **개선 사항**
	- 작업 공간 삭제 프로세스의 안정성 향상
	- 네트워크 관리 기능 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->