### PR TITLE
🔀 :: [#516] - 애플리케이션의 컨테이너 이름을 각 애플리케이션마다 유니크한 값을 가지도록 수정

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/model/Application.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/model/Application.kt
@@ -20,7 +20,7 @@ data class Application(
     val failureReason: String? = null,
     val labels: List<String>
 ) {
-    val containerName = name.lowercase()
+    val containerName = "${name.replace(" ", "_").lowercase()}-$id"
 
     override fun equals(other: Any?): Boolean {
         if (other !is Application) return false

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/BuildDockerImageServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/BuildDockerImageServiceImpl.kt
@@ -21,7 +21,7 @@ class BuildDockerImageServiceImpl(
     override suspend fun buildImageByApplicationId(id: String) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
-        val directoryName = application.name
+        val directoryName = "'${application.name}'"
         withContext(Dispatchers.IO) {
             val exitValue = when (application.applicationType) {
                 ApplicationType.SPRING_BOOT -> {
@@ -44,7 +44,7 @@ class BuildDockerImageServiceImpl(
     }
 
     override suspend fun buildImageByApplication(application: Application) {
-        val directoryName = application.name
+        val directoryName = "'${application.name}'"
         withContext(Dispatchers.IO) {
             val exitValue = when(application.applicationType) {
                 ApplicationType.SPRING_BOOT -> {

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CloneApplicationByUrlServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CloneApplicationByUrlServiceImpl.kt
@@ -22,7 +22,7 @@ class CloneApplicationByUrlServiceImpl(
             val application = (queryApplicationPort.findById(id)
                 ?: throw ApplicationNotFoundException())
             val githubUrl = application.githubUrl
-            val exitValue = commandPort.executeShellCommand("git clone $githubUrl ${application.name}")
+            val exitValue = commandPort.executeShellCommand("git clone $githubUrl '${application.name}'")
             checkExitValuePort.checkApplicationExitValue(exitValue, application, this, FailureCase.CLONE_FAILURE)
         }
     }
@@ -30,7 +30,7 @@ class CloneApplicationByUrlServiceImpl(
     override suspend fun cloneByApplication(application: Application) {
         withContext(Dispatchers.IO) {
             val githubUrl = application.githubUrl
-            commandPort.executeShellCommand("git clone $githubUrl ${application.name}")
+            commandPort.executeShellCommand("git clone $githubUrl '${application.name}'")
                 .also {exitValue ->
                     checkExitValuePort.checkApplicationExitValue(exitValue, application, this, FailureCase.CLONE_FAILURE)
                 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateDockerFileServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateDockerFileServiceImpl.kt
@@ -71,9 +71,9 @@ class CreateDockerFileServiceImpl(
                 FileContent.getNestJsDockerFileContent(version, application.port, mutableEnv)
         }
         try {
+            if (!file.exists())
+                file.createNewFile()
             file.writeText(fileContent)
-            if (!file.createNewFile())
-                return
         } catch (e: IOException) {
             e.printStackTrace()
             commandPort.executeShellCommand("rm -rf $directoryName")

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteApplicationDirectoryServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteApplicationDirectoryServiceImpl.kt
@@ -19,7 +19,7 @@ class DeleteApplicationDirectoryServiceImpl(
 ) : DeleteApplicationDirectoryService {
     override suspend fun deleteApplicationDirectory(application: Application) {
         withContext(Dispatchers.IO) {
-            commandPort.executeShellCommand("rm -rf ${application.name}")
+            commandPort.executeShellCommand("rm -rf '${application.name}'")
                 .also {exitValue ->
                     checkExitValuePort.checkApplicationExitValue(exitValue, application, this, FailureCase.DELETE_DIRECTORY_FAILURE)
                 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/spi/QueryApplicationPort.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/spi/QueryApplicationPort.kt
@@ -11,4 +11,5 @@ interface QueryApplicationPort {
     fun existsByExternalPort(externalPort: Int): Boolean
     fun findAllByStatus(status: ApplicationStatus): List<Application>
     fun existsByName(name: String): Boolean
+    fun existsByNameAndWorkspace(name: String, workspace: Workspace): Boolean
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCase.kt
@@ -28,12 +28,16 @@ class CreateApplicationUseCase(
     private val deleteApplicationDirectoryService: DeleteApplicationDirectoryService
 ) : CoroutineScope by CoroutineScope(Dispatchers.IO) {
     fun execute(workspaceId: String, createApplicationReqDto: CreateApplicationReqDto): CreateApplicationResDto {
+        println("workspaceId = ${workspaceId}")
+
         val workspace = queryWorkspacePort.findById(workspaceId)
             ?: throw WorkspaceNotFoundException()
 
+        println("workspace = ${workspace}")
+
         val externalPort = getExternalPortService.getExternalPort(createApplicationReqDto.port)
 
-        if (queryApplicationPort.existsByName(createApplicationReqDto.name))
+        if (queryApplicationPort.existsByNameAndWorkspace(createApplicationReqDto.name, workspace))
             throw AlreadyExistsApplicationException()
 
         val application = createApplicationReqDto.toEntity(workspace, externalPort)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCase.kt
@@ -28,12 +28,8 @@ class CreateApplicationUseCase(
     private val deleteApplicationDirectoryService: DeleteApplicationDirectoryService
 ) : CoroutineScope by CoroutineScope(Dispatchers.IO) {
     fun execute(workspaceId: String, createApplicationReqDto: CreateApplicationReqDto): CreateApplicationResDto {
-        println("workspaceId = ${workspaceId}")
-
         val workspace = queryWorkspacePort.findById(workspaceId)
             ?: throw WorkspaceNotFoundException()
-
-        println("workspace = ${workspace}")
 
         val externalPort = getExternalPortService.getExternalPort(createApplicationReqDto.port)
 

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCase.kt
@@ -12,7 +12,7 @@ import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.springframework.context.ApplicationEventPublisher
 
 @UseCase
@@ -31,7 +31,7 @@ class UpdateApplicationUseCase(
             throw AlreadyRunningException()
 
         if (application.name != updateApplicationReqDto.name) {
-            launch {
+            runBlocking {
                 deleteContainerService.deleteContainer(application)
                 deleteImageService.deleteImage(application)
                 eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.STOPPED, application))
@@ -48,6 +48,5 @@ class UpdateApplicationUseCase(
                 port = updateApplicationReqDto.port
             )
         commandApplicationPort.save(updatedApplication)
-        eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.PENDING, updatedApplication))
     }
 }

--- a/src/main/kotlin/com/dcd/server/persistence/application/ApplicationPersistenceAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/application/ApplicationPersistenceAdapter.kt
@@ -51,4 +51,7 @@ class ApplicationPersistenceAdapter(
 
     override fun existsByName(name: String): Boolean =
         applicationRepository.existsByName(name)
+
+    override fun existsByNameAndWorkspace(name: String, workspace: Workspace): Boolean =
+        applicationRepository.existsByNameAndWorkspace(name, workspace.toEntity())
 }

--- a/src/main/kotlin/com/dcd/server/persistence/application/repository/ApplicationRepository.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/application/repository/ApplicationRepository.kt
@@ -17,4 +17,5 @@ interface ApplicationRepository : JpaRepository<ApplicationJpaEntity, String> {
     fun existsByExternalPort(externalPort: Int): Boolean
     fun findAllByStatus(status: ApplicationStatus): List<ApplicationJpaEntity>
     fun existsByName(name: String): Boolean
+    fun existsByNameAndWorkspace(name: String, workspace: WorkspaceJpaEntity): Boolean
 }

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationRequestDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationRequestDataExtension.kt
@@ -10,7 +10,7 @@ fun AddApplicationEnvRequest.toDto(): AddApplicationEnvReqDto =
 
 fun CreateApplicationRequest.toDto(): CreateApplicationReqDto =
     CreateApplicationReqDto(
-        name = this.name.replace(" ", "-"),
+        name = this.name,
         description = this.description,
         githubUrl = this.githubUrl,
         env = this.env,
@@ -22,7 +22,7 @@ fun CreateApplicationRequest.toDto(): CreateApplicationReqDto =
 
 fun UpdateApplicationRequest.toDto(): UpdateApplicationReqDto =
     UpdateApplicationReqDto(
-        name = this.name.replace(" ", "-"),
+        name = this.name,
         description = this.description,
         applicationType = this.applicationType,
         githubUrl = this.githubUrl,

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/request/CreateApplicationRequest.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/request/CreateApplicationRequest.kt
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Pattern
 
 data class CreateApplicationRequest(
     @field:NotBlank
-    @field:Pattern(regexp = "^[a-zA-Z0-9]+$")
+    @field:Pattern(regexp = "^[a-zA-Z0-9 ]{1,26}$")
     val name: String,
     val description: String?,
     val githubUrl: String?,

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/request/UpdateApplicationRequest.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/request/UpdateApplicationRequest.kt
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Pattern
 
 data class UpdateApplicationRequest(
     @field:NotBlank
-    @field:Pattern(regexp = "^[a-zA-Z0-9]+$")
+    @field:Pattern(regexp = "^[a-zA-Z0-9 ]{1,26}$")
     val name: String,
     val description: String?,
     val applicationType: ApplicationType,

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/BuildDockerImageServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/BuildDockerImageServiceImplTest.kt
@@ -29,7 +29,7 @@ class BuildDockerImageServiceImplTest : BehaviorSpec({
             service.buildImageByApplicationId(appId)
             then("commandPort가 실행되어야함") {
                 coVerify { commandPort.executeShellCommand("cd ./${application.name} && ./gradlew clean build") }
-                coVerify { commandPort.executeShellCommand("cd ./${application.name} && docker build -t ${application.name.lowercase()}:latest .") }
+                coVerify { commandPort.executeShellCommand("cd ./${application.name} && docker build -t ${application.containerName}:latest .") }
             }
         }
     }
@@ -43,7 +43,7 @@ class BuildDockerImageServiceImplTest : BehaviorSpec({
 
             then("commandPort가 실행되어야함") {
                 coVerify { commandPort.executeShellCommand("cd ./${application.name} && ./gradlew clean build") }
-                coVerify { commandPort.executeShellCommand("cd ./${application.name} && docker build -t ${application.name.lowercase()}:latest .") }
+                coVerify { commandPort.executeShellCommand("cd ./${application.name} && docker build -t ${application.containerName}:latest .") }
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/BuildDockerImageServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/BuildDockerImageServiceImplTest.kt
@@ -28,8 +28,8 @@ class BuildDockerImageServiceImplTest : BehaviorSpec({
 
             service.buildImageByApplicationId(appId)
             then("commandPort가 실행되어야함") {
-                coVerify { commandPort.executeShellCommand("cd ./${application.name} && ./gradlew clean build") }
-                coVerify { commandPort.executeShellCommand("cd ./${application.name} && docker build -t ${application.containerName}:latest .") }
+                coVerify { commandPort.executeShellCommand("cd ./'${application.name}' && ./gradlew clean build") }
+                coVerify { commandPort.executeShellCommand("cd ./'${application.name}' && docker build -t ${application.containerName}:latest .") }
             }
         }
     }
@@ -42,8 +42,8 @@ class BuildDockerImageServiceImplTest : BehaviorSpec({
             service.buildImageByApplication(application)
 
             then("commandPort가 실행되어야함") {
-                coVerify { commandPort.executeShellCommand("cd ./${application.name} && ./gradlew clean build") }
-                coVerify { commandPort.executeShellCommand("cd ./${application.name} && docker build -t ${application.containerName}:latest .") }
+                coVerify { commandPort.executeShellCommand("cd ./'${application.name}' && ./gradlew clean build") }
+                coVerify { commandPort.executeShellCommand("cd ./'${application.name}' && docker build -t ${application.containerName}:latest .") }
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/CloneApplicationByUrlServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/CloneApplicationByUrlServiceImplTest.kt
@@ -28,7 +28,7 @@ class CloneApplicationByUrlServiceImplTest : BehaviorSpec({
 
             service.cloneById(appId)
             then("commandPort가 실행되어야함") {
-                verify { commandPort.executeShellCommand("git clone ${application.githubUrl} ${application.name}") }
+                verify { commandPort.executeShellCommand("git clone ${application.githubUrl} '${application.name}'") }
             }
         }
     }
@@ -41,7 +41,7 @@ class CloneApplicationByUrlServiceImplTest : BehaviorSpec({
             service.cloneByApplication(application)
 
             then("commandPort가 실행되어야함") {
-                verify { commandPort.executeShellCommand("git clone ${application.githubUrl} ${application.name}") }
+                verify { commandPort.executeShellCommand("git clone ${application.githubUrl} '${application.name}'") }
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/CreateContainerServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/CreateContainerServiceImplTest.kt
@@ -25,8 +25,8 @@ class CreateContainerServiceImplTest : BehaviorSpec({
                 verify {
                     commandPort.executeShellCommand(
                         "docker create --network ${application.workspace.title.replace(' ', '_')} " +
-                        "--name ${application.name.lowercase()} " +
-                        "-p ${application.externalPort}:${application.port} ${application.name.lowercase()}:latest"
+                        "--name ${application.containerName} " +
+                        "-p ${application.externalPort}:${application.port} ${application.containerName}:latest"
                     )
                 }
                 verify { checkExitValuePort.checkApplicationExitValue(0, application, any() as CoroutineScope, FailureCase.CREATE_CONTAINER_FAILURE) }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/CreateDockerFileServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/CreateDockerFileServiceImplTest.kt
@@ -30,10 +30,10 @@ class CreateDockerFileServiceImplTest : BehaviorSpec({
             createDockerFileService.createFileToApplication(application, application.version)
 
             then("애플리케이션의 이름을 가진 디렉토리를 생성해야함") {
-                verify { commandPort.executeShellCommand("mkdir -p ${application.name}") }
+                verify { commandPort.executeShellCommand("mkdir -p '${application.name}'") }
             }
             then("실제로 애플리케이션 이름의 디렉토리가 생성되야함") {
-                commandPort.executeShellCommand("test -e ${application.name}") shouldBe 0
+                commandPort.executeShellCommand("test -e '${application.name}'") shouldBe 0
             }
             then("생성된 DockerFile의 내용은 FileContent의 내용과 같아야함") {
                 val actualFileContent = StringBuilder()
@@ -46,7 +46,7 @@ class CreateDockerFileServiceImplTest : BehaviorSpec({
             }
         }
 
-        commandPort.executeShellCommand("rm -rf ${application.name}") // 실제로 생성된 디렉토리 제거
+        commandPort.executeShellCommand("rm -rf '${application.name}'") // 실제로 생성된 디렉토리 제거
     }
 
     given("레디스 애플리케이션이 주어지고") {
@@ -57,10 +57,10 @@ class CreateDockerFileServiceImplTest : BehaviorSpec({
             createDockerFileService.createFileToApplication(application, application.version)
 
             then("애플리케이션의 이름을 가진 디렉토리를 생성해야함") {
-                verify { commandPort.executeShellCommand("mkdir -p ${application.name}") }
+                verify { commandPort.executeShellCommand("mkdir -p '${application.name}'") }
             }
             then("실제로 애플리케이션 이름의 디렉토리가 생성되야함") {
-                commandPort.executeShellCommand("test -e ${application.name}") shouldBe 0
+                commandPort.executeShellCommand("test -e '${application.name}'") shouldBe 0
             }
             then("생성된 DockerFile의 내용은 FileContent의 내용과 같아야함") {
                 val actualFileContent = StringBuilder()
@@ -72,7 +72,7 @@ class CreateDockerFileServiceImplTest : BehaviorSpec({
             }
         }
 
-        commandPort.executeShellCommand("rm -rf ${application.name}") // 실제로 생성된 디렉토리 제거
+        commandPort.executeShellCommand("rm -rf '${application.name}'") // 실제로 생성된 디렉토리 제거
     }
 
     given("MYSQL 애플리케이션이 주어지고") {
@@ -83,10 +83,10 @@ class CreateDockerFileServiceImplTest : BehaviorSpec({
             createDockerFileService.createFileToApplication(application, application.version)
 
             then("애플리케이션의 이름을 가진 디렉토리를 생성해야함") {
-                verify { commandPort.executeShellCommand("mkdir -p ${application.name}") }
+                verify { commandPort.executeShellCommand("mkdir -p '${application.name}'") }
             }
             then("실제로 애플리케이션 이름의 디렉토리가 생성되야함") {
-                commandPort.executeShellCommand("test -e ${application.name}") shouldBe 0
+                commandPort.executeShellCommand("test -e '${application.name}'") shouldBe 0
             }
             then("생성된 DockerFile의 내용은 FileContent의 내용과 같아야함") {
                 val actualFileContent = StringBuilder()
@@ -98,7 +98,7 @@ class CreateDockerFileServiceImplTest : BehaviorSpec({
             }
         }
 
-        commandPort.executeShellCommand("rm -rf ${application.name}") // 실제로 생성된 디렉토리 제거
+        commandPort.executeShellCommand("rm -rf '${application.name}'") // 실제로 생성된 디렉토리 제거
     }
 
     given("MARIADB 애플리케이션이 주어지고") {
@@ -109,10 +109,10 @@ class CreateDockerFileServiceImplTest : BehaviorSpec({
             createDockerFileService.createFileToApplication(application, application.version)
 
             then("애플리케이션의 이름을 가진 디렉토리를 생성해야함") {
-                verify { commandPort.executeShellCommand("mkdir -p ${application.name}") }
+                verify { commandPort.executeShellCommand("mkdir -p '${application.name}'") }
             }
             then("실제로 애플리케이션 이름의 디렉토리가 생성되야함") {
-                commandPort.executeShellCommand("test -e ${application.name}") shouldBe 0
+                commandPort.executeShellCommand("test -e '${application.name}'") shouldBe 0
             }
             then("생성된 DockerFile의 내용은 FileContent의 내용과 같아야함") {
                 val actualFileContent = StringBuilder()
@@ -124,7 +124,7 @@ class CreateDockerFileServiceImplTest : BehaviorSpec({
             }
         }
 
-        commandPort.executeShellCommand("rm -rf ${application.name}") // 실제로 생성된 디렉토리 제거
+        commandPort.executeShellCommand("rm -rf '${application.name}'") // 실제로 생성된 디렉토리 제거
     }
 
 })

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/DeleteApplicationDirectoryServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/DeleteApplicationDirectoryServiceImplTest.kt
@@ -20,7 +20,7 @@ class DeleteApplicationDirectoryServiceImplTest : BehaviorSpec({
             service.deleteApplicationDirectory(application)
 
             then("commandPort가 실행되어야함") {
-                verify { commandPort.executeShellCommand("rm -rf ${application.name}") }
+                verify { commandPort.executeShellCommand("rm -rf '${application.name}'") }
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/DeleteContainerServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/DeleteContainerServiceImplTest.kt
@@ -20,7 +20,7 @@ class DeleteContainerServiceImplTest : BehaviorSpec({
             service.deleteContainer(application)
 
             then("commandPort가 실행되어야함") {
-                verify { commandPort.executeShellCommand("docker rm ${application.name.lowercase()}") }
+                verify { commandPort.executeShellCommand("docker rm ${application.containerName}") }
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/DeleteImageServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/DeleteImageServiceImplTest.kt
@@ -20,7 +20,7 @@ class DeleteImageServiceImplTest : BehaviorSpec({
             deleteImageService.deleteImage(application)
 
             then("이미지를 제거하는 명령이 실행되어야함") {
-                verify { commandPort.executeShellCommand("docker rmi ${application.name.lowercase()}") }
+                verify { commandPort.executeShellCommand("docker rmi ${application.containerName}") }
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/DockerRunServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/DockerRunServiceImplTest.kt
@@ -26,7 +26,7 @@ class DockerRunServiceImplTest : BehaviorSpec({
 
             service.runContainer(appId)
             then("commandPort가 실행되어야함") {
-                verify { commandPort.executeShellCommand("docker start ${application.name.lowercase()}") }
+                verify { commandPort.executeShellCommand("docker start ${application.containerName}") }
             }
         }
     }
@@ -38,7 +38,7 @@ class DockerRunServiceImplTest : BehaviorSpec({
             service.runContainer(application)
 
             then("commandPort가 실행되어야함") {
-                verify { commandPort.executeShellCommand("docker start ${application.name.lowercase()}") }
+                verify { commandPort.executeShellCommand("docker start ${application.containerName}") }
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/StopContainerServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/StopContainerServiceImplTest.kt
@@ -22,12 +22,12 @@ class StopContainerServiceImplTest : BehaviorSpec({
             stopContainerService.stopContainer(application)
 
             then("컨테이너 정지 명령이 실행되야함") {
-                verify { commandPort.executeShellCommand("docker stop ${application.name.lowercase()}") }
+                verify { commandPort.executeShellCommand("docker stop ${application.containerName}") }
             }
         }
 
         `when`("컨테이너 정지 명령이 실패했을때") {
-            every { commandPort.executeShellCommand("docker stop ${application.name.lowercase()}") } returns 125
+            every { commandPort.executeShellCommand("docker stop ${application.containerName}") } returns 125
             stopContainerService.stopContainer(application)
 
             then("ContainerNotStoppedException이 발생해야함") {

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
@@ -66,9 +66,6 @@ class CreateApplicationUseCaseTest(
         val generateApplication =
             ApplicationGenerator.generateApplication(name = "testName", workspace = targetWorkspace)
         commandApplicationPort.save(generateApplication)
-        println("targetWorkspace = ${targetWorkspace}")
-
-        println("targetWorkspaceId = ${targetWorkspaceId}")
 
         val existsApplicationRequest = CreateApplicationReqDto(
             name = "testName",

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCaseTest.kt
@@ -61,8 +61,8 @@ class DeployApplicationUseCaseTest(
 
                 coVerify { commandPort.executeShellCommand("docker rm ${result.containerName}") }
                 coVerify { commandPort.executeShellCommand("docker rmi ${result.containerName}") }
-                coVerify { commandPort.executeShellCommand("git clone ${result.githubUrl} ${result.name}") }
-                coVerify { commandPort.executeShellCommand("cd ./${result.name} && docker build -t ${result.containerName}:latest .") }
+                coVerify { commandPort.executeShellCommand("git clone ${result.githubUrl} '${result.name}'") }
+                coVerify { commandPort.executeShellCommand("cd ./'${result.name}' && docker build -t ${result.containerName}:latest .") }
                 coVerify {
                     commandPort.executeShellCommand(
                         "docker create --network ${result.workspace.title.replace(' ', '_')} " +
@@ -70,7 +70,7 @@ class DeployApplicationUseCaseTest(
                             "-p ${result.externalPort}:${result.port} ${result.containerName}:latest"
                     )
                 }
-                coVerify { commandPort.executeShellCommand("rm -rf ${result.name}") }
+                coVerify { commandPort.executeShellCommand("rm -rf '${result.name}'") }
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCaseTest.kt
@@ -59,15 +59,15 @@ class DeployApplicationUseCaseTest(
                 result shouldNotBe null
                 result!!.status shouldBe ApplicationStatus.PENDING
 
-                coVerify { commandPort.executeShellCommand("docker rm ${result.name.lowercase()}") }
-                coVerify { commandPort.executeShellCommand("docker rmi ${result.name.lowercase()}") }
+                coVerify { commandPort.executeShellCommand("docker rm ${result.containerName}") }
+                coVerify { commandPort.executeShellCommand("docker rmi ${result.containerName}") }
                 coVerify { commandPort.executeShellCommand("git clone ${result.githubUrl} ${result.name}") }
-                coVerify { commandPort.executeShellCommand("cd ./${result.name} && docker build -t ${result.name.lowercase()}:latest .") }
+                coVerify { commandPort.executeShellCommand("cd ./${result.name} && docker build -t ${result.containerName}:latest .") }
                 coVerify {
                     commandPort.executeShellCommand(
                         "docker create --network ${result.workspace.title.replace(' ', '_')} " +
-                            "--name ${result.name.lowercase()} " +
-                            "-p ${result.externalPort}:${result.port} ${result.name.lowercase()}:latest"
+                            "--name ${result.containerName} " +
+                            "-p ${result.externalPort}:${result.port} ${result.containerName}:latest"
                     )
                 }
                 coVerify { commandPort.executeShellCommand("rm -rf ${result.name}") }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCaseTest.kt
@@ -37,7 +37,7 @@ class ExecuteCommandUseCaseTest : BehaviorSpec({
         val request = ExecuteCommandReqDto(cmd)
 
         val givenApplication = ApplicationGenerator.generateApplication(id = applicationId, status = ApplicationStatus.RUNNING)
-        val executedCmd = "docker exec ${givenApplication.name.lowercase()} sh -c 'cd / && $cmd'"
+        val executedCmd = "docker exec ${givenApplication.containerName} sh -c 'cd / && $cmd'"
         val testCmdResult = listOf("test cmd result")
 
         `when`("주어진 아이디를 가진 애플리케이션이 없을때") {

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCaseTest.kt
@@ -35,7 +35,7 @@ class GetApplicationLogUseCaseTest(
         val workspace = WorkspaceGenerator.generateWorkspace(user = user)
         val application = ApplicationGenerator.generateApplication(id = targetApplicationId, workspace = workspace)
         val expectedResult = listOf("test logs")
-        every { commandPort.executeShellCommandWithResult("docker logs ${application.name.lowercase()}") } returns expectedResult
+        every { commandPort.executeShellCommandWithResult("docker logs ${application.containerName}") } returns expectedResult
 
         commandUserPort.save(user)
         commandWorkspacePort.save(workspace)

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCaseTest.kt
@@ -55,7 +55,7 @@ class RunApplicationUseCaseTest(
                 targetApplication shouldNotBe null
                 targetApplication!!.status shouldBe ApplicationStatus.PENDING
 
-                coVerify { commandPort.executeShellCommand("docker start ${targetApplication.name.lowercase()}") }
+                coVerify { commandPort.executeShellCommand("docker start ${targetApplication.containerName}") }
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
@@ -55,7 +55,7 @@ class StopApplicationUseCaseTest(
                 targetApplication shouldNotBe null
                 targetApplication!!.status shouldBe ApplicationStatus.PENDING
 
-                coVerify { commandPort.executeShellCommand("docker stop ${targetApplication.name.lowercase()}") }
+                coVerify { commandPort.executeShellCommand("docker stop ${targetApplication.containerName}") }
             }
         }
     }


### PR DESCRIPTION
## 개요
* 애플리케이션의 컨테이너 이름을 각 애플리케이션마다 유니크한 값을 가지도록 수정합니다.
## 작업내용
* 애플리케이션의 컨테이너 이름을 사용하는 테스트 케이스에서 ContainerName을 사용해서 테스트 하도록 수정
* 애플리케이션 컨테이너 이름 생성 방식 수정
* 애플리케이션 이름 정규식 수정
* 애플리케이션 이름에 공백이 허용됨에 따른 디렉토리 관련 처리 수정
* 애플리케이션 업데이트 로직 수정
* 같은 워크스페이스 내에서 애플리케이션의 중복을 허용하지 않도록 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [ ] pr에서 작업할 내용외에 작업한 내용이 있나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- 작업공간을 고려한 중복 애플리케이션 체크가 추가되었습니다.
	- 애플리케이션 이름 유효성 검증이 변경되어, 공백 허용 및 최대 26자 제한이 적용되었습니다.

- **Enhancements**
	- 컨테이너 이름 포맷이 개선되어 고유성이 강화되었습니다.
	- 실행 명령어의 인자 처리 방식이 보완되어 공백 및 특수문자 처리가 안정적으로 개선되었습니다.
	- 파일 생성 시 오류 처리 로직이 강화되어 문제 발생 시 복구 조치가 개선되었습니다.
	- 관련 테스트 케이스가 업데이트되어 새로운 동작을 정확히 검증합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->