### PR TITLE
🔀 :: [#494] - 워크스페이스 이름 수정시 컨테이너의 네트워크 연결끊기가 제대로 이루어지지 않는 현상 수정

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/service/DisconnectNetworkService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/service/DisconnectNetworkService.kt
@@ -1,5 +1,7 @@
 package com.dcd.server.core.domain.workspace.service
 
+import com.dcd.server.core.domain.workspace.model.Workspace
+
 interface DisconnectNetworkService {
-    fun disconnectNetwork(networkName: String)
+    fun disconnectNetwork(workspace: Workspace)
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/service/impl/DisconnectNetworkServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/service/impl/DisconnectNetworkServiceImpl.kt
@@ -1,18 +1,20 @@
 package com.dcd.server.core.domain.workspace.service.impl
 
 import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import com.dcd.server.core.domain.workspace.model.Workspace
 import com.dcd.server.core.domain.workspace.service.DisconnectNetworkService
 import org.springframework.stereotype.Service
 
 @Service
 class DisconnectNetworkServiceImpl(
-    private val commandPort: CommandPort
+    private val commandPort: CommandPort,
+    private val queryApplicationPort: QueryApplicationPort
 ) : DisconnectNetworkService {
-    override fun disconnectNetwork(networkName: String) {
-        commandPort.executeShellCommand(
-            "for container in \$(docker network inspect $networkName -f '{{range .Containers}}{{.Name}} {{end}}'); do" +
-                " docker network disconnect $networkName \$container;" +
-                " done"
-        )
+    override fun disconnectNetwork(workspace: Workspace) {
+        val applicationList = queryApplicationPort.findAllByWorkspace(workspace)
+        applicationList.forEach {
+            commandPort.executeShellCommand("docker network disconnect ${workspace.networkName} ${it.containerName}")
+        }
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/UpdateWorkspaceUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/UpdateWorkspaceUseCase.kt
@@ -27,7 +27,7 @@ class UpdateWorkspaceUseCase(
 
         if (workspace.title != updateWorkspaceReqDto.title) {
             //기존 워크스페이스에서 생성된 네트워크 분리
-            disconnectNetworkService.disconnectNetwork(workspace.networkName)
+            disconnectNetworkService.disconnectNetwork(workspace)
             //기존 워크스페이스의 네트워크 삭제
             deleteNetworkService.deleteNetwork(workspace.networkName)
             //수정된 네트워크 생성


### PR DESCRIPTION
## 개요
* 워크스페이스 수정시 이름이 수정되면 컨테이너의 네트워크 연결끊기가 정상적으로 이루어지지 않는 현상을 수정합니다.
## 작업내용
* DisconnectNetworkService 인터페이스를 workspace를 매개변수로 받도록 수정
* DisconnectNetworkService의 구현을 주어진 워크스페이스를 가진 애플리케이션의 네트워크를 직접 끊는 방식으로 수정
* disconnectNetwork 호출시 워크스페이스를 매개변수로 호출하도록 수정
## 기타
* 원래는 코루틴을 적용하려 했는데 워크스페이스는 진행 상태를 가지고 있지 않아서 비동기로 처리후  제대로 처리됐는지 확인할 방법이 없어서 동기로 처리하도록 수정
  * 애플리케이션에서 코루틴을 사용하는 이유는 코루틴으로 실행후 해당 코루틴에 대한 관리를 하지 않고, 애플리케이션의 상태를 통해서 실패했는지 검증하기 때문에 코루틴을 실행후 해당 코루틴에대한 처리를 하지 않아도 됐었음
  * 즉 코루틴에서 실행하는 작업중 예외가 발생하더라도 이벤트를 발생시켜서 유저가 해당 작업이 실패했음을 인지하게끔 할 수 있다.
  * But 워크스페이스는 그럴 방법이 없다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩토링**
  - 작업 공간 네트워크 분리 기능이 개선되어, 작업 공간의 전체 정보를 기반으로 관련 애플리케이션들의 연결을 일괄적으로 해제합니다.
  - 업데이트된 로직을 통해 작업 공간 업데이트 시 네트워크 분리가 보다 체계적으로 이루어집니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->