### PR TITLE
🔀 :: [#484] - 워크스페이스 생성시 영문및 숫자 공백만 사용 가능하도록 수정

### DIFF
--- a/src/main/kotlin/com/dcd/server/presentation/domain/workspace/WorkspaceWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/workspace/WorkspaceWebAdapter.kt
@@ -51,7 +51,13 @@ class WorkspaceWebAdapter(
             .let { ResponseEntity.ok().build() }
 
     @PutMapping("/{workspaceId}")
-    fun updateWorkspace(@PathVariable workspaceId: String, @RequestBody updateWorkspaceRequest: UpdateWorkspaceRequest): ResponseEntity<Void> =
+    fun updateWorkspace(
+        @PathVariable
+        workspaceId: String,
+        @Validated
+        @RequestBody
+        updateWorkspaceRequest: UpdateWorkspaceRequest
+    ): ResponseEntity<Void> =
         updateWorkspaceUseCase.execute(workspaceId, updateWorkspaceRequest.toDto())
             .run { ResponseEntity.ok().build() }
 

--- a/src/main/kotlin/com/dcd/server/presentation/domain/workspace/WorkspaceWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/workspace/WorkspaceWebAdapter.kt
@@ -13,6 +13,7 @@ import com.dcd.server.presentation.domain.workspace.data.response.WorkspaceListR
 import com.dcd.server.presentation.domain.workspace.data.response.WorkspaceResponse
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
 
 @WebAdapter("/workspace")
@@ -27,7 +28,10 @@ class WorkspaceWebAdapter(
     private val updateGlobalEnvUseCase: UpdateGlobalEnvUseCase
 ) {
     @PostMapping
-    fun createWorkspace(@RequestBody createWorkspaceRequest: CreateWorkspaceRequest): ResponseEntity<CreateWorkspaceResponse> =
+    fun createWorkspace(
+        @Validated
+        @RequestBody createWorkspaceRequest: CreateWorkspaceRequest
+    ): ResponseEntity<CreateWorkspaceResponse> =
         createWorkspaceUseCase.execute(createWorkspaceRequest.toDto())
             .run { ResponseEntity(this.toResponse(), HttpStatus.CREATED) }
 

--- a/src/main/kotlin/com/dcd/server/presentation/domain/workspace/data/request/CreateWorkspaceRequest.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/workspace/data/request/CreateWorkspaceRequest.kt
@@ -1,6 +1,9 @@
 package com.dcd.server.presentation.domain.workspace.data.request
 
+import jakarta.validation.constraints.Pattern
+
 data class CreateWorkspaceRequest(
+    @field:Pattern(regexp = "^(?!host$|bridge$|none$)[a-zA-Z0-9 ]+$")
     val title: String,
     val description: String
 )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/workspace/data/request/CreateWorkspaceRequest.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/workspace/data/request/CreateWorkspaceRequest.kt
@@ -1,8 +1,10 @@
 package com.dcd.server.presentation.domain.workspace.data.request
 
+import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Pattern
 
 data class CreateWorkspaceRequest(
+    @field:NotBlank
     @field:Pattern(regexp = "^(?!host$|bridge$|none$)[a-zA-Z0-9 ]+$")
     val title: String,
     val description: String

--- a/src/main/kotlin/com/dcd/server/presentation/domain/workspace/data/request/UpdateWorkspaceRequest.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/workspace/data/request/UpdateWorkspaceRequest.kt
@@ -1,6 +1,11 @@
 package com.dcd.server.presentation.domain.workspace.data.request
 
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+
 data class UpdateWorkspaceRequest(
+    @field:NotBlank
+    @field:Pattern(regexp = "^(?!host$|bridge$|none$)[a-zA-Z0-9 ]+$")
     val title: String,
     val description: String
 )


### PR DESCRIPTION
## 개요
* 워크스페이스를 생성및 수정할때 presentation 계층에서 영문및 숫자만 가능하도록 수정합니다.
## 작업내용
* Pattern 어노테이션 추가
* NotBlank 어노테이션 추가
* WorkspaceWebAdapter에서 워크스페이스 생성시 요청을 검증하도록 수정
* 워크스페이스 수정 요청 객체에 정규식 추가
* WorkspaceWebAdapter에서 워크스페이스 수정시 요청을 검증하도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 작업 공간 생성 및 업데이트 시 입력 유효성 검사 추가
	- 작업 공간 제목에 대한 엄격한 유효성 검사 규칙 도입

- **버그 수정**
	- 허용되지 않는 작업 공간 제목 입력 방지
	- 빈 제목 또는 특정 예약어 사용 차단

<!-- end of auto-generated comment: release notes by coderabbit.ai -->