### PR TITLE
🔀 :: [#526] - 커맨드 실행시 작업 경로 관리 수정

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExecContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExecContainerServiceImpl.kt
@@ -20,10 +20,10 @@ class ExecContainerServiceImpl(
 
         @Suppress("UNCHECKED_CAST")
         val dirStack = (session.attributes["workingDir"] as? Stack<String>) ?: Stack<String>()
+        val workingDir = "/${dirStack.joinToString("/")}"
 
         if (cmd.contains("cd")) {
             val newDir = cmdArray[1]
-            val currentDir = session.attributes["workingDir"] as? String ?: "/"
             val updatedDir = updateWorkingDir(currentDir, newDir)
             session.attributes["workingDir"] = updatedDir
             session.sendMessage(TextMessage("current dir = ${session.attributes["workingDir"] ?: "/"}"))
@@ -32,8 +32,6 @@ class ExecContainerServiceImpl(
             session.attributes["workingDir"] = dirStack
             return
         }
-
-        val workingDir = session.attributes["workingDir"] as? String ?: "/"
 
         // Docker attach API 호출
         val execInstance = dockerClient.execCreateCmd(application.containerName)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExecContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExecContainerServiceImpl.kt
@@ -54,12 +54,13 @@ class ExecContainerServiceImpl(
     private fun updateWorkingDir(dirStack: Stack<String>, newDir: String) {
         when {
             newDir == "/" -> dirStack.removeAllElements()
-            newDir == ".." -> dirStack.pop()
+            newDir == ".." -> if (dirStack.isNotEmpty()) dirStack.pop()
             newDir.startsWith("/") -> {
                 dirStack.removeAllElements()
                 dirStack.push(newDir)
             }
             newDir == "." -> return
+            newDir.isBlank() -> return
             else -> { dirStack.push(newDir) }
         }
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExecContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExecContainerServiceImpl.kt
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service
 import org.springframework.web.socket.TextMessage
 import org.springframework.web.socket.WebSocketSession
 import java.io.*
+import java.util.Stack
 
 @Service
 class ExecContainerServiceImpl(
@@ -17,6 +18,9 @@ class ExecContainerServiceImpl(
     override fun execCmd(application: Application, session: WebSocketSession, cmd: String) {
         val cmdArray = cmd.split(" ").toTypedArray()
 
+        @Suppress("UNCHECKED_CAST")
+        val dirStack = (session.attributes["workingDir"] as? Stack<String>) ?: Stack<String>()
+
         if (cmd.contains("cd")) {
             val newDir = cmdArray[1]
             val currentDir = session.attributes["workingDir"] as? String ?: "/"
@@ -24,6 +28,8 @@ class ExecContainerServiceImpl(
             session.attributes["workingDir"] = updatedDir
             session.sendMessage(TextMessage("current dir = ${session.attributes["workingDir"] ?: "/"}"))
             session.sendMessage(TextMessage("cmd end"))
+
+            session.attributes["workingDir"] = dirStack
             return
         }
 

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExecContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExecContainerServiceImpl.kt
@@ -84,8 +84,12 @@ class ExecContainerServiceImpl(
         }
 
         override fun onComplete() {
+            @Suppress("UNCHECKED_CAST")
+            val dirStack = (session.attributes["workingDir"] as? Stack<String>) ?: Stack<String>()
+            val workingDir = "/${dirStack.joinToString("/")}"
+
             if (session.isOpen) {
-                session.sendMessage(TextMessage("current dir = ${session.attributes["workingDir"] ?: "/"}"))
+                session.sendMessage(TextMessage("current dir = $workingDir"))
                 session.sendMessage(TextMessage("cmd end"))
             }
             super.onComplete()

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExecContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExecContainerServiceImpl.kt
@@ -47,16 +47,16 @@ class ExecContainerServiceImpl(
             .exec(AttachResultCallback(session))
     }
 
-    private fun updateWorkingDir(currentDir: String, newDir: String): String {
-        return when {
-            newDir == "/" -> "/"  // 루트 디렉토리로 이동
-            newDir == ".." -> currentDir.substringBeforeLast("/", "/")  // 상위 디렉토리로 이동
-            newDir.startsWith("/") -> newDir  // 절대 경로로 설정
-            else -> {
-                if (currentDir != "/")
-                    "$currentDir/$newDir"
-                else "/${newDir}"
-            }  // 현재 디렉토리에서 하위 디렉토리로 이동
+    private fun updateWorkingDir(dirStack: Stack<String>, newDir: String) {
+        when {
+            newDir == "/" -> dirStack.removeAllElements()
+            newDir == ".." -> dirStack.pop()
+            newDir.startsWith("/") -> {
+                dirStack.removeAllElements()
+                dirStack.push(newDir)
+            }
+            newDir == "." -> return
+            else -> { dirStack.push(newDir) }
         }
     }
 

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExecContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExecContainerServiceImpl.kt
@@ -23,10 +23,14 @@ class ExecContainerServiceImpl(
         val workingDir = "/${dirStack.joinToString("/")}"
 
         if (cmd.contains("cd")) {
-            val newDir = cmdArray[1]
-            val updatedDir = updateWorkingDir(currentDir, newDir)
-            session.attributes["workingDir"] = updatedDir
-            session.sendMessage(TextMessage("current dir = ${session.attributes["workingDir"] ?: "/"}"))
+            val newDirList = cmdArray[1].split("/")
+
+            newDirList.forEach { newDir ->
+                updateWorkingDir(dirStack, newDir)
+            }
+            val updatedWorkingDir = "/${dirStack.joinToString("/")}"
+
+            session.sendMessage(TextMessage("current dir = $updatedWorkingDir"))
             session.sendMessage(TextMessage("cmd end"))
 
             session.attributes["workingDir"] = dirStack


### PR DESCRIPTION
## 개요
* 애플리케이션에 커맨드를 실행할때 작업 경로를 관리하는 방식을 스택으로 수정합니다.
## 작업내용
* 작업 디렉토리를 Stack으로 관리하는 부분 추가
* 현재 작업 디렉토리를 dirStack에서 joinToString으로 가져오도록 수정
* updateWorkingDir 메서드가 stack에서 push혹은 pop하도록 수정
* 경로 수정후 session attributes에 저장하도록 수정
* onComplete 메서드에서 스택에서 작업경로를 출력하도록 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [ ] pr에서 작업할 내용외에 작업한 내용이 있나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **리팩터**
  - 웹소켓 세션에서 명령 실행 중 디렉토리 관리 로직을 개선하여, 복잡한 디렉토리 탐색 명령을 보다 효과적으로 처리하도록 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->