### PR TITLE
🔀 :: [#508] - 애플리케이션을 배포하는 중에 실패하면 디렉토리를 삭제하도록 리펙토링

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/BuildDockerImageServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/BuildDockerImageServiceImpl.kt
@@ -37,6 +37,8 @@ class BuildDockerImageServiceImpl(
                     commandPort.executeShellCommand("cd ./$directoryName && docker build -t ${application.containerName}:latest .")
                 }
             }
+            if (exitValue != 0)
+                commandPort.executeShellCommand("rm -rf $directoryName")
             checkExitValuePort.checkApplicationExitValue(exitValue, application, this, FailureCase.IMAGE_BUILD_FAILURE)
         }
     }
@@ -53,6 +55,8 @@ class BuildDockerImageServiceImpl(
                     commandPort.executeShellCommand("cd ./$directoryName && docker build -t ${application.containerName}:latest .")
                 }
             }
+            if (exitValue != 0)
+                commandPort.executeShellCommand("rm -rf $directoryName")
             checkExitValuePort.checkApplicationExitValue(exitValue, application, this, FailureCase.IMAGE_BUILD_FAILURE)
         }
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateContainerServiceImpl.kt
@@ -23,12 +23,16 @@ class CreateContainerServiceImpl(
 
             commandPort.executeShellCommand(cmd)
                 .also {exitValue ->
+                    if (exitValue != 0)
+                        commandPort.executeShellCommand("rm -rf ${application.name}")
                     checkExitValuePort.checkApplicationExitValue(exitValue, application, this, FailureCase.CREATE_CONTAINER_FAILURE)
                 }
 
             val dcdNetworkConnectCmd = "docker network connect dcd ${application.containerName}"
             commandPort.executeShellCommand(dcdNetworkConnectCmd)
                 .also {exitValue ->
+                    if (exitValue != 0)
+                        commandPort.executeShellCommand("rm -rf ${application.name}")
                     checkExitValuePort.checkApplicationExitValue(exitValue, application, this, FailureCase.CONNECT_NETWORK_FAILURE)
                 }
         }


### PR DESCRIPTION
## 개요
* 애플리케이션을 배포하는 중에 실패하면 디렉토리를 삭제하도록 리펙토링합니다.
## 작업내용
* 이미지 빌드가 실패하면 해당 애플리케이션의 디렉토리를 삭제하도록 수정
* 도커 파일 생성이 실패하면 해당 애플리케이션의 디렉토리를 삭제하도록 수정
* 컨테이너 생성이 실패하면 해당 애플리케이션의 디렉토리를 삭제하도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 빌드, 컨테이너 생성 및 파일 작성 과정에서 오류 발생 시 임시 리소스를 자동 정리하는 기능이 강화되어 운영 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->