### PR TITLE
🔀 :: [#500] - 애플리케이션 status를 다루는 플로우 리펙토링

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/event/ChangeApplicationStatusEvent.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/event/ChangeApplicationStatusEvent.kt
@@ -5,5 +5,6 @@ import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 
 class ChangeApplicationStatusEvent(
     val status: ApplicationStatus,
-    val application: Application
+    val application: Application,
+    val failureReason: String? = null
 )

--- a/src/main/kotlin/com/dcd/server/core/domain/application/event/listener/ApplicationEventListener.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/event/listener/ApplicationEventListener.kt
@@ -14,7 +14,8 @@ class ApplicationEventListener(
     @Transactional(rollbackFor = [Exception::class])
     fun process(event: ChangeApplicationStatusEvent) {
         val updatedApplication = event.application.copy(
-            status = event.status
+            status = event.status,
+            failureReason = event.failureReason
         )
 
         commandApplicationPort.save(updatedApplication)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/model/Application.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/model/Application.kt
@@ -17,6 +17,7 @@ data class Application(
     val port: Int,
     val externalPort: Int,
     val status: ApplicationStatus,
+    val failureReason: String? = null,
     val labels: List<String>
 ) {
     val containerName = name.lowercase()

--- a/src/main/kotlin/com/dcd/server/core/domain/application/scheduler/ApplicationStatusScheduler.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/scheduler/ApplicationStatusScheduler.kt
@@ -25,13 +25,17 @@ class ApplicationStatusScheduler(
 
         val updatedApplicationList = mutableListOf<Application>()
         getContainerService.getContainerNameByStatus(ContainerStatus.EXITED)
-            .forEach {containerName ->
+            .forEach { result ->
+                val (containerName, exitCode) = result.split(" ")
                 val containerExitedApplication = runningApplicationList.lastOrNull { it.containerName == containerName }
                     ?: return@forEach
 
-                val updatedApplication = containerExitedApplication.copy(
-                    status = ApplicationStatus.STOPPED
-                )
+                val updatedApplication =
+                    if (exitCode == "0")
+                        containerExitedApplication.copy(status = ApplicationStatus.STOPPED)
+                    else
+                        containerExitedApplication.copy(status = ApplicationStatus.FAILURE)
+
                 updatedApplicationList.add(updatedApplication)
             }
 

--- a/src/main/kotlin/com/dcd/server/core/domain/application/scheduler/ApplicationStatusScheduler.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/scheduler/ApplicationStatusScheduler.kt
@@ -34,7 +34,7 @@ class ApplicationStatusScheduler(
                     if (exitCode == "0")
                         containerExitedApplication.copy(status = ApplicationStatus.STOPPED)
                     else
-                        containerExitedApplication.copy(status = ApplicationStatus.FAILURE)
+                        containerExitedApplication.copy(status = ApplicationStatus.FAILURE, failureReason = "컨테이너가 비정상적으로 종료됨")
 
                 updatedApplicationList.add(updatedApplication)
             }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/scheduler/ApplicationStatusScheduler.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/scheduler/ApplicationStatusScheduler.kt
@@ -15,6 +15,10 @@ class ApplicationStatusScheduler(
     private val getContainerService: GetContainerService,
     private val commandApplicationPort: CommandApplicationPort
 ) {
+    /**
+     * 실행중인 애플리케이션중 컨테이너가 종료된 애플리케이션의 상태를 STOPPED로 변경하는 스케줄러
+     * @author dolong2
+     */
     @Scheduled(cron = "0 * * * * ?")
     fun checkExitedApplication() {
         val runningApplicationList = queryApplicationPort.findAllByStatus(ApplicationStatus.RUNNING)
@@ -34,6 +38,10 @@ class ApplicationStatusScheduler(
         commandApplicationPort.saveAll(updatedApplicationList)
     }
 
+    /**
+     * 정지된 애플리케이션중 실행중인 컨테이너가 있는 애플리케이션의 상태를 RUNNING으로 변경하는 스케줄러
+     * @author dolong2
+     */
     @Scheduled(cron = "0 * * * * ?")
     fun checkRunningApplication() {
         val stoppedApplicationList = queryApplicationPort.findAllByStatus(ApplicationStatus.STOPPED)
@@ -53,6 +61,10 @@ class ApplicationStatusScheduler(
         commandApplicationPort.saveAll(updatedApplicationList)
     }
 
+    /**
+     * 실행중인 상태인 애플리케이션중 컨테이너가 생성된 상태가 있는 애플리케이션이 있다면 정지됨 상태로 변경하는 스케줄러
+     * @author dolong2
+     */
     @Scheduled(cron = "0 * * * * ?")
     fun checkCreatedContainer() {
         val runningApplicationList = queryApplicationPort.findAllByStatus(ApplicationStatus.RUNNING)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/scheduler/ApplicationStatusScheduler.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/scheduler/ApplicationStatusScheduler.kt
@@ -52,7 +52,8 @@ class ApplicationStatusScheduler(
 
         val updatedApplicationList = mutableListOf<Application>()
         getContainerService.getContainerNameByStatus(ContainerStatus.RUNNING)
-            .forEach {containerName ->
+            .forEach { result ->
+                val (containerName, _) = result.split(" ")
                 val containerRunningApplication = stoppedApplicationList.lastOrNull { it.containerName == containerName }
                     ?: return@forEach
 
@@ -75,7 +76,8 @@ class ApplicationStatusScheduler(
 
         val updatedApplicationList = mutableListOf<Application>()
         getContainerService.getContainerNameByStatus(ContainerStatus.CREATED)
-            .forEach {containerName ->
+            .forEach { result ->
+                val (containerName, _) = result.split(" ")
                 val containerExitedApplication = runningApplicationList.lastOrNull { it.containerName == containerName }
                     ?: return@forEach
 

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/BuildDockerImageServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/BuildDockerImageServiceImpl.kt
@@ -36,7 +36,7 @@ class BuildDockerImageServiceImpl(
                     commandPort.executeShellCommand("cd ./$directoryName && docker build -t ${application.containerName}:latest .")
                 }
             }
-            checkExitValuePort.checkApplicationExitValue(exitValue, application, this)
+            checkExitValuePort.checkApplicationExitValue(exitValue, application, this, "도커 이미지 빌드중 에러")
         }
     }
 
@@ -52,7 +52,7 @@ class BuildDockerImageServiceImpl(
                     commandPort.executeShellCommand("cd ./$directoryName && docker build -t ${application.containerName}:latest .")
                 }
             }
-            checkExitValuePort.checkApplicationExitValue(exitValue, application, this)
+            checkExitValuePort.checkApplicationExitValue(exitValue, application, this, "도커 이미지 빌드중 에러")
         }
     }
 

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CloneApplicationByUrlServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CloneApplicationByUrlServiceImpl.kt
@@ -22,7 +22,7 @@ class CloneApplicationByUrlServiceImpl(
                 ?: throw ApplicationNotFoundException())
             val githubUrl = application.githubUrl
             val exitValue = commandPort.executeShellCommand("git clone $githubUrl ${application.name}")
-            checkExitValuePort.checkApplicationExitValue(exitValue, application, this)
+            checkExitValuePort.checkApplicationExitValue(exitValue, application, this, "애플리케이션 복사중 에러")
         }
     }
 
@@ -31,7 +31,7 @@ class CloneApplicationByUrlServiceImpl(
             val githubUrl = application.githubUrl
             commandPort.executeShellCommand("git clone $githubUrl ${application.name}")
                 .also {exitValue ->
-                    checkExitValuePort.checkApplicationExitValue(exitValue, application, this)
+                    checkExitValuePort.checkApplicationExitValue(exitValue, application, this, "애플리케이션 복사중 에러")
                 }
         }
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateContainerServiceImpl.kt
@@ -22,13 +22,13 @@ class CreateContainerServiceImpl(
 
             commandPort.executeShellCommand(cmd)
                 .also {exitValue ->
-                    checkExitValuePort.checkApplicationExitValue(exitValue, application, this)
+                    checkExitValuePort.checkApplicationExitValue(exitValue, application, this, "컨테이너 생성시 에러")
                 }
 
             val dcdNetworkConnectCmd = "docker network connect dcd ${application.containerName}"
             commandPort.executeShellCommand(dcdNetworkConnectCmd)
                 .also {exitValue ->
-                    checkExitValuePort.checkApplicationExitValue(exitValue, application, this)
+                    checkExitValuePort.checkApplicationExitValue(exitValue, application, this, "네트워크 연결 실패")
                 }
         }
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateDockerFileServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateDockerFileServiceImpl.kt
@@ -48,7 +48,7 @@ class CreateDockerFileServiceImpl(
 
         commandPort.executeShellCommand("mkdir -p $directoryName")
             .also {exitValue ->
-                checkExitValuePort.checkApplicationExitValue(exitValue, application, coroutineScope)
+                checkExitValuePort.checkApplicationExitValue(exitValue, application, coroutineScope, "애플리케이션 디렉토리 생성중 에러")
             }
 
         val file = File("./$directoryName/Dockerfile")
@@ -73,7 +73,7 @@ class CreateDockerFileServiceImpl(
             if (!file.createNewFile())
                 return
         } catch (e: IOException) {
-            eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application))
+            eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application, "도커파일 생성중 에러"))
         }
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteApplicationDirectoryServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteApplicationDirectoryServiceImpl.kt
@@ -20,7 +20,7 @@ class DeleteApplicationDirectoryServiceImpl(
         withContext(Dispatchers.IO) {
             commandPort.executeShellCommand("rm -rf ${application.name}")
                 .also {exitValue ->
-                    checkExitValuePort.checkApplicationExitValue(exitValue, application, this)
+                    checkExitValuePort.checkApplicationExitValue(exitValue, application, this, "애플리케이션 디렉토리 삭제중 에러")
                 }
         }
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteContainerServiceImpl.kt
@@ -18,7 +18,7 @@ class DeleteContainerServiceImpl(
             commandPort.executeShellCommand("docker rm ${application.containerName}")
                 .also {exitValue ->
                     if (exitValue != 0 && exitValue != 1)
-                        checkExitValuePort.checkApplicationExitValue(exitValue, application, this)
+                        checkExitValuePort.checkApplicationExitValue(exitValue, application, this, "컨테이너 삭제중 에러")
                 }
         }
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteImageServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteImageServiceImpl.kt
@@ -18,7 +18,7 @@ class DeleteImageServiceImpl(
             commandPort.executeShellCommand("docker rmi ${application.containerName}")
                 .also {exitValue ->
                     if (exitValue != 0 && exitValue != 1)
-                        checkExitValuePort.checkApplicationExitValue(exitValue, application, this)
+                        checkExitValuePort.checkApplicationExitValue(exitValue, application, this, "이미지 삭제중 에러")
                 }
         }
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetContainerServiceImpl.kt
@@ -10,5 +10,5 @@ class GetContainerServiceImpl(
     private val commandPort: CommandPort
 ) : GetContainerService {
     override fun getContainerNameByStatus(status: ContainerStatus): List<String> =
-        commandPort.executeShellCommandWithResult("docker ps -a --filter \"status=${status.value}\" --format \"{{.Names}}\"")
+        commandPort.executeShellCommandWithResult("docker ps -a --filter \"status=${status.value}\" --format \"{{.ID}}\" | xargs -I {} docker inspect --format \"{{.Name}} {{.State.ExitCode}}\" {}")
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/RunContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/RunContainerServiceImpl.kt
@@ -36,7 +36,7 @@ class RunContainerServiceImpl(
             val exitValue = commandPort.executeShellCommand("docker start ${application.containerName}")
             if (exitValue != 0) {
                 log.error("$exitValue")
-                eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application))
+                eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application, "컨테이너 실행중 에러"))
             }
 
             else

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/StopContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/StopContainerServiceImpl.kt
@@ -23,7 +23,7 @@ class StopContainerServiceImpl(
             val exitValue = commandPort.executeShellCommand("docker stop ${application.containerName}")
             if (exitValue != 0) {
                 log.error("$exitValue")
-                eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application))
+                eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application, "컨테이너 정지중 에러"))
             }
 
             else

--- a/src/main/kotlin/com/dcd/server/core/domain/application/spi/CheckExitValuePort.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/spi/CheckExitValuePort.kt
@@ -4,7 +4,7 @@ import com.dcd.server.core.domain.application.model.Application
 import kotlinx.coroutines.CoroutineScope
 
 interface CheckExitValuePort {
-    fun checkApplicationExitValue(exitValue: Int, application: Application, failureReason: String)
+    fun checkApplicationExitValue(exitValue: Int, application: Application, failureReason: String?)
 
-    fun checkApplicationExitValue(exitValue: Int, application: Application, coroutineScope: CoroutineScope, failureReason: String)
+    fun checkApplicationExitValue(exitValue: Int, application: Application, coroutineScope: CoroutineScope, failureReason: String?)
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/spi/CheckExitValuePort.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/spi/CheckExitValuePort.kt
@@ -4,7 +4,7 @@ import com.dcd.server.core.domain.application.model.Application
 import kotlinx.coroutines.CoroutineScope
 
 interface CheckExitValuePort {
-    fun checkApplicationExitValue(exitValue: Int, application: Application)
+    fun checkApplicationExitValue(exitValue: Int, application: Application, failureReason: String)
 
-    fun checkApplicationExitValue(exitValue: Int, application: Application, coroutineScope: CoroutineScope)
+    fun checkApplicationExitValue(exitValue: Int, application: Application, coroutineScope: CoroutineScope, failureReason: String)
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/spi/adapter/CheckExitValueAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/spi/adapter/CheckExitValueAdapter.kt
@@ -16,17 +16,17 @@ class CheckExitValueAdapter(
 ) : CheckExitValuePort {
     private val log = LoggerFactory.getLogger(this::class.simpleName)
 
-    override fun checkApplicationExitValue(exitValue: Int, application: Application) {
+    override fun checkApplicationExitValue(exitValue: Int, application: Application, failureReason: String) {
         if (exitValue != 0) {
             log.error("${application.name} - $exitValue")
-            eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application))
+            eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application, failureReason))
         }
     }
 
-    override fun checkApplicationExitValue(exitValue: Int, application: Application, coroutineScope: CoroutineScope) {
+    override fun checkApplicationExitValue(exitValue: Int, application: Application, coroutineScope: CoroutineScope, failureReason: String) {
         if (exitValue != 0) {
             log.error("${application.name} - $exitValue")
-            eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application))
+            eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application, failureReason))
             coroutineScope.cancel()
         }
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/spi/adapter/CheckExitValueAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/spi/adapter/CheckExitValueAdapter.kt
@@ -16,14 +16,14 @@ class CheckExitValueAdapter(
 ) : CheckExitValuePort {
     private val log = LoggerFactory.getLogger(this::class.simpleName)
 
-    override fun checkApplicationExitValue(exitValue: Int, application: Application, failureReason: String) {
+    override fun checkApplicationExitValue(exitValue: Int, application: Application, failureReason: String?) {
         if (exitValue != 0) {
             log.error("${application.name} - $exitValue")
             eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application, failureReason))
         }
     }
 
