### PR TITLE
🔀 :: [#486] - 리소스 이름을 반환하는 필드 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/model/Application.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/model/Application.kt
@@ -19,6 +19,8 @@ data class Application(
     val status: ApplicationStatus,
     val labels: List<String>
 ) {
+    val containerName = name.lowercase()
+
     override fun equals(other: Any?): Boolean {
         if (other !is Application) return false
         return this.id == other.id

--- a/src/main/kotlin/com/dcd/server/core/domain/application/scheduler/ApplicationStatusScheduler.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/scheduler/ApplicationStatusScheduler.kt
@@ -22,7 +22,7 @@ class ApplicationStatusScheduler(
         val updatedApplicationList = mutableListOf<Application>()
         getContainerService.getContainerNameByStatus(ContainerStatus.EXITED)
             .forEach {containerName ->
-                val containerExitedApplication = runningApplicationList.lastOrNull { it.name.lowercase() == containerName }
+                val containerExitedApplication = runningApplicationList.lastOrNull { it.containerName == containerName }
                     ?: return@forEach
 
                 val updatedApplication = containerExitedApplication.copy(
@@ -41,7 +41,7 @@ class ApplicationStatusScheduler(
         val updatedApplicationList = mutableListOf<Application>()
         getContainerService.getContainerNameByStatus(ContainerStatus.RUNNING)
             .forEach {containerName ->
-                val containerRunningApplication = stoppedApplicationList.lastOrNull { it.name.lowercase() == containerName }
+                val containerRunningApplication = stoppedApplicationList.lastOrNull { it.containerName == containerName }
                     ?: return@forEach
 
                 val updatedApplication = containerRunningApplication.copy(
@@ -60,7 +60,7 @@ class ApplicationStatusScheduler(
         val updatedApplicationList = mutableListOf<Application>()
         getContainerService.getContainerNameByStatus(ContainerStatus.CREATED)
             .forEach {containerName ->
-                val containerExitedApplication = runningApplicationList.lastOrNull { it.name.lowercase() == containerName }
+                val containerExitedApplication = runningApplicationList.lastOrNull { it.containerName == containerName }
                     ?: return@forEach
 
                 val updatedApplication = containerExitedApplication.copy(

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/BuildDockerImageServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/BuildDockerImageServiceImpl.kt
@@ -20,20 +20,20 @@ class BuildDockerImageServiceImpl(
     override suspend fun buildImageByApplicationId(id: String) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
-        val name = application.name
+        val directoryName = application.name
         withContext(Dispatchers.IO) {
             val exitValue = when (application.applicationType) {
                 ApplicationType.SPRING_BOOT -> {
-                    commandPort.executeShellCommand("cd ./$name && ./gradlew clean build")
+                    commandPort.executeShellCommand("cd ./$directoryName && ./gradlew clean build")
                         .run {
                             if (this == 0)
-                                commandPort.executeShellCommand("cd ./$name && docker build -t ${name.lowercase()}:latest .")
+                                commandPort.executeShellCommand("cd ./$directoryName && docker build -t ${application.containerName}:latest .")
                             else this
                         }
                 }
 
                 else -> {
-                    commandPort.executeShellCommand("cd ./$name && docker build -t ${name.lowercase()}:latest .")
+                    commandPort.executeShellCommand("cd ./$directoryName && docker build -t ${application.containerName}:latest .")
                 }
             }
             checkExitValuePort.checkApplicationExitValue(exitValue, application, this)
@@ -41,15 +41,15 @@ class BuildDockerImageServiceImpl(
     }
 
     override suspend fun buildImageByApplication(application: Application) {
-        val name = application.name
+        val directoryName = application.name
         withContext(Dispatchers.IO) {
             val exitValue = when(application.applicationType) {
                 ApplicationType.SPRING_BOOT -> {
-                    commandPort.executeShellCommand("cd ./$name && ./gradlew clean build")
-                    commandPort.executeShellCommand("cd ./$name && docker build -t ${name.lowercase()}:latest .")
+                    commandPort.executeShellCommand("cd ./$directoryName && ./gradlew clean build")
+                    commandPort.executeShellCommand("cd ./$directoryName && docker build -t ${application.containerName}:latest .")
                 }
                 else -> {
-                    commandPort.executeShellCommand("cd ./$name && docker build -t ${name.lowercase()}:latest .")
+                    commandPort.executeShellCommand("cd ./$directoryName && docker build -t ${application.containerName}:latest .")
                 }
             }
             checkExitValuePort.checkApplicationExitValue(exitValue, application, this)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateContainerServiceImpl.kt
@@ -16,7 +16,7 @@ class CreateContainerServiceImpl(
     override suspend fun createContainer(application: Application, externalPort: Int) {
         withContext(Dispatchers.IO) {
             val cmd =
-                "docker create --network ${application.workspace.title.replace(' ', '_')} " +
+                "docker create --network ${application.workspace.networkName} " +
                         "--name ${application.containerName} " +
                         "-p ${externalPort}:${application.port} ${application.containerName}:latest"
 

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateContainerServiceImpl.kt
@@ -17,15 +17,15 @@ class CreateContainerServiceImpl(
         withContext(Dispatchers.IO) {
             val cmd =
                 "docker create --network ${application.workspace.title.replace(' ', '_')} " +
-                        "--name ${application.name.lowercase()} " +
-                        "-p ${externalPort}:${application.port} ${application.name.lowercase()}:latest"
+                        "--name ${application.containerName} " +
+                        "-p ${externalPort}:${application.port} ${application.containerName}:latest"
 
             commandPort.executeShellCommand(cmd)
                 .also {exitValue ->
                     checkExitValuePort.checkApplicationExitValue(exitValue, application, this)
                 }
 
-            val dcdNetworkConnectCmd = "docker network connect dcd ${application.name.lowercase()}"
+            val dcdNetworkConnectCmd = "docker network connect dcd ${application.containerName}"
             commandPort.executeShellCommand(dcdNetworkConnectCmd)
                 .also {exitValue ->
                     checkExitValuePort.checkApplicationExitValue(exitValue, application, this)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateDockerFileServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateDockerFileServiceImpl.kt
@@ -42,19 +42,19 @@ class CreateDockerFileServiceImpl(
     }
 
     private fun createFile(application: Application, version: String, coroutineScope: CoroutineScope) {
-        val name = application.name
+        val directoryName = application.name
         val mutableEnv = application.env.toMutableMap()
         mutableEnv.putAll(application.workspace.globalEnv)
 
-        commandPort.executeShellCommand("mkdir -p $name")
+        commandPort.executeShellCommand("mkdir -p $directoryName")
             .also {exitValue ->
                 checkExitValuePort.checkApplicationExitValue(exitValue, application, coroutineScope)
             }
 
-        val file = File("./$name/Dockerfile")
+        val file = File("./$directoryName/Dockerfile")
         val fileContent = when (application.applicationType) {
             ApplicationType.SPRING_BOOT ->
-                FileContent.getSpringBootDockerFileContent(name, version, application.port, mutableEnv)
+                FileContent.getSpringBootDockerFileContent(directoryName, version, application.port, mutableEnv)
 
             ApplicationType.MYSQL ->
                 FileContent.getMYSQLDockerFileContent(version, application.port, mutableEnv)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteContainerServiceImpl.kt
@@ -15,8 +15,7 @@ class DeleteContainerServiceImpl(
 ) : DeleteContainerService {
     override suspend fun deleteContainer(application: Application) {
         withContext(Dispatchers.IO) {
-            val name = application.name.lowercase()
-            commandPort.executeShellCommand("docker rm $name")
+            commandPort.executeShellCommand("docker rm ${application.containerName}")
                 .also {exitValue ->
                     if (exitValue != 0 && exitValue != 1)
                         checkExitValuePort.checkApplicationExitValue(exitValue, application, this)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteImageServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteImageServiceImpl.kt
@@ -15,7 +15,7 @@ class DeleteImageServiceImpl(
 ) : DeleteImageService {
     override suspend fun deleteImage(application: Application) {
         withContext(Dispatchers.IO) {
-            commandPort.executeShellCommand("docker rmi ${application.name.lowercase()}")
+            commandPort.executeShellCommand("docker rmi ${application.containerName}")
                 .also {exitValue ->
                     if (exitValue != 0 && exitValue != 1)
                         checkExitValuePort.checkApplicationExitValue(exitValue, application, this)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExecContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExecContainerServiceImpl.kt
@@ -15,8 +15,6 @@ class ExecContainerServiceImpl(
     private val dockerClient: DockerClient,
 ) : ExecContainerService {
     override fun execCmd(application: Application, session: WebSocketSession, cmd: String) {
-        val containerName = application.name.lowercase()
-
         val cmdArray = cmd.split(" ").toTypedArray()
 
         if (cmd.contains("cd")) {
@@ -32,7 +30,7 @@ class ExecContainerServiceImpl(
         val workingDir = session.attributes["workingDir"] as? String ?: "/"
 
         // Docker attach API 호출
-        val execInstance = dockerClient.execCreateCmd(containerName)
+        val execInstance = dockerClient.execCreateCmd(application.containerName)
             .withAttachStdout(true)
             .withAttachStderr(true)
             .withCmd(*cmdArray)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetContainerLogServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetContainerLogServiceImpl.kt
@@ -10,5 +10,5 @@ class GetContainerLogServiceImpl(
     private val commandPort: CommandPort
 ) : GetContainerLogService {
     override fun getLogs(application: Application): List<String> =
-        commandPort.executeShellCommandWithResult("docker logs ${application.name.lowercase()}")
+        commandPort.executeShellCommandWithResult("docker logs ${application.containerName}")
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/RunContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/RunContainerServiceImpl.kt
@@ -33,7 +33,7 @@ class RunContainerServiceImpl(
 
     private suspend fun run(application: Application) {
         withContext(Dispatchers.IO) {
-            val exitValue = commandPort.executeShellCommand("docker start ${application.name.lowercase()}")
+            val exitValue = commandPort.executeShellCommand("docker start ${application.containerName}")
             if (exitValue != 0) {
                 log.error("$exitValue")
                 eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application))

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/StopContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/StopContainerServiceImpl.kt
@@ -20,7 +20,7 @@ class StopContainerServiceImpl(
 
     override suspend fun stopContainer(application: Application) {
         withContext(Dispatchers.IO) {
-            val exitValue = commandPort.executeShellCommand("docker stop ${application.name.lowercase()}")
+            val exitValue = commandPort.executeShellCommand("docker stop ${application.containerName}")
             if (exitValue != 0) {
                 log.error("$exitValue")
                 eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application))

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCase.kt
@@ -33,7 +33,7 @@ class ExecuteCommandUseCase(
             throw InvalidApplicationStatusException()
 
         val result =
-            commandPort.executeShellCommandWithResult("docker exec ${application.name.lowercase()} sh -c 'cd / && ${executeCommandReqDto.command}'")
+            commandPort.executeShellCommandWithResult("docker exec ${application.containerName} sh -c 'cd / && ${executeCommandReqDto.command}'")
 
         return CommandResultResDto(result)
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/model/Workspace.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/model/Workspace.kt
@@ -10,6 +10,8 @@ data class Workspace(
     val globalEnv: Map<String, String> = mapOf(),
     val owner: User
 ) {
+    val networkName: String = title.replace(" ", "_")
+
     override fun equals(other: Any?): Boolean {
         if (other !is Workspace) return false
         return this.id == other.id

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/service/impl/CreateNetworkServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/service/impl/CreateNetworkServiceImpl.kt
@@ -9,6 +9,6 @@ class CreateNetworkServiceImpl(
     private val commandPort: CommandPort
 ) : CreateNetworkService {
     override fun createNetwork(networkTitle: String) {
-        commandPort.executeShellCommand("docker network create --driver bridge ${networkTitle.replace(' ', '_')}")
+        commandPort.executeShellCommand("docker network create --driver bridge $networkTitle")
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/CreateWorkspaceUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/CreateWorkspaceUseCase.kt
@@ -26,7 +26,7 @@ class CreateWorkspaceUseCase(
         val workspace = createWorkspaceReqDto.toEntity(currentUser)
         commandWorkspacePort.save(workspace)
 
-        createNetworkService.createNetwork(createWorkspaceReqDto.title)
+        createNetworkService.createNetwork(workspace.networkName)
 
         return CreateWorkspaceResDto(workspace.id)
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/service/CreateNetworkServiceTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/service/CreateNetworkServiceTest.kt
@@ -19,7 +19,7 @@ class CreateNetworkServiceTest(
 ) : BehaviorSpec({
 
     given("생성할 네트워크 제목을 주어지고") {
-        val testNetworkTitle = "test network"
+        val testNetworkTitle = "test_network"
 
         `when`("createNetwork 메서드를 실행할때") {
             createNetworkService.createNetwork(testNetworkTitle)


### PR DESCRIPTION
## 개요
* 도매인 객체의 리소스 이름을 반환하는 필드를 추가합니다.
## 작업내용
* 애플리케이션 도메인 클래스에 컨테이너 이름 필드 추가
* 애플리케이션 스케줄러에서 containerName을 사용하도록 수정
* 애플리케이션 서비스에서 containerName을 사용하도록 수정
* 애플리케이션 유스케이스에서 containerName을 사용하도록 수정
* 워크스페이스 도메인 클래스에 네트워크 이름 필드 추가
* 워크스페이스 서비스에서 networkName을 사용하도록 수정
* 워크스페이스 유스케이스에서 networkName을 사용하도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 애플리케이션 및 워크스페이스 모델에 `containerName`과 `networkName` 속성 추가
	- 컨테이너 및 네트워크 이름 생성 로직 개선

- **버그 수정**
	- 대소문자 변환 로직 제거 및 일관성 있는 이름 생성
	- Docker 명령어에서의 네트워크 제목 처리 방식 최적화

- **리팩토링**
	- 여러 서비스 클래스의 Docker 관련 메서드 업데이트
	- 컨테이너 및 이미지 관리 로직 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->