### PR TITLE
🔀 :: [#518] - 코루틴에서 실행되는 작업이 실패할때 코루틴 취소를 적용

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateContainerServiceImpl.kt
@@ -23,9 +23,11 @@ class CreateContainerServiceImpl(
 
             commandPort.executeShellCommand(cmd)
                 .also {exitValue ->
-                    if (exitValue != 0)
-                        commandPort.executeShellCommand("rm -rf ${application.name}")
                     checkExitValuePort.checkApplicationExitValue(exitValue, application, this, FailureCase.CREATE_CONTAINER_FAILURE)
+                    if (exitValue != 0) {
+                        commandPort.executeShellCommand("rm -rf ${application.name}")
+                        return@withContext
+                    }
                 }
 
             val dcdNetworkConnectCmd = "docker network connect dcd ${application.containerName}"

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateContainerServiceImpl.kt
@@ -33,9 +33,11 @@ class CreateContainerServiceImpl(
             val dcdNetworkConnectCmd = "docker network connect dcd ${application.containerName}"
             commandPort.executeShellCommand(dcdNetworkConnectCmd)
                 .also {exitValue ->
-                    if (exitValue != 0)
-                        commandPort.executeShellCommand("rm -rf ${application.name}")
                     checkExitValuePort.checkApplicationExitValue(exitValue, application, this, FailureCase.CONNECT_NETWORK_FAILURE)
+                    if (exitValue != 0) {
+                        commandPort.executeShellCommand("rm -rf ${application.name}")
+                        return@withContext
+                    }
                 }
         }
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateDockerFileServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateDockerFileServiceImpl.kt
@@ -75,7 +75,6 @@ class CreateDockerFileServiceImpl(
                 file.createNewFile()
             file.writeText(fileContent)
         } catch (e: IOException) {
-            e.printStackTrace()
             commandPort.executeShellCommand("rm -rf $directoryName")
             eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application, FailureCase.CREATE_DOCKER_FILE_FAILURE))
         }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateDockerFileServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateDockerFileServiceImpl.kt
@@ -13,6 +13,7 @@ import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.application.util.FailureCase
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.withContext
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
@@ -76,6 +77,7 @@ class CreateDockerFileServiceImpl(
             file.writeText(fileContent)
         } catch (e: IOException) {
             commandPort.executeShellCommand("rm -rf $directoryName")
+            coroutineScope.cancel()
             eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application, FailureCase.CREATE_DOCKER_FILE_FAILURE))
         }
     }


### PR DESCRIPTION
## 개요
* 파일 입출력 혹은 여러 작업이 이루어질때 에러 메시지가 정상적으로 출력되지 않음
  * 파일 입출력시 코루틴을 취소하지 않아서 해당 작업 다음에 이루어지는 작업이 정상적으로 동작해서 에러 메시지를 받지 못함 
## 작업내용
* 컨테이너 생성시 에러가 발생하면 해당 코루틴 컨텍스트에서 리턴하도록 수정
* 컨테이너 생성시 네트워크 연결할때 에러 발생시 코루틴 컨텍스트에서 리턴하도록 수정
* 도커 파일을 생성할때 에러가 발생할때 printStackTrace하는 부분 제거
* 도커 파일을 생성할때 에러가 발생할때 코루틴을 취소하는 로직 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [ ] pr에서 작업할 내용외에 작업한 내용이 있나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 컨테이너 및 네트워크 작업 중 오류 발생 시, 추가 명령이 실행되지 않도록 즉각적으로 작업을 종료하도록 개선되었습니다.
	- 도커 파일 생성 과정에서 오류 발생 시 코루틴이 취소되고 오류 이벤트가 발행되어 보다 안정적인 실패 처리가 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->