### PR TITLE
🔀 :: [#530] - 애플리케이션 버전 조회 리펙토링

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ logs/
 *.env
 
 src/main/resources/application-test.yml
+
+getImageVersion.sh

--- a/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
@@ -37,6 +37,61 @@ object FileContent {
         "EXPOSE ${port}\n" +
         getEnvString(env)
 
+    fun getImageVersionShellScriptContent(imageName: String, minVersion: String): String =
+        "#!/bin/bash\n" +
+        "\n" +
+        "# 이미지, 페이지 사이즈, 최소 버전(threshold) 설정\n" +
+        "IMAGE_NAME=\"library/$imageName\"\n" +
+        "PAGE_SIZE=100\n" +
+        "MIN_VERSION=\"$minVersion\"\n" +
+        "\n" +
+        "# 첫 페이지 URL 구성\n" +
+        "URL=\"https://hub.docker.com/v2/repositories/\$IMAGE_NAME/tags/?page_size=\$PAGE_SIZE\"\n" +
+        "\n" +
+        "# 결과를 저장할 변수 및 배열 초기화\n" +
+        "LATEST_FOUND=false\n" +
+        "NUMERIC_TAGS=()\n" +
+        "\n" +
+        "# pagination 처리: next URL이 없을 때까지 반복\n" +
+        "while [ -n \"\$URL\" ] && [ \"\$URL\" != \"null\" ]; do\n" +
+        "    RESPONSE=\$(curl -s \"\$URL\")\n" +
+        "    \n" +
+        "    # 현재 페이지의 태그 목록 추출\n" +
+        "    TAGS=\$(echo \"\$RESPONSE\" | jq -r '.results[].name')\n" +
+        "    \n" +
+        "    for tag in \$TAGS; do\n" +
+        "        # latest는 따로 체크\n" +
+        "        if [[ \"\$tag\" == \"latest\" ]]; then\n" +
+        "            LATEST_FOUND=true\n" +
+        "        # 숫자와 점(.)만 포함된 태그 필터링\n" +
+        "        elif [[ \"\$tag\" =~ ^[0-9]+(\\.[0-9]+)*\$ ]]; then\n" +
+        "            # 버전 비교: tag가 MIN_VERSION 이상이면 저장\n" +
+        "            # sort -V를 사용하여 두 버전을 정렬한 후 첫 번째가 MIN_VERSION이면 tag가 MIN_VERSION 이상입니다.\n" +
+        "            lowest=\$(printf \"%s\\n%s\" \"\$MIN_VERSION\" \"\$tag\" | sort -V | head -n1)\n" +
+        "            if [ \"\$lowest\" = \"\$MIN_VERSION\" ]; then\n" +
+        "                NUMERIC_TAGS+=(\"\$tag\")\n" +
+        "            fi\n" +
+        "        fi\n" +
+        "    done\n" +
+        "    \n" +
+        "    # 다음 페이지 URL 추출 (없으면 \"null\" 또는 빈 문자열)\n" +
+        "    URL=\$(echo \"\$RESPONSE\" | jq -r '.next')\n" +
+        "done\n" +
+        "\n" +
+        "echo \"Sorted tags for $imageName:\"\n" +
+        "echo \"-----------------------------------------------\"\n" +
+        "\n" +
+        "# 최신 태그(latest)가 있으면 제일 먼저 출력\n" +
+        "if \$LATEST_FOUND; then\n" +
+        "    echo \"latest\"\n" +
+        "fi\n" +
+        "\n" +
+        "# 숫자 태그를 내림차순(-r 옵션) 버전 정렬(-V 옵션) 후 출력\n" +
+        "if [ \${#NUMERIC_TAGS[@]} -gt 0 ]; then\n" +
+        "    sorted_numeric_tags=\$(printf \"%s\\n\" \"\${NUMERIC_TAGS[@]}\" | sort -r -V)\n" +
+        "    echo \"\$sorted_numeric_tags\"\n" +
+        "fi\n"
+
     fun getBuildGradleKtsFileContent(name: String): String =
         "tasks {\n" +
         "\tval customBootJarName = \"$name.jar\"\n" +

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
@@ -69,7 +69,7 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.DELETE, "/{workspaceId}/application/env").authenticated()
                 it.requestMatchers(HttpMethod.PATCH, "/{workspaceId}/application/{applicationId}/env").authenticated()
                 it.requestMatchers(HttpMethod.PATCH, "/{workspaceId}/application/env").authenticated()
-                it.requestMatchers(HttpMethod.GET, "/{workspaceId}/application/version/{applicationType}").authenticated()
+                it.requestMatchers(HttpMethod.GET, "/application/{applicationType}/version").authenticated()
                 it.requestMatchers(HttpMethod.POST, "/{workspaceId}/application/{id}/exec").authenticated()
                 it.requestMatchers(HttpMethod.GET, "/application/exec").authenticated()
 

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationStaticWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationStaticWebAdapter.kt
@@ -1,0 +1,20 @@
+package com.dcd.server.presentation.domain.application
+
+import com.dcd.server.core.domain.application.model.enums.ApplicationType
+import com.dcd.server.core.domain.application.usecase.GetAvailableVersionUseCase
+import com.dcd.server.presentation.common.annotation.WebAdapter
+import com.dcd.server.presentation.domain.application.data.exetension.toResponse
+import com.dcd.server.presentation.domain.application.data.response.AvailableVersionResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+
+@WebAdapter("/application")
+class ApplicationStaticWebAdapter(
+    private val getAvailableVersionUseCase: GetAvailableVersionUseCase
+) {
+    @GetMapping("/{applicationType}/version")
+    fun getAvailableVersion(@PathVariable applicationType: ApplicationType): ResponseEntity<AvailableVersionResponse> =
+        getAvailableVersionUseCase.execute(applicationType)
+            .let { ResponseEntity.ok(it.toResponse()) }
+}

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
@@ -1,7 +1,6 @@
 package com.dcd.server.presentation.domain.application
 
 import com.dcd.server.core.common.annotation.WorkspaceOwnerVerification
-import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.usecase.*
 import com.dcd.server.presentation.common.annotation.WebAdapter
 import com.dcd.server.presentation.domain.application.data.exetension.toDto
@@ -25,7 +24,6 @@ class ApplicationWebAdapter(
     private val stopApplicationUseCase: StopApplicationUseCase,
     private val deleteApplicationUseCase: DeleteApplicationUseCase,
     private val updateApplicationUseCase: UpdateApplicationUseCase,
-    private val getAvailableVersionUseCase: GetAvailableVersionUseCase,
     private val getApplicationLogUseCase: GetApplicationLogUseCase,
     private val deployApplicationUseCase: DeployApplicationUseCase,
     private val executeCommandUseCase: ExecuteCommandUseCase,
@@ -168,12 +166,6 @@ class ApplicationWebAdapter(
     ): ResponseEntity<Void> =
         updateApplicationUseCase.execute(applicationId, updateApplicationRequest.toDto())
             .run { ResponseEntity.ok().build() }
-
-    @GetMapping("/version/{applicationType}")
-    @WorkspaceOwnerVerification
-    fun getAvailableVersion(@PathVariable workspaceId: String, @PathVariable applicationType: ApplicationType): ResponseEntity<AvailableVersionResponse> =
-        getAvailableVersionUseCase.execute(applicationType)
-            .let { ResponseEntity.ok(it.toResponse()) }
 
     @PostMapping("/{applicationId}/domain")
     @WorkspaceOwnerVerification

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/GetApplicationVersionServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/GetApplicationVersionServiceImplTest.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.core.domain.application.service
 
 import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.common.file.FileContent
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.impl.GetApplicationVersionServiceImpl
 import io.kotest.core.spec.style.BehaviorSpec
@@ -15,22 +16,22 @@ class GetApplicationVersionServiceImplTest : BehaviorSpec({
         val commandPort = mockk<CommandPort>()
 
         `when`("getAvailableVersion 실행할때") {
-            every { commandPort.executeShellCommandWithResult("docker images ${applicationType.name.lowercase()}") } returns
-                    listOf(
-                        "REPOSITORY   TAG       IMAGE ID       CREATED         SIZE\n",
-                        "mysql        <none>    2010e93e56ca   8 weeks ago     608MB\n",
-                        "mysql        <none>    affb2bfc837e   8 weeks ago     608MB\n",
-                        "mysql        latest    0367e9abf33f   8 weeks ago     609MB\n",
-                        "mysql        <none>    f958d2869db0   8 weeks ago     609MB\n",
-                        "mysql        <none>    70e413dee93d   2 months ago    608MB\n",
-                        "mysql        <none>    c3239d2b6d88   2 months ago    608MB"
-                    )
+            val imageVersionShellScriptContent = FileContent.getImageVersionShellScriptContent("mysql", "8")
+            val tagList = listOf(
+                "latest",
+                "11.1.0",
+                "10.0.0",
+                "9.0.0",
+                "8.1.0",
+                "8.0.1"
+            )
+            every { commandPort.executeShellCommandWithResult(imageVersionShellScriptContent) } returns tagList
 
             val getApplicationVersionService = GetApplicationVersionServiceImpl(commandPort)
             val result = getApplicationVersionService.getAvailableVersion(applicationType)
             then("latest가 있어야함") {
                 result.size shouldBe 6
-                result.contains("latest") shouldBe true
+                result shouldBe tagList
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationStaticWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationStaticWebAdapterTest.kt
@@ -1,0 +1,32 @@
+package com.dcd.server.presentation.domain.application
+
+import com.dcd.server.core.domain.application.dto.response.AvailableVersionResDto
+import com.dcd.server.core.domain.application.model.enums.ApplicationType
+import com.dcd.server.core.domain.application.usecase.GetAvailableVersionUseCase
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.http.HttpStatus
+
+class ApplicationStaticWebAdapterTest : BehaviorSpec({
+    val getAvailableVersionUseCase = mockk<GetAvailableVersionUseCase>()
+    val applicationWebAdapter = ApplicationStaticWebAdapter(getAvailableVersionUseCase)
+
+    given("애플리케이션 타입이 주어지고") {
+        val applicationType = ApplicationType.SPRING_BOOT
+
+        `when`("getAvailableVersion 메서드를 실행할때") {
+            val availableVersionResDto = AvailableVersionResDto(version = listOf("11", "17"))
+            every { getAvailableVersionUseCase.execute(applicationType) } returns availableVersionResDto
+
+            val result = applicationWebAdapter.getAvailableVersion(applicationType)
+            then("result의 바디는 availableVersionResDto랑 같아야함") {
+                result.body?.version shouldBe availableVersionResDto.version
+            }
+            then("result는 200 상태코드를 가져야함") {
+                result.statusCode shouldBe HttpStatus.OK
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -26,12 +26,11 @@ class ApplicationWebAdapterTest : BehaviorSpec({
     val stopApplicationUseCase = mockk<StopApplicationUseCase>()
     val deleteApplicationUseCase = mockk<DeleteApplicationUseCase>()
     val updateApplicationUseCase = mockk<UpdateApplicationUseCase>(relaxUnitFun = true)
-    val getAvailableVersionUseCase = mockk<GetAvailableVersionUseCase>()
     val setApplicationDomainUseCase = mockk<SetApplicationDomainUseCase>(relaxUnitFun = true)
     val getApplicationLogUseCase = mockk<GetApplicationLogUseCase>()
     val deployApplicationUseCase = mockk<DeployApplicationUseCase>(relaxUnitFun = true)
     val executeCommandUseCase = mockk<ExecuteCommandUseCase>(relaxUnitFun = true)
-    val applicationWebAdapter = ApplicationWebAdapter(createApplicationUseCase, springRunApplicationUseCase, getAllApplicationUseCase, getOneApplicationUseCase, addApplicationEnvUseCase, deleteApplicationEnvUseCase, updateApplicationEnvUseCase, stopApplicationUseCase, deleteApplicationUseCase, updateApplicationUseCase, getAvailableVersionUseCase, getApplicationLogUseCase, deployApplicationUseCase, executeCommandUseCase, setApplicationDomainUseCase)
+    val applicationWebAdapter = ApplicationWebAdapter(createApplicationUseCase, springRunApplicationUseCase, getAllApplicationUseCase, getOneApplicationUseCase, addApplicationEnvUseCase, deleteApplicationEnvUseCase, updateApplicationEnvUseCase, stopApplicationUseCase, deleteApplicationUseCase, updateApplicationUseCase, getApplicationLogUseCase, deployApplicationUseCase, executeCommandUseCase, setApplicationDomainUseCase)
 
     val testWorkspaceId = "testWorkspaceId"
 
@@ -197,23 +196,6 @@ class ApplicationWebAdapterTest : BehaviorSpec({
             }
             then("updateApplicationUseCase를 실행해야함") {
                 verify { updateApplicationUseCase.execute(testId, any() as UpdateApplicationReqDto) }
-            }
-        }
-    }
-
-    given("애플리케이션 타입이 주어지고") {
-        val applicationType = ApplicationType.SPRING_BOOT
-
-        `when`("getAvailableVersion 메서드를 실행할때") {
-            val availableVersionResDto = AvailableVersionResDto(version = listOf("11", "17"))
-            every { getAvailableVersionUseCase.execute(applicationType) } returns availableVersionResDto
-
-            val result = applicationWebAdapter.getAvailableVersion(testWorkspaceId, applicationType)
-            then("result의 바디는 availableVersionResDto랑 같아야함") {
-                result.body?.version shouldBe availableVersionResDto.version
-            }
-            then("result는 200 상태코드를 가져야함") {
-                result.statusCode shouldBe HttpStatus.OK
             }
         }
     }


### PR DESCRIPTION
## 개요
* 애플리케이션의 버전을 조회하는 로직을 리펙토링합니다.
## 작업내용
* 도커 허브에서 특정 이미지의 버전을 조회하는 스크립트의 내용을 가져오는 메서드 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [ ] pr에서 작업할 내용외에 작업한 내용이 있나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - Docker 이미지 버전 태그를 조회하기 위한 쉘 스크립트 생성 기능이 추가되어, 애플리케이션 업데이트 시 필요한 버전 정보를 보다 쉽게 확인할 수 있습니다.
  - 새로운 HTTP GET 요청을 통해 애플리케이션 유형에 따른 사용 가능한 버전을 조회하는 기능이 추가되었습니다.

- **버그 수정**
  - 애플리케이션 버전 조회 시 URL 구조가 변경되어, 워크스페이스 ID 없이도 접근할 수 있게 되었습니다.

- **리팩터**
  - 애플리케이션 버전 조회 로직이 개선되어, 각 애플리케이션 유형별로 명확한 기준에 따른 안정적인 결과를 제공하게 되었습니다.
  
- **테스트**
  - 새로운 테스트 클래스가 추가되어 `ApplicationStaticWebAdapter`의 동작을 검증합니다.
  - 기존의 애플리케이션 버전 조회 테스트가 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->