### PR TITLE
🔀 :: [#536] - ApplicationStatusScheduler 리펙토링

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/scheduler/ApplicationStatusScheduler.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/scheduler/ApplicationStatusScheduler.kt
@@ -6,6 +6,7 @@ import com.dcd.server.core.domain.application.scheduler.enums.ContainerStatus
 import com.dcd.server.core.domain.application.service.GetContainerService
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import kotlinx.coroutines.runBlocking
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
@@ -22,9 +23,10 @@ class ApplicationStatusScheduler(
      */
     @Scheduled(cron = "0 * * * * ?")
     @Transactional(rollbackFor = [Exception::class])
-    fun checkApplicationStatus() {
         val runningApplicationList = queryApplicationPort.findAllByStatus(ApplicationStatus.RUNNING)
         val stoppedApplicationList = queryApplicationPort.findAllByStatus(ApplicationStatus.STOPPED)
+    fun checkApplicationStatus() =
+        runBlocking {
 
         val checkExitedApplicationList = checkExitedContainer(runningApplicationList)
         val checkedRunningApplicationList = checkRunningContainer(stoppedApplicationList)
@@ -33,7 +35,7 @@ class ApplicationStatusScheduler(
         val updatedApplicationList =
             checkExitedApplicationList + checkedRunningApplicationList + checkCreatedContainerApplicationList
         commandApplicationPort.saveAll(updatedApplicationList)
-    }
+        }
 
     /**
      * 실행중인 애플리케이션중 컨테이너가 종료된 애플리케이션의 상태가 STOPPED로 변경될 애플리케이션 리스트를 반환하는 메서드


### PR DESCRIPTION
## 개요
* ApplicationStatusScheduler에서 검사할때 소요되는 시간을 비동기를 적용해서 감소시킵니다.
## 작업내용
* runBlocking 적용
* async를 통해서 각 상태인 애플리케이션 검사를 비동기로 처리하도록 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [ ] pr에서 작업할 내용외에 작업한 내용이 있나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?
## 기타
* 기존에 3.5초 정도 소요되던 로직을 1.94초 정도 소요되도록 개선

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 애플리케이션 상태 확인 프로세스를 비동기 방식으로 개선하여, 전체적인 처리 효율성과 응답성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->