### PR TITLE
🔀 :: [#502] - 애플리케이션 응답에 failureReason 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/extenstion/ApplicationDtoExtension.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/extenstion/ApplicationDtoExtension.kt
@@ -35,6 +35,7 @@ fun Application.toDto(): ApplicationResDto =
         externalPort = this.externalPort,
         version = this.version,
         status = this.status,
+        failureReason = this.failureReason,
         labels = this.labels
     )
 

--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/response/ApplicationResDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/response/ApplicationResDto.kt
@@ -14,5 +14,6 @@ data class ApplicationResDto(
     val externalPort: Int,
     val version: String,
     val status: ApplicationStatus,
+    val failureReason: String?,
     val labels: List<String>
 )

--- a/src/main/kotlin/com/dcd/server/infrastructure/test/application/ApplicationGenerator.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/test/application/ApplicationGenerator.kt
@@ -18,6 +18,7 @@ object ApplicationGenerator {
         workspace: Workspace = WorkspaceGenerator.generateWorkspace(),
         port: Int = 8080,
         status: ApplicationStatus = ApplicationStatus.STOPPED,
+        failureReason: String? = null,
         labels: List<String> = listOf()
     ): Application =
         Application(
@@ -32,6 +33,7 @@ object ApplicationGenerator {
             port = port,
             externalPort = port,
             status = status,
+            failureReason = failureReason,
             labels = labels
         )
 }

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationResponseDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationResponseDataExtension.kt
@@ -18,6 +18,7 @@ fun ApplicationResDto.toResponse(): ApplicationResponse =
         externalPort = this.externalPort,
         version = this.version,
         status = this.status,
+        failureReason = this.failureReason,
         labels = this.labels
     )
 

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/response/ApplicationResponse.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/response/ApplicationResponse.kt
@@ -14,5 +14,6 @@ data class ApplicationResponse(
     val externalPort: Int,
     val version: String,
     val status: ApplicationStatus,
+    val failureReason: String?,
     val labels: List<String>
 )

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -71,7 +71,8 @@ class ApplicationWebAdapterTest : BehaviorSpec({
             externalPort = 8080,
             version = "latest",
             status = ApplicationStatus.STOPPED,
-            labels = listOf()
+            labels = listOf(),
+            failureReason = null
         )
         val list = listOf(applicationResponse)
         val responseDto = ApplicationListResDto(list)
@@ -99,7 +100,8 @@ class ApplicationWebAdapterTest : BehaviorSpec({
             externalPort = 8080,
             version = "latest",
             status = ApplicationStatus.STOPPED,
-            labels = listOf()
+            labels = listOf(),
+            failureReason = null
         )
         `when`("getOneApplication 메서드를 실행할때") {
             every { getOneApplicationUseCase.execute(testId) } returns applicationResponse


### PR DESCRIPTION
## 개요
* 애플리케이션 조회시 응답에서 failureReason을 같이 응답하도록 수정합니다.
## 작업내용
* ApplicationResDto에 failureReason 필드 추가
* ApplicationResponse에 failureReason 필드 추가
* ApplicationGenerator에 failureReason 반영
* 테스트 코드 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- 응용 프로그램 응답에 선택적 실패 사유 정보가 추가되어, 실패 발생 시 보다 명확한 피드백을 제공할 수 있게 되었습니다.
- **Tests**
	- 새로운 필드를 반영하도록 테스트 케이스가 업데이트되어, 응답 데이터의 정확성과 안정성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->