### PR TITLE
🔀 :: [#492] - 워크스페이스 수정시 네트워크를 수정하도록 리펙토링

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/service/ConnectNetworkService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/service/ConnectNetworkService.kt
@@ -1,0 +1,7 @@
+package com.dcd.server.core.domain.workspace.service
+
+import com.dcd.server.core.domain.workspace.model.Workspace
+
+interface ConnectNetworkService {
+    fun connectNetworkByWorkspace(workspace: Workspace)
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/service/DisconnectNetworkService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/service/DisconnectNetworkService.kt
@@ -1,0 +1,5 @@
+package com.dcd.server.core.domain.workspace.service
+
+interface DisconnectNetworkService {
+    fun disconnectNetwork(networkName: String)
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/service/impl/ConnectNetworkServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/service/impl/ConnectNetworkServiceImpl.kt
@@ -1,0 +1,20 @@
+package com.dcd.server.core.domain.workspace.service.impl
+
+import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import com.dcd.server.core.domain.workspace.model.Workspace
+import com.dcd.server.core.domain.workspace.service.ConnectNetworkService
+import org.springframework.stereotype.Service
+
+@Service
+class ConnectNetworkServiceImpl(
+    private val commandPort: CommandPort,
+    private val queryApplicationPort: QueryApplicationPort
+) : ConnectNetworkService{
+    override fun connectNetworkByWorkspace(workspace: Workspace) {
+        val applicationList = queryApplicationPort.findAllByWorkspace(workspace)
+        applicationList.forEach {
+            commandPort.executeShellCommand("docker network connect ${workspace.networkName} ${it.containerName}")
+        }
+    }
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/service/impl/DisconnectNetworkServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/service/impl/DisconnectNetworkServiceImpl.kt
@@ -1,0 +1,18 @@
+package com.dcd.server.core.domain.workspace.service.impl
+
+import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.domain.workspace.service.DisconnectNetworkService
+import org.springframework.stereotype.Service
+
+@Service
+class DisconnectNetworkServiceImpl(
+    private val commandPort: CommandPort
+) : DisconnectNetworkService {
+    override fun disconnectNetwork(networkName: String) {
+        commandPort.executeShellCommand(
+            "for container in \$(docker network inspect $networkName -f '{{range .Containers}}{{.Name}} {{end}}'); do" +
+                " docker network disconnect $networkName \$container;" +
+                " done"
+        )
+    }
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteWorkspaceUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteWorkspaceUseCase.kt
@@ -20,7 +20,7 @@ class DeleteWorkspaceUseCase(
 
         validateWorkspaceOwnerService.validateOwner(workspace)
 
-        deleteNetworkService.deleteNetwork(workspace.title)
+        deleteNetworkService.deleteNetwork(workspace.networkName)
 
         commandWorkspacePort.delete(workspace)
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/UpdateWorkspaceUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/UpdateWorkspaceUseCase.kt
@@ -3,7 +3,7 @@ package com.dcd.server.core.domain.workspace.usecase
 import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.domain.workspace.dto.request.UpdateWorkspaceReqDto
 import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
-import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
+import com.dcd.server.core.domain.workspace.service.*
 import com.dcd.server.core.domain.workspace.spi.CommandWorkspacePort
 import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
 
@@ -11,7 +11,11 @@ import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
 class UpdateWorkspaceUseCase(
     private val commandWorkspacePort: CommandWorkspacePort,
     private val queryWorkspacePort: QueryWorkspacePort,
-    private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService
+    private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService,
+    private val deleteNetworkService: DeleteNetworkService,
+    private val disconnectNetworkService: DisconnectNetworkService,
+    private val createNetworkService: CreateNetworkService,
+    private val connectNetworkService: ConnectNetworkService
 ) {
     fun execute(workspaceId: String, updateWorkspaceReqDto: UpdateWorkspaceReqDto) {
         val workspace = (queryWorkspacePort.findById(workspaceId)
@@ -20,6 +24,18 @@ class UpdateWorkspaceUseCase(
         validateWorkspaceOwnerService.validateOwner(workspace)
 
         val updatedWorkspace = workspace.copy(title = updateWorkspaceReqDto.title, description = updateWorkspaceReqDto.description)
+
+        if (workspace.title != updateWorkspaceReqDto.title) {
+            //기존 워크스페이스에서 생성된 네트워크 분리
+            disconnectNetworkService.disconnectNetwork(workspace.networkName)
+            //기존 워크스페이스의 네트워크 삭제
+            deleteNetworkService.deleteNetwork(workspace.networkName)
+            //수정된 네트워크 생성
+            createNetworkService.createNetwork(updatedWorkspace.networkName)
+            //워크스페이스의 애플리케이션에 신규 생성된 네트워크 연결
+            connectNetworkService.connectNetworkByWorkspace(updatedWorkspace)
+        }
+
         commandWorkspacePort.save(updatedWorkspace)
     }
 }

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/UpdateWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/UpdateWorkspaceUseCaseTest.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.core.domain.workspace.usecase
 
+import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.domain.user.spi.CommandUserPort
 import com.dcd.server.core.domain.user.spi.QueryUserPort
 import com.dcd.server.core.domain.workspace.dto.request.UpdateWorkspaceReqDto
@@ -12,6 +13,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import com.dcd.server.infrastructure.test.user.UserGenerator
 import com.dcd.server.infrastructure.test.workspace.WorkspaceGenerator
+import com.ninjasquad.springmockk.MockkBean
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import org.springframework.boot.test.context.SpringBootTest
@@ -29,7 +31,9 @@ class UpdateWorkspaceUseCaseTest(
     private val queryWorkspacePort: QueryWorkspacePort,
     private val commandWorkspacePort: CommandWorkspacePort,
     private val queryUserPort: QueryUserPort,
-    private val commandUserPort: CommandUserPort
+    private val commandUserPort: CommandUserPort,
+    @MockkBean(relaxed = true)
+    private val commandPort: CommandPort
 ) : BehaviorSpec({
     val userId = "user1"
     val workspaceId = "testWorkspaceId"


### PR DESCRIPTION
## 개요
* 워크스페이스 수정시 네트워크를 수정하도록 리펙토링합니다.
## 작업내용
* 워크스페이스 삭제시 워크스페이스의 networkName을 사용하도록 수정
* DisconnectNetworkService 추가
* ConnectNetworkService 추가
* 워크스페이스 이름이 변경되면 해당하는 네트워크및 컨테이너의 정보를 변경하도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 작업공간 업데이트 시, 작업공간의 이름 변경에 따라 관련 네트워크 연결이 자동으로 관리됩니다. 기존 네트워크 연결은 해제 및 제거되고, 새 네트워크가 생성되어 애플리케이션 연결이 재구성됩니다.
  - 네트워크 연결과 해제 기능이 강화되어 보다 안정적인 작업 환경을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->