-    override fun checkApplicationExitValue(exitValue: Int, application: Application, coroutineScope: CoroutineScope, failureReason: String) {
+    override fun checkApplicationExitValue(exitValue: Int, application: Application, coroutineScope: CoroutineScope, failureReason: String?) {
         if (exitValue != 0) {
             log.error("${application.name} - $exitValue")
             eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application, failureReason))

--- a/src/main/kotlin/com/dcd/server/persistence/application/adapter/ApplicationAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/application/adapter/ApplicationAdapter.kt
@@ -20,6 +20,7 @@ fun Application.toEntity(): ApplicationJpaEntity =
         externalPort = this.externalPort,
         version = this.version,
         status = this.status,
+        failureReason = this.failureReason,
         labels = this.labels
     )
 
@@ -36,5 +37,6 @@ fun ApplicationJpaEntity.toDomain(): Application =
         externalPort = this.externalPort,
         version = this.version,
         status = this.status,
+        failureReason = this.failureReason,
         labels = this.labels
     )

--- a/src/main/kotlin/com/dcd/server/persistence/application/entity/ApplicationJpaEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/application/entity/ApplicationJpaEntity.kt
@@ -31,6 +31,7 @@ class ApplicationJpaEntity(
     val version: String,
     @Enumerated(EnumType.STRING)
     val status: ApplicationStatus,
+    val failureReason: String?,
     @ElementCollection
     @CollectionTable(name = "application_label_entity", joinColumns = [JoinColumn(name = "application_id")])
     @Column(name = "label")

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/CreateContainerServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/CreateContainerServiceImplTest.kt
@@ -28,7 +28,8 @@ class CreateContainerServiceImplTest : BehaviorSpec({
                         "-p ${application.externalPort}:${application.port} ${application.name.lowercase()}:latest"
                     )
                 }
-                verify { checkExitValuePort.checkApplicationExitValue(0, application, any() as CoroutineScope) }
+                verify { checkExitValuePort.checkApplicationExitValue(0, application, any() as CoroutineScope, "컨테이너 생성시 에러") }
+                verify { checkExitValuePort.checkApplicationExitValue(0, application, any() as CoroutineScope, "네트워크 연결 실패") }
             }
         }
     }


### PR DESCRIPTION
## 개요
* 애플리케이션의 상태를 다루는 플로우를 리펙토링합니다.
## 작업내용
* 컨테이너 상태에 맞는 컨테이너를 조회할때 ExitCode도 같이 반환하도록 수정
* 애플리케이션 상태 스케줄러 주석 추가
* checkExitedApplication 메서드에서 exitCode에맞게 상태를 변경하게끔 수정
* 나머지 스케줄러의 check메서드에서 컨테이너의 이름만 사용하도록 수정
* 애플리케이션 도매인에 failureReason 추가
* ChangeApplicationStatusEvent에 failureReason을 전달할 수 있도록 수정
* CheckExitValuePort에서 failureReason을 전달받도록 수정
* 애플리케이션 배포과정에서 실패시 특정 이유를 이벤트에 전달하도록 수정
* 테스트 코드 수정
## 기타
* 추후에 애플리케이션 실패 케이스를 상수로 관리하도록 리펙토링

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- 애플리케이션 및 컨테이너 상태 업데이트 로직이 개선되어, 오류 발생 시 구체적인 실패 사유와 명확한 에러 메시지가 함께 제공됩니다.
	- 개선된 오류 리포팅 덕분에 문제 원인 파악 및 대응이 보다 신속하고 용이해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->