### PR TITLE
🔀 :: [#510] - 로그아웃후 토큰을 블랙리스트에 등록하도록 수정

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/auth/model/TokenBlackList.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/model/TokenBlackList.kt
@@ -1,0 +1,6 @@
+package com.dcd.server.core.domain.auth.model
+
+class TokenBlackList(
+    val token: String,
+    val ttl: Long,
+)

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/spi/CommandTokenBlackListPort.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/spi/CommandTokenBlackListPort.kt
@@ -1,0 +1,7 @@
+package com.dcd.server.core.domain.auth.spi
+
+import com.dcd.server.core.domain.auth.model.TokenBlackList
+
+interface CommandTokenBlackListPort {
+    fun save(tokenBlackList: TokenBlackList)
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/spi/QueryTokenBlackListPort.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/spi/QueryTokenBlackListPort.kt
@@ -1,0 +1,5 @@
+package com.dcd.server.core.domain.auth.spi
+
+interface QueryTokenBlackListPort {
+    fun existsByToken(token: String): Boolean
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/spi/TokenBlackListPort.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/spi/TokenBlackListPort.kt
@@ -1,0 +1,5 @@
+package com.dcd.server.core.domain.auth.spi
+
+interface TokenBlackListPort :
+        CommandTokenBlackListPort,
+        QueryTokenBlackListPort

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/SignOutUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/SignOutUseCase.kt
@@ -2,18 +2,22 @@ package com.dcd.server.core.domain.auth.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.common.service.SecurityService
+import com.dcd.server.core.domain.auth.model.TokenBlackList
 import com.dcd.server.core.domain.auth.spi.CommandRefreshTokenPort
+import com.dcd.server.core.domain.auth.spi.CommandTokenBlackListPort
 import com.dcd.server.core.domain.auth.spi.QueryRefreshTokenPort
 
 @UseCase
 class SignOutUseCase(
     private val commandRefreshTokenPort: CommandRefreshTokenPort,
     private val queryRefreshTokenPort: QueryRefreshTokenPort,
-    private val securityService: SecurityService
+    private val securityService: SecurityService,
+    private val commandTokenBlackListPort: CommandTokenBlackListPort
 ) {
-    fun execute() {
+    fun execute(accessToken: String) {
         val userId = securityService.getCurrentUserId()
         val refreshTokenList = queryRefreshTokenPort.findByUserId(userId)
+        commandTokenBlackListPort.save(TokenBlackList(accessToken.replace("Bearer ", ""), 60 * 10))
         commandRefreshTokenPort.delete(refreshTokenList)
     }
 }

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/jwt/adapter/ParseTokenAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/jwt/adapter/ParseTokenAdapter.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.infrastructure.global.jwt.adapter
 
+import com.dcd.server.core.domain.auth.spi.QueryTokenBlackListPort
 import com.dcd.server.infrastructure.global.jwt.exception.ExpiredTokenException
 import com.dcd.server.infrastructure.global.jwt.properties.JwtProperty
 import com.dcd.server.infrastructure.global.jwt.exception.TokenNotValidException
@@ -16,7 +17,8 @@ import java.security.Key
 @Component
 class ParseTokenAdapter(
     private val jwtProperty: JwtProperty,
-    private val authDetailsService: AuthDetailsService
+    private val authDetailsService: AuthDetailsService,
+    private val queryTokenBlackListPort: QueryTokenBlackListPort
 ) {
     object JwtPrefix{
         const val ACCESS = "access"
@@ -44,6 +46,9 @@ class ParseTokenAdapter(
     }
 
     private fun getClaims(token: String, secret: Key): Jws<Claims> {
+        if (queryTokenBlackListPort.existsByToken(token))
+            throw ExpiredTokenException()
+
         return try {
             Jwts.parserBuilder()
                 .setSigningKey(secret)

--- a/src/main/kotlin/com/dcd/server/persistence/auth/TokenBlackListPersistenceAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/auth/TokenBlackListPersistenceAdapter.kt
@@ -1,0 +1,19 @@
+package com.dcd.server.persistence.auth
+
+import com.dcd.server.core.domain.auth.model.TokenBlackList
+import com.dcd.server.core.domain.auth.spi.TokenBlackListPort
+import com.dcd.server.persistence.auth.adapter.toEntity
+import com.dcd.server.persistence.auth.repository.TokenBlackListRepository
+import org.springframework.stereotype.Component
+
+@Component
+class TokenBlackListPersistenceAdapter(
+    private val tokenBlackListRepository: TokenBlackListRepository
+) : TokenBlackListPort {
+    override fun save(tokenBlackList: TokenBlackList) {
+        tokenBlackListRepository.save(tokenBlackList.toEntity())
+    }
+
+    override fun existsByToken(token: String): Boolean =
+        tokenBlackListRepository.existsById(token)
+}

--- a/src/main/kotlin/com/dcd/server/persistence/auth/adapter/TokenBlackListAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/auth/adapter/TokenBlackListAdapter.kt
@@ -1,0 +1,16 @@
+package com.dcd.server.persistence.auth.adapter
+
+import com.dcd.server.core.domain.auth.model.TokenBlackList
+import com.dcd.server.persistence.auth.entity.TokenBlackListEntity
+
+fun TokenBlackList.toEntity(): TokenBlackListEntity =
+    TokenBlackListEntity(
+        token = this.token,
+        ttl = this.ttl
+    )
+
+fun TokenBlackListEntity.toDomain(): TokenBlackList =
+    TokenBlackList(
+        token = this.token,
+        ttl = this.ttl
+    )

--- a/src/main/kotlin/com/dcd/server/persistence/auth/entity/TokenBlackListEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/auth/entity/TokenBlackListEntity.kt
@@ -1,0 +1,13 @@
+package com.dcd.server.persistence.auth.entity
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.redis.core.RedisHash
+import org.springframework.data.redis.core.TimeToLive
+
+@RedisHash(value = "TokenBlackList")
+class TokenBlackListEntity(
+    @Id
+    val token: String,
+    @TimeToLive
+    var ttl: Long,
+)

--- a/src/main/kotlin/com/dcd/server/persistence/auth/repository/TokenBlackListRepository.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/auth/repository/TokenBlackListRepository.kt
@@ -1,0 +1,8 @@
+package com.dcd.server.persistence.auth.repository
+
+import com.dcd.server.persistence.auth.entity.TokenBlackListEntity
+import org.springframework.data.repository.CrudRepository
+
+interface TokenBlackListRepository : CrudRepository<TokenBlackListEntity, String> {
+    fun existsByToken(token: String): Boolean
+}

--- a/src/main/kotlin/com/dcd/server/presentation/domain/auth/AuthWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/auth/AuthWebAdapter.kt
@@ -71,8 +71,8 @@ class AuthWebAdapter(
             .let { ResponseEntity.ok(it.toReissueResponse()) }
 
     @DeleteMapping
-    fun signOut(): ResponseEntity<Void>  =
-        signOutUseCase.execute()
+    fun signOut(@RequestHeader("Authorization") accessToken: String): ResponseEntity<Void>  =
+        signOutUseCase.execute(accessToken)
             .run { ResponseEntity.ok().build() }
 
     @PatchMapping("/password")

--- a/src/test/kotlin/com/dcd/server/presentation/domain/auth/AuthWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/auth/AuthWebAdapterTest.kt
@@ -120,8 +120,8 @@ class AuthWebAdapterTest : BehaviorSpec({
 
     given("주어지는게 없고") {
         `when`("signOut메서드를 실행할때") {
-            every { signOutUseCase.execute() } returns Unit
-            val result = authWebAdapter.signOut()
+            every { signOutUseCase.execute("testAccessToken") } returns Unit
+            val result = authWebAdapter.signOut("testAccessToken")
             then("상태코드는 200이여야함") {
                 result.statusCode shouldBe HttpStatus.OK
             }


### PR DESCRIPTION
## 개요
* 로그아웃후 토큰을 블랙리스트에 저장해서 해당 토큰으로 인증/인가가 되지 않도록 수정합니다.
## 작업내용
* TokenBlackList 도매인 추가
* TokenBlackList 엔티티 추가
* TokenBlackList 어뎁터 추가
* 로그아웃시 주어진 엑세스 토큰을 블랙리스트에 등록하도록 수정
* jwt 클레임 조회시 해당 토큰이 블랙리스트에 등록되었는지 검증하도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 로그아웃 API가 업데이트되어, 이제 "Authorization" 헤더를 통해 액세스 토큰을 제공해야 합니다.
  - 로그아웃 시 전달받은 액세스 토큰이 즉시 무효화되어, 향상된 보안 체계가 적용됩니다.
  - 인증 토큰 검증 프로세스가 개선되어, 무효화된 토큰은 조기에 차단됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->