### PR TITLE
🔀 :: [#542] - WorkspaceInfo를 사용하도록 수정

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCase.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.common.data.WorkspaceInfo
 import com.dcd.server.core.domain.application.dto.extenstion.toEntity
 import com.dcd.server.core.domain.application.dto.request.CreateApplicationReqDto
 import com.dcd.server.core.domain.application.dto.response.CreateApplicationResDto
@@ -10,7 +11,6 @@ import com.dcd.server.core.domain.application.service.*
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
-import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -19,7 +19,7 @@ import kotlinx.coroutines.launch
 class CreateApplicationUseCase(
     private val commandApplicationPort: CommandApplicationPort,
     private val queryApplicationPort: QueryApplicationPort,
-    private val queryWorkspacePort: QueryWorkspacePort,
+    private val workspaceInfo: WorkspaceInfo,
     private val cloneApplicationByUrlService: CloneApplicationByUrlService,
     private val createDockerFileService: CreateDockerFileService,
     private val getExternalPortService: GetExternalPortService,
@@ -28,7 +28,7 @@ class CreateApplicationUseCase(
     private val deleteApplicationDirectoryService: DeleteApplicationDirectoryService
 ) : CoroutineScope by CoroutineScope(Dispatchers.IO) {
     fun execute(workspaceId: String, createApplicationReqDto: CreateApplicationReqDto): CreateApplicationResDto {
-        val workspace = queryWorkspacePort.findById(workspaceId)
+        val workspace = workspaceInfo.workspace
             ?: throw WorkspaceNotFoundException()
 
         val externalPort = getExternalPortService.getExternalPort(createApplicationReqDto.port)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCase.kt
@@ -1,20 +1,20 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.ReadOnlyUseCase
+import com.dcd.server.core.common.data.WorkspaceInfo
 import com.dcd.server.core.domain.application.dto.extenstion.toDto
 import com.dcd.server.core.domain.application.dto.response.ApplicationListResDto
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
-import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
 
 @ReadOnlyUseCase
 class GetAllApplicationUseCase(
     private val queryApplicationPort: QueryApplicationPort,
-    private val queryWorkspacePort: QueryWorkspacePort
+    private val workspaceInfo: WorkspaceInfo
 ) {
     fun execute(workspaceId: String, labels: List<String>?): ApplicationListResDto {
-        val workspace = (queryWorkspacePort.findById(workspaceId)
-            ?: throw WorkspaceNotFoundException())
+        val workspace = workspaceInfo.workspace
+            ?: throw WorkspaceNotFoundException()
 
         return ApplicationListResDto(
             queryApplicationPort

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.core.domain.application.usecase
 
+import com.dcd.server.core.common.data.WorkspaceInfo
 import com.dcd.server.core.domain.application.dto.request.CreateApplicationReqDto
 import com.dcd.server.core.domain.application.exception.AlreadyExistsApplicationException
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
@@ -29,7 +30,8 @@ class CreateApplicationUseCaseTest(
     private val commandWorkspacePort: CommandWorkspacePort,
     private val queryApplicationPort: QueryApplicationPort,
     private val queryWorkspacePort: QueryWorkspacePort,
-    private val commandApplicationPort: CommandApplicationPort
+    private val commandApplicationPort: CommandApplicationPort,
+    private val workspaceInfo: WorkspaceInfo
 ) : BehaviorSpec({
     val targetWorkspaceId = UUID.randomUUID().toString()
 
@@ -37,6 +39,7 @@ class CreateApplicationUseCaseTest(
         val user = queryUserPort.findById("user2")!!
         val workspace = WorkspaceGenerator.generateWorkspace(id = targetWorkspaceId, user = user)
         commandWorkspacePort.save(workspace)
+        workspaceInfo.workspace = workspace
     }
 
     given("새로 생성할 애플리케이션 요청이 주어지고") {
@@ -105,6 +108,7 @@ class CreateApplicationUseCaseTest(
 
             then("에러가 발생해야함") {
                 shouldThrow<WorkspaceNotFoundException> {
+                    workspaceInfo.workspace = queryWorkspacePort.findById(notFoundWorkspaceId)
                     createApplicationUseCase.execute(notFoundWorkspaceId, request)
                 }
             }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCaseTest.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.core.domain.application.usecase
 
+import com.dcd.server.core.common.data.WorkspaceInfo
 import com.dcd.server.core.domain.application.dto.extenstion.toDto
 import com.dcd.server.core.domain.application.dto.response.ApplicationListResDto
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
@@ -22,13 +23,15 @@ class GetAllApplicationUseCaseTest(
     private val authDetailsService: AuthDetailsService,
     private val queryWorkspacePort: QueryWorkspacePort,
     private val queryUserPort: QueryUserPort,
-    private val queryApplicationPort: QueryApplicationPort
+    private val queryApplicationPort: QueryApplicationPort,
+    private val workspaceInfo: WorkspaceInfo
 ) : BehaviorSpec({
     val userId = "user1"
 
     beforeContainer {
         val userDetails = authDetailsService.loadUserByUsername(userId)
         val authenticationToken = UsernamePasswordAuthenticationToken(userDetails, "", userDetails.authorities)
+        workspaceInfo.workspace = queryWorkspacePort.findByUser(queryUserPort.findById(userId)!!).first()
         SecurityContextHolder.getContext().authentication = authenticationToken
     }
 


### PR DESCRIPTION
## 개요
* 유저 소유의 워크스페이스를 조회할때 WorkspaceInfo를 사용하도록 리펙토링합니다.
## 작업내용
* 애플리케이션 생성 유스케이스에서 WorkspaceInfo를 통해 워크스페이스를 조회하도록 수정
* 애플리케이션 생성 유스케이스 테스트 수정
* 애플리케이션 전체 조회 유스케이스에서 WorkspaceInfo를 통해 워크스페이스를 조회하도록 수정
* 애플리케이션 전체 조회 유스케이스 테스트 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [ ] pr에서 작업할 내용외에 작업한 내용이 있나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩토링**
  - 애플리케이션 생성 및 조회 과정에서 워크스페이스 정보 접근 방식을 간소화하여 더 직접적인 데이터 참조로 전환했습니다.
  
- **테스트**
  - 변경된 워크스페이스 접근 방식을 반영하도록 테스트 설정을 업데이트하여 기능 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->