### PR TITLE
🔀 :: [#496] - Redis 해시 TTL 만료시 키, 인덱스를 삭제하도록 수정

### DIFF
--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/RedisConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/RedisConfig.kt
@@ -5,9 +5,12 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.connection.RedisConnectionFactory
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.RedisKeyValueAdapter
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories
 
 
 @Configuration
+@EnableRedisRepositories(enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP)
 class RedisConfig {
     @Value("\${spring.data.redis.host}")
     private val host: String = ""


### PR DESCRIPTION
## 개요
* Redis 해시 TTL 만료시 키, 인덱스를 삭제하도록 수정합니다.
## 작업내용
* Key Space Notifications 옵션 활성화

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 애플리케이션이 시작될 때부터 캐시 저장소 이벤트를 자동으로 관리하여 데이터 동기화 및 응답 성능이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->