### PR TITLE
🔀 :: [#528] - 애플리케이션 배포시 SupervisorJob을 사용하지 않도록 수정

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
@@ -37,7 +37,7 @@ class DeployApplicationUseCase(
         if (application.status == ApplicationStatus.RUNNING || application.status == ApplicationStatus.PENDING)
             throw CanNotDeployApplicationException()
 
-        executionScope.launch {
+        launch {
             deployApplication(application)
         }
 

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
@@ -70,6 +70,10 @@ class DeployApplicationUseCase(
 
         // 작업 완료 후 코루틴 스코프 종료
         launch {
+            applicationList.forEach { _ ->
+                // 각 애플리케이션 배포 완료 시그널 대기
+                deploymentChannel.receive()
+            }
             deploymentChannel.close()
         }
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
@@ -63,7 +63,7 @@ class DeployApplicationUseCase(
 
         // 코루틴을 생성하여 작업 처리
         repeat(3) {
-            scope.launch {
+            launch {
                 for (application in deploymentChannel) {
                     deployApplication(application)
                 }
@@ -71,7 +71,7 @@ class DeployApplicationUseCase(
         }
 
         // 작업 완료 후 코루틴 스코프 종료
-        scope.launch {
+        launch {
             deploymentChannel.close()
         }
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
@@ -49,8 +49,6 @@ class DeployApplicationUseCase(
         val applicationList = queryApplicationPort.findAllByWorkspace(workspace, labels)
 
         val deploymentChannel = Channel<Application>(capacity = Channel.UNLIMITED)
-        val job = SupervisorJob()
-        val scope = this + job
         applicationList.forEach {
             // 만약 애플리케이션의 상태가 배포할 수 없는 상태일때는 건너뜀
             if (it.status == ApplicationStatus.RUNNING || it.status == ApplicationStatus.PENDING)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
@@ -29,8 +29,6 @@ class DeployApplicationUseCase(
     private val workspaceInfo: WorkspaceInfo
 ) : CoroutineScope by CoroutineScope(Dispatchers.IO) {
     fun execute(id: String) {
-        val job = SupervisorJob()
-        val executionScope = this + job
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
 


### PR DESCRIPTION
## 개요
* 애플리케이션 배포시 SupervisorJob을 사용하지 않도록 수정합니다.
## 작업내용
* 애플리케이션 아이디로 배포를 실행할때 클래스의 코루틴을 사용하도록 수정
* 애플리케이션 아이디로 배포를 실행하는 메서드에서 SupervisorJob제거
* 애플리케이션 배포를 실행할때 클래스의 코루틴을 사용하도록 수정
* 애플리케이션 아이디로 배포를 실행하는 메서드에서 SupervisorJob 제거
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [ ] pr에서 작업할 내용외에 작업한 내용이 있나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- 애플리케이션 배포 프로세스의 내부 백그라운드 실행 메커니즘이 단순화되어 시스템 유지보수성이 향상되었습니다. 사용자 경험에는 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->