### PR TITLE
🔀 :: [#534] - 애플리케이션 타입 조회 API 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/response/ApplicationTypeListResDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/response/ApplicationTypeListResDto.kt
@@ -1,0 +1,5 @@
+package com.dcd.server.core.domain.application.dto.response
+
+data class ApplicationTypeListResDto(
+    val list: List<String>
+)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationTypeUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationTypeUseCase.kt
@@ -1,0 +1,14 @@
+package com.dcd.server.core.domain.application.usecase
+
+import com.dcd.server.core.common.annotation.ReadOnlyUseCase
+import com.dcd.server.core.domain.application.dto.response.ApplicationTypeListResDto
+import com.dcd.server.core.domain.application.model.enums.ApplicationType
+
+@ReadOnlyUseCase
+class GetApplicationTypeUseCase {
+    fun execute(): ApplicationTypeListResDto {
+        val typeList = ApplicationType.values().map { it.name }
+
+        return ApplicationTypeListResDto(typeList)
+    }
+}

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
@@ -72,6 +72,7 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.GET, "/application/{applicationType}/version").authenticated()
                 it.requestMatchers(HttpMethod.POST, "/{workspaceId}/application/{id}/exec").authenticated()
                 it.requestMatchers(HttpMethod.GET, "/application/exec").authenticated()
+                it.requestMatchers(HttpMethod.GET, "/application/types").authenticated()
 
                 //workspace
                 it.requestMatchers(HttpMethod.POST, "/workspace").authenticated()

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationStaticWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationStaticWebAdapter.kt
@@ -1,9 +1,11 @@
 package com.dcd.server.presentation.domain.application
 
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
+import com.dcd.server.core.domain.application.usecase.GetApplicationTypeUseCase
 import com.dcd.server.core.domain.application.usecase.GetAvailableVersionUseCase
 import com.dcd.server.presentation.common.annotation.WebAdapter
 import com.dcd.server.presentation.domain.application.data.exetension.toResponse
+import com.dcd.server.presentation.domain.application.data.response.ApplicationTypeListResponse
 import com.dcd.server.presentation.domain.application.data.response.AvailableVersionResponse
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -11,10 +13,16 @@ import org.springframework.web.bind.annotation.PathVariable
 
 @WebAdapter("/application")
 class ApplicationStaticWebAdapter(
-    private val getAvailableVersionUseCase: GetAvailableVersionUseCase
+    private val getAvailableVersionUseCase: GetAvailableVersionUseCase,
+    private val getApplicationTypeUseCase: GetApplicationTypeUseCase
 ) {
     @GetMapping("/{applicationType}/version")
     fun getAvailableVersion(@PathVariable applicationType: ApplicationType): ResponseEntity<AvailableVersionResponse> =
         getAvailableVersionUseCase.execute(applicationType)
+            .let { ResponseEntity.ok(it.toResponse()) }
+
+    @GetMapping("/types")
+    fun getApplicationTypes(): ResponseEntity<ApplicationTypeListResponse> =
+        getApplicationTypeUseCase.execute()
             .let { ResponseEntity.ok(it.toResponse()) }
 }

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationResponseDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationResponseDataExtension.kt
@@ -64,3 +64,8 @@ fun CreateApplicationResDto.toResponse(): CreateApplicationResponse =
     CreateApplicationResponse(
         applicationId = this.applicationId
     )
+
+fun ApplicationTypeListResDto.toResponse(): ApplicationTypeListResponse =
+    ApplicationTypeListResponse(
+        list = this.list
+    )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/response/ApplicationTypeListResponse.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/response/ApplicationTypeListResponse.kt
@@ -1,0 +1,5 @@
+package com.dcd.server.presentation.domain.application.data.response
+
+data class ApplicationTypeListResponse(
+    val list: List<String>
+)

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationTypeUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationTypeUseCaseTest.kt
@@ -1,0 +1,20 @@
+package com.dcd.server.core.domain.application.usecase
+
+import com.dcd.server.core.domain.application.model.enums.ApplicationType
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+class GetApplicationTypeUseCaseTest : BehaviorSpec({
+
+    given("애플리케이션 타입 조회 유스케이스가 주어지고") {
+        val getApplicationTypeUseCase = GetApplicationTypeUseCase()
+
+        `when`("유스케이스를 실행할때") {
+            val result = getApplicationTypeUseCase.execute()
+
+            then("현재 지원가능한 애플리케이션의 타입이 조회되어야함") {
+                result.list shouldBe ApplicationType.values().map { it.name }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationStaticWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationStaticWebAdapterTest.kt
@@ -2,6 +2,7 @@ package com.dcd.server.presentation.domain.application
 
 import com.dcd.server.core.domain.application.dto.response.AvailableVersionResDto
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
+import com.dcd.server.core.domain.application.usecase.GetApplicationTypeUseCase
 import com.dcd.server.core.domain.application.usecase.GetAvailableVersionUseCase
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -11,7 +12,8 @@ import org.springframework.http.HttpStatus
 
 class ApplicationStaticWebAdapterTest : BehaviorSpec({
     val getAvailableVersionUseCase = mockk<GetAvailableVersionUseCase>()
-    val applicationWebAdapter = ApplicationStaticWebAdapter(getAvailableVersionUseCase)
+    val getApplicationTypeUseCase = GetApplicationTypeUseCase()
+    val applicationWebAdapter = ApplicationStaticWebAdapter(getAvailableVersionUseCase, getApplicationTypeUseCase)
 
     given("애플리케이션 타입이 주어지고") {
         val applicationType = ApplicationType.SPRING_BOOT
@@ -23,6 +25,20 @@ class ApplicationStaticWebAdapterTest : BehaviorSpec({
             val result = applicationWebAdapter.getAvailableVersion(applicationType)
             then("result의 바디는 availableVersionResDto랑 같아야함") {
                 result.body?.version shouldBe availableVersionResDto.version
+            }
+            then("result는 200 상태코드를 가져야함") {
+                result.statusCode shouldBe HttpStatus.OK
+            }
+        }
+    }
+
+    given("주어지는게 없고") {
+
+        `when`("애플리케이션 타입을 조회할때") {
+            val result = applicationWebAdapter.getApplicationTypes()
+
+            then("결과값에는 모든 애플리케이션 타입이 들어가 있어야함") {
+                result.body?.list shouldBe ApplicationType.values().map { it.name }
             }
             then("result는 200 상태코드를 가져야함") {
                 result.statusCode shouldBe HttpStatus.OK


### PR DESCRIPTION
## 개요
* 애플리케이션 타입 조회 API를 추가합니다.
## 작업내용
* ApplicationTypeListResDto 추가
* GetApplicationTypeUseCase 추가
* GetApplicationTypeUseCaseTest 추가
* ApplicationTypeListResponse 추가
* 애플리케이션 타입 조회 엔드포인트 추가
* 애플리케이션 타입 조회 엔드포인트 테스트 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [ ] pr에서 작업할 내용외에 작업한 내용이 있나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 새로운 API 엔드포인트가 추가되어, 사용자는 인증 후 응용 프로그램 유형 목록을 조회할 수 있습니다.
  - 응용 프로그램 유형 데이터를 명확한 응답 구조로 전달하여 사용자의 데이터 활용성을 높였습니다.
  - 보안 설정이 강화되어, 해당 API 요청은 사용자 인증을 요구합니다.

- **Tests**
  - 추가된 테스트 케이스를 통해 응용 프로그램 유형 조회 기능의 안정성과 일관성이 검증되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->