### PR TITLE
🔀 :: [#532] - 애플리케이션 스케줄러에서 정상적으로 상태를 변경하지 못하는 현상 수정

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/scheduler/ApplicationStatusScheduler.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/scheduler/ApplicationStatusScheduler.kt
@@ -95,7 +95,7 @@ class ApplicationStatusScheduler(
         getContainerService.getContainerNameByStatus(ContainerStatus.CREATED)
             .forEach { result ->
                 val (containerName, _) = result.split(" ")
-                val containerExitedApplication = updatedApplicationList.lastOrNull { it.containerName == containerName }
+                val containerExitedApplication = targetApplicationList.find { it.containerName == containerName }
                     ?: return@forEach
 
                 val updatedApplication = containerExitedApplication.copy(

--- a/src/main/kotlin/com/dcd/server/core/domain/application/scheduler/ApplicationStatusScheduler.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/scheduler/ApplicationStatusScheduler.kt
@@ -8,6 +8,7 @@ import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 
 @Component
 class ApplicationStatusScheduler(
@@ -20,6 +21,7 @@ class ApplicationStatusScheduler(
      * @author dolong2
      */
     @Scheduled(cron = "0 * * * * ?")
+    @Transactional(rollbackFor = [Exception::class])
     fun checkApplicationStatus() {
         val runningApplicationList = queryApplicationPort.findAllByStatus(ApplicationStatus.RUNNING)
         val stoppedApplicationList = queryApplicationPort.findAllByStatus(ApplicationStatus.STOPPED)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetContainerServiceImpl.kt
@@ -11,4 +11,5 @@ class GetContainerServiceImpl(
 ) : GetContainerService {
     override fun getContainerNameByStatus(status: ContainerStatus): List<String> =
         commandPort.executeShellCommandWithResult("docker ps -a --filter \"status=${status.value}\" --format \"{{.ID}}\" | xargs -I {} docker inspect --format \"{{.Name}} {{.State.ExitCode}}\" {}")
+            .map { it.replace("/", "") }
 }


### PR DESCRIPTION
## 개요
* 애플리케이션 스케줄러에서 정상적으로 상태를 변경하지 못하는 현상을 수정합니다.
## 작업내용
* 컨테이너 이름 조회시 '/'가 포함되서 출력되지 않도록 수정
* 애플리케이션 스케줄러에 Transaction 추가
* checkCreatedContainer에서 targetApplicationList를 대상으로 컨테이너 이름을 비교하도록 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [ ] pr에서 작업할 내용외에 작업한 내용이 있나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 애플리케이션 상태 업데이트 처리 시, 오류 발생 시 데이터 정합성이 보장되도록 개선되었습니다.
	- 컨테이너 상태를 정확하게 식별할 수 있도록 로직이 개선되어 안정성이 향상되었습니다.
	- 출력되는 컨테이너 이름에서 불필요한 문자가 제거되어 보다 깔끔하게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->