### PR TITLE
🔀 :: [#506] - 애플리케이션 삭제를 동기적으로 하도록 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,4 +20,4 @@ services:
       - REDIS_DISABLE_COMMANDS=FLUSHDB,FLUSHALL
     ports:
       - 6378:6379
-    command: ["redis-server", "--requirepass", "$$REDIS_PASSWORD"]
+    command: ["redis-server", "--requirepass", "$REDIS_PASSWORD"]

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationUseCase.kt
@@ -31,6 +31,7 @@ class DeleteApplicationUseCase(
             deleteImageService.deleteImage(application)
         }
 
-        commandApplicationPort.delete(application)
+        if (application.status != ApplicationStatus.FAILURE)
+            commandApplicationPort.delete(application)
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationUseCase.kt
@@ -10,7 +10,7 @@ import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 
 @UseCase
 class DeleteApplicationUseCase(
@@ -26,7 +26,7 @@ class DeleteApplicationUseCase(
         if (application.status == ApplicationStatus.RUNNING || application.status == ApplicationStatus.PENDING)
             throw CanNotDeleteApplicationException()
 
-        launch {
+        runBlocking {
             deleteContainerService.deleteContainer(application)
             deleteImageService.deleteImage(application)
         }


### PR DESCRIPTION
## 개요
* 애플리케이션을 삭제할때 컨테이너및 이미지를 삭제할때 동기적으로 삭제하도록 수정합니다.
## 작업내용
* DeleteApplicationUseCase에서 컨테이너및 이미지 삭제가 실패하지 않았을때만 삭제하도록 수정
* runBlocking을 사용하도록 수정
* docker-compose 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **기타 변경 사항**
  - Redis 서비스에서 환경 변수 참조 방식이 개선되어, 비밀번호가 보다 명확하게 전달됩니다.
- **버그 수정**
  - 애플리케이션 삭제 처리 로직이 강화되어, 동기적 실행과 함께 오류 상태인 애플리케이션의 삭제를 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->