### PR TITLE
🔀 :: [#490] - 애플리케이션 수정시 컨테이너를 수정하도록 리펙토링

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/RunContainerService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/RunContainerService.kt
@@ -3,7 +3,7 @@ package com.dcd.server.core.domain.application.service
 import com.dcd.server.core.domain.application.model.Application
 
 interface RunContainerService {
-    suspend fun runApplication(id: String)
+    suspend fun runContainer(id: String)
 
-   suspend fun runApplication(application: Application)
+   suspend fun runContainer(application: Application)
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/RunContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/RunContainerServiceImpl.kt
@@ -21,13 +21,13 @@ class RunContainerServiceImpl(
 ) : RunContainerService {
     private val log = LoggerFactory.getLogger(this::class.simpleName)
 
-    override suspend fun runApplication(id: String) {
+    override suspend fun runContainer(id: String) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
         run(application)
     }
 
-    override suspend fun runApplication(application: Application) {
+    override suspend fun runContainer(application: Application) {
         run(application)
     }
 

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCase.kt
@@ -28,7 +28,7 @@ class RunApplicationUseCase(
             throw AlreadyRunningException()
 
         launch  {
-            runContainerService.runApplication(application)
+            runContainerService.runContainer(application)
         }
 
         changeApplicationStatusService.changeApplicationStatus(application, ApplicationStatus.PENDING)
@@ -55,7 +55,7 @@ class RunApplicationUseCase(
         repeat(3) {
             scope.launch {
                 for (application in runChannel) {
-                    runContainerService.runApplication(application)
+                    runContainerService.runContainer(application)
                 }
             }
         }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCase.kt
@@ -48,5 +48,6 @@ class UpdateApplicationUseCase(
                 port = updateApplicationReqDto.port
             )
         commandApplicationPort.save(updatedApplication)
+        eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.PENDING, updatedApplication))
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCase.kt
@@ -2,23 +2,41 @@ package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.domain.application.dto.request.UpdateApplicationReqDto
+import com.dcd.server.core.domain.application.event.ChangeApplicationStatusEvent
 import com.dcd.server.core.domain.application.exception.AlreadyRunningException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
+import com.dcd.server.core.domain.application.service.DeleteContainerService
+import com.dcd.server.core.domain.application.service.DeleteImageService
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.springframework.context.ApplicationEventPublisher
 
 @UseCase
 class UpdateApplicationUseCase(
     private val queryApplicationPort: QueryApplicationPort,
     private val commandApplicationPort: CommandApplicationPort,
-) {
+    private val deleteContainerService: DeleteContainerService,
+    private val deleteImageService: DeleteImageService,
+    private val eventPublisher: ApplicationEventPublisher
+) : CoroutineScope by CoroutineScope(Dispatchers.IO) {
     fun execute(id: String, updateApplicationReqDto: UpdateApplicationReqDto) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
 
         if (application.status == ApplicationStatus.RUNNING)
             throw AlreadyRunningException()
+
+        if (application.name != updateApplicationReqDto.name) {
+            launch {
+                deleteContainerService.deleteContainer(application)
+                deleteImageService.deleteImage(application)
+                eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.STOPPED, application))
+            }
+        }
 
         val updatedApplication =
             application.copy(

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/DockerRunServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/DockerRunServiceImplTest.kt
@@ -24,7 +24,7 @@ class DockerRunServiceImplTest : BehaviorSpec({
             val application = ApplicationGenerator.generateApplication()
             every { queryApplicationPort.findById(appId) } returns application
 
-            service.runApplication(appId)
+            service.runContainer(appId)
             then("commandPort가 실행되어야함") {
                 verify { commandPort.executeShellCommand("docker start ${application.name.lowercase()}") }
             }
@@ -35,7 +35,7 @@ class DockerRunServiceImplTest : BehaviorSpec({
         val application = ApplicationGenerator.generateApplication()
 
         `when`("executeShellCommand 메서드를 실행할때") {
-            service.runApplication(application)
+            service.runContainer(application)
 
             then("commandPort가 실행되어야함") {
                 verify { commandPort.executeShellCommand("docker start ${application.name.lowercase()}") }


### PR DESCRIPTION
## 개요
* 애플리케이션 수정시 이름이 변경된다면 해당 애플리케이션의 컨테이너를 삭제하도록 리펙토링합니다.
## 작업내용
* 코루틴을 활용해서 생성된 컨테이너를 삭제하도록 수정
* 코루틴을 제외한 애플리케이션 수정이 이루어졌을때 PENDING 상태로 변경하도록 수정
* 테스트 코드 수정
* RunContainerService 메서드 네이밍 수정
## 기타
* 이름이 변경됐을때 해당 애플리케이션의 컨테이너및 이미지를 삭제하도록 수정됐습니다.
  * 배포, 실행할때 컨테이너의 실행을 애플리케이션의 이름으로 진행하다보니 이름이 변경될 경우 컨테이너를 삭제할 필요가 있었습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩토링**
  - 컨테이너 실행 관련 내부 메소드의 명칭을 일관되게 수정하여 용어 통일성을 강화했습니다.
- **새로운 기능**
  - 애플리케이션 업데이트 시 이름 변경에 따라 기존 컨테이너와 이미지를 비동기로 정리하는 프로세스를 도입했습니다.
- **테스트**
  - 실행 명령 검증과 관련된 테스트 케이스를 보완하여 시스템 안정성을 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->