### PR TITLE
🔀 :: [#504] - 애플리케이션의 FailureCase를 상수로 관리하도록 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,15 +8,13 @@ networks:
 services:
   db:
     container_name: dcd-db
-    image: yobasystems/alpine-mariadb:latest
-    platform: "linux/arm"
+    image: mariadb:latest
     env_file: dcd-db.env
     ports:
       - 3307:3306
   redis:
-    platform: linux/arm/v7
     container_name: dcd-redis
-    image: redis:7.4.1-alpine
+    image: redis:latest
     env_file: dcd-redis.env
     environment:
       - REDIS_DISABLE_COMMANDS=FLUSHDB,FLUSHALL

--- a/src/main/kotlin/com/dcd/server/core/domain/application/event/ChangeApplicationStatusEvent.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/event/ChangeApplicationStatusEvent.kt
@@ -2,9 +2,10 @@ package com.dcd.server.core.domain.application.event
 
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
+import com.dcd.server.core.domain.application.util.FailureCase
 
 class ChangeApplicationStatusEvent(
     val status: ApplicationStatus,
     val application: Application,
-    val failureReason: String? = null
+    val failureCase: FailureCase? = null
 )

--- a/src/main/kotlin/com/dcd/server/core/domain/application/event/listener/ApplicationEventListener.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/event/listener/ApplicationEventListener.kt
@@ -15,7 +15,7 @@ class ApplicationEventListener(
     fun process(event: ChangeApplicationStatusEvent) {
         val updatedApplication = event.application.copy(
             status = event.status,
-            failureReason = event.failureReason
+            failureReason = event.failureCase?.reason
         )
 
         commandApplicationPort.save(updatedApplication)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/BuildDockerImageServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/BuildDockerImageServiceImpl.kt
@@ -7,6 +7,7 @@ import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.BuildDockerImageService
 import com.dcd.server.core.domain.application.spi.CheckExitValuePort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import com.dcd.server.core.domain.application.util.FailureCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.springframework.stereotype.Service
@@ -36,7 +37,7 @@ class BuildDockerImageServiceImpl(
                     commandPort.executeShellCommand("cd ./$directoryName && docker build -t ${application.containerName}:latest .")
                 }
             }
-            checkExitValuePort.checkApplicationExitValue(exitValue, application, this, "도커 이미지 빌드중 에러")
+            checkExitValuePort.checkApplicationExitValue(exitValue, application, this, FailureCase.IMAGE_BUILD_FAILURE)
         }
     }
 
@@ -52,7 +53,7 @@ class BuildDockerImageServiceImpl(
                     commandPort.executeShellCommand("cd ./$directoryName && docker build -t ${application.containerName}:latest .")
                 }
             }
-            checkExitValuePort.checkApplicationExitValue(exitValue, application, this, "도커 이미지 빌드중 에러")
+            checkExitValuePort.checkApplicationExitValue(exitValue, application, this, FailureCase.IMAGE_BUILD_FAILURE)
         }
     }
 

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CloneApplicationByUrlServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CloneApplicationByUrlServiceImpl.kt
@@ -6,6 +6,7 @@ import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.service.CloneApplicationByUrlService
 import com.dcd.server.core.domain.application.spi.CheckExitValuePort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import com.dcd.server.core.domain.application.util.FailureCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.springframework.stereotype.Service
@@ -22,7 +23,7 @@ class CloneApplicationByUrlServiceImpl(
                 ?: throw ApplicationNotFoundException())
             val githubUrl = application.githubUrl
             val exitValue = commandPort.executeShellCommand("git clone $githubUrl ${application.name}")
-            checkExitValuePort.checkApplicationExitValue(exitValue, application, this, "애플리케이션 복사중 에러")
+            checkExitValuePort.checkApplicationExitValue(exitValue, application, this, FailureCase.CLONE_FAILURE)
         }
     }
 
@@ -31,7 +32,7 @@ class CloneApplicationByUrlServiceImpl(
             val githubUrl = application.githubUrl
             commandPort.executeShellCommand("git clone $githubUrl ${application.name}")
                 .also {exitValue ->
-                    checkExitValuePort.checkApplicationExitValue(exitValue, application, this, "애플리케이션 복사중 에러")
+                    checkExitValuePort.checkApplicationExitValue(exitValue, application, this, FailureCase.CLONE_FAILURE)
                 }
         }
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateContainerServiceImpl.kt
@@ -4,6 +4,7 @@ import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.service.CreateContainerService
 import com.dcd.server.core.domain.application.spi.CheckExitValuePort
+import com.dcd.server.core.domain.application.util.FailureCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.springframework.stereotype.Service
@@ -22,13 +23,13 @@ class CreateContainerServiceImpl(
 
             commandPort.executeShellCommand(cmd)
                 .also {exitValue ->
-                    checkExitValuePort.checkApplicationExitValue(exitValue, application, this, "컨테이너 생성시 에러")
+                    checkExitValuePort.checkApplicationExitValue(exitValue, application, this, FailureCase.CREATE_CONTAINER_FAILURE)
                 }
 
             val dcdNetworkConnectCmd = "docker network connect dcd ${application.containerName}"
             commandPort.executeShellCommand(dcdNetworkConnectCmd)
                 .also {exitValue ->
-                    checkExitValuePort.checkApplicationExitValue(exitValue, application, this, "네트워크 연결 실패")
+                    checkExitValuePort.checkApplicationExitValue(exitValue, application, this, FailureCase.CONNECT_NETWORK_FAILURE)
                 }
         }
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateDockerFileServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateDockerFileServiceImpl.kt
@@ -11,6 +11,7 @@ import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.CreateDockerFileService
 import com.dcd.server.core.domain.application.spi.CheckExitValuePort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import com.dcd.server.core.domain.application.util.FailureCase
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
@@ -73,7 +74,7 @@ class CreateDockerFileServiceImpl(
             if (!file.createNewFile())
                 return
         } catch (e: IOException) {
-            eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application, "도커파일 생성중 에러"))
+            eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application, FailureCase.CREATE_DOCKER_FILE_FAILURE))
         }
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateDockerFileServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateDockerFileServiceImpl.kt
@@ -49,7 +49,7 @@ class CreateDockerFileServiceImpl(
 
         commandPort.executeShellCommand("mkdir -p $directoryName")
             .also {exitValue ->
-                checkExitValuePort.checkApplicationExitValue(exitValue, application, coroutineScope, "애플리케이션 디렉토리 생성중 에러")
+                checkExitValuePort.checkApplicationExitValue(exitValue, application, coroutineScope, FailureCase.CREATE_DIRECTORY_FAILURE)
             }
 
         val file = File("./$directoryName/Dockerfile")

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteApplicationDirectoryServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteApplicationDirectoryServiceImpl.kt
@@ -6,6 +6,7 @@ import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.service.DeleteApplicationDirectoryService
 import com.dcd.server.core.domain.application.spi.CheckExitValuePort
+import com.dcd.server.core.domain.application.util.FailureCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.springframework.context.ApplicationEventPublisher
@@ -20,7 +21,7 @@ class DeleteApplicationDirectoryServiceImpl(
         withContext(Dispatchers.IO) {
             commandPort.executeShellCommand("rm -rf ${application.name}")
                 .also {exitValue ->
-                    checkExitValuePort.checkApplicationExitValue(exitValue, application, this, "애플리케이션 디렉토리 삭제중 에러")
+                    checkExitValuePort.checkApplicationExitValue(exitValue, application, this, FailureCase.DELETE_DIRECTORY_FAILURE)
                 }
         }
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteContainerServiceImpl.kt
@@ -4,6 +4,7 @@ import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.service.DeleteContainerService
 import com.dcd.server.core.domain.application.spi.CheckExitValuePort
+import com.dcd.server.core.domain.application.util.FailureCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.springframework.stereotype.Service
@@ -18,7 +19,7 @@ class DeleteContainerServiceImpl(
             commandPort.executeShellCommand("docker rm ${application.containerName}")
                 .also {exitValue ->
                     if (exitValue != 0 && exitValue != 1)
-                        checkExitValuePort.checkApplicationExitValue(exitValue, application, this, "컨테이너 삭제중 에러")
+                        checkExitValuePort.checkApplicationExitValue(exitValue, application, this, FailureCase.DELETE_CONTAINER_FAILURE)
                 }
         }
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteImageServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteImageServiceImpl.kt
@@ -4,6 +4,7 @@ import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.service.DeleteImageService
 import com.dcd.server.core.domain.application.spi.CheckExitValuePort
+import com.dcd.server.core.domain.application.util.FailureCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.springframework.stereotype.Service
@@ -18,7 +19,7 @@ class DeleteImageServiceImpl(
             commandPort.executeShellCommand("docker rmi ${application.containerName}")
                 .also {exitValue ->
                     if (exitValue != 0 && exitValue != 1)
-                        checkExitValuePort.checkApplicationExitValue(exitValue, application, this, "이미지 삭제중 에러")
+                        checkExitValuePort.checkApplicationExitValue(exitValue, application, this, FailureCase.DELETE_IMAGE_FAILURE)
                 }
         }
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/RunContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/RunContainerServiceImpl.kt
@@ -7,6 +7,7 @@ import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.service.RunContainerService
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import com.dcd.server.core.domain.application.util.FailureCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
@@ -36,7 +37,7 @@ class RunContainerServiceImpl(
             val exitValue = commandPort.executeShellCommand("docker start ${application.containerName}")
             if (exitValue != 0) {
                 log.error("$exitValue")
-                eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application, "컨테이너 실행중 에러"))
+                eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application, FailureCase.RUN_CONTAINER_FAILURE))
             }
 
             else

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/StopContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/StopContainerServiceImpl.kt
@@ -5,6 +5,7 @@ import com.dcd.server.core.domain.application.event.ChangeApplicationStatusEvent
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.service.StopContainerService
+import com.dcd.server.core.domain.application.util.FailureCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
@@ -23,7 +24,7 @@ class StopContainerServiceImpl(
             val exitValue = commandPort.executeShellCommand("docker stop ${application.containerName}")
             if (exitValue != 0) {
                 log.error("$exitValue")
-                eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application, "컨테이너 정지중 에러"))
+                eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application, FailureCase.STOP_CONTAINER_FAILURE))
             }
 
             else

--- a/src/main/kotlin/com/dcd/server/core/domain/application/spi/CheckExitValuePort.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/spi/CheckExitValuePort.kt
@@ -1,10 +1,11 @@
 package com.dcd.server.core.domain.application.spi
 
 import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.util.FailureCase
 import kotlinx.coroutines.CoroutineScope
 
 interface CheckExitValuePort {
-    fun checkApplicationExitValue(exitValue: Int, application: Application, failureReason: String?)
+    fun checkApplicationExitValue(exitValue: Int, application: Application, failureCase: FailureCase?)
 
-    fun checkApplicationExitValue(exitValue: Int, application: Application, coroutineScope: CoroutineScope, failureReason: String?)
+    fun checkApplicationExitValue(exitValue: Int, application: Application, coroutineScope: CoroutineScope, failureCase: FailureCase?)
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/spi/adapter/CheckExitValueAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/spi/adapter/CheckExitValueAdapter.kt
@@ -4,6 +4,7 @@ import com.dcd.server.core.domain.application.event.ChangeApplicationStatusEvent
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.spi.CheckExitValuePort
+import com.dcd.server.core.domain.application.util.FailureCase
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import org.slf4j.LoggerFactory
@@ -16,17 +17,17 @@ class CheckExitValueAdapter(
 ) : CheckExitValuePort {
     private val log = LoggerFactory.getLogger(this::class.simpleName)
 
-    override fun checkApplicationExitValue(exitValue: Int, application: Application, failureReason: String?) {
+    override fun checkApplicationExitValue(exitValue: Int, application: Application, failureCase: FailureCase?) {
         if (exitValue != 0) {
             log.error("${application.name} - $exitValue")
-            eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application, failureReason))
+            eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application, failureCase))
         }
     }
 
-    override fun checkApplicationExitValue(exitValue: Int, application: Application, coroutineScope: CoroutineScope, failureReason: String?) {
+    override fun checkApplicationExitValue(exitValue: Int, application: Application, coroutineScope: CoroutineScope, failureCase: FailureCase?) {
         if (exitValue != 0) {
             log.error("${application.name} - $exitValue")
-            eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application, failureReason))
+            eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application, failureCase))
             coroutineScope.cancel()
         }
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/util/FailureCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/util/FailureCase.kt
@@ -1,0 +1,17 @@
+package com.dcd.server.core.domain.application.util
+
+enum class FailureCase(
+    val reason: String
+) {
+    CLONE_FAILURE("애플리케이션 복사중 에러"),
+    CREATE_DOCKER_FILE_FAILURE("도커파일 생성중 에러"),
+    IMAGE_BUILD_FAILURE("이미지 빌드중 에러"),
+    CREATE_CONTAINER_FAILURE("컨테이너 생성시 에러"),
+    RUN_CONTAINER_FAILURE("컨테이너 실행중 에러"),
+    STOP_CONTAINER_FAILURE("컨테이너 정지중 에러"),
+    CONNECT_NETWORK_FAILURE("네트워크 연결중 에러"),
+    CREATE_DIRECTORY_FAILURE("애플리케이션 디렉토리 생성중 에러"),
+    DELETE_DIRECTORY_FAILURE("애플리케이션 디렉토리 삭제중 에러"),
+    DELETE_CONTAINER_FAILURE("컨테이너 삭제중 에러"),
+    DELETE_IMAGE_FAILURE("이미지 삭제중 에러"),
+}

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/CreateContainerServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/CreateContainerServiceImplTest.kt
@@ -3,6 +3,7 @@ package com.dcd.server.core.domain.application.service
 import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.domain.application.service.impl.CreateContainerServiceImpl
 import com.dcd.server.core.domain.application.spi.CheckExitValuePort
+import com.dcd.server.core.domain.application.util.FailureCase
 import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.mockk
 import io.mockk.verify
@@ -28,8 +29,8 @@ class CreateContainerServiceImplTest : BehaviorSpec({
                         "-p ${application.externalPort}:${application.port} ${application.name.lowercase()}:latest"
                     )
                 }
-                verify { checkExitValuePort.checkApplicationExitValue(0, application, any() as CoroutineScope, "컨테이너 생성시 에러") }
-                verify { checkExitValuePort.checkApplicationExitValue(0, application, any() as CoroutineScope, "네트워크 연결 실패") }
+                verify { checkExitValuePort.checkApplicationExitValue(0, application, any() as CoroutineScope, FailureCase.CREATE_CONTAINER_FAILURE) }
+                verify { checkExitValuePort.checkApplicationExitValue(0, application, any() as CoroutineScope, FailureCase.CONNECT_NETWORK_FAILURE) }
             }
         }
     }


### PR DESCRIPTION
## 개요
* 애플리케이션 FailureCase를 상수로 관리하도록 수정합니다.
## 작업내용
* FailureCase 추가
* ChangeApplicationStatusEvent에서 FailureCase를 사용하도록 수정
* ChangeApplicationStatus를 발급할때 FailureCase를 사용하도록 수정
* CheckExitValuePort에서 FailureCase를 사용하도록 수정
* FailureCase 적용
* docker-compose.yml 수정
* 테스트 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Docker 구성 업데이트: 데이터베이스와 캐시 서비스용 이미지가 최신 버전으로 변경되고, 불필요한 플랫폼 설정이 제거되었습니다.
- **Refactor**
	- 오류 처리 방식 개선: 기존 하드코딩된 에러 메시지를 표준화된 실패 코드로 전환하여, 오류 보고의 일관성과 명확성이 향상되었습니다.
- **Tests**
	- 오류 처리 개선에 따라 관련 테스트 케이스가 업데이트되어, 새로운 에러 코드 체계를 반영합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->