### PR TITLE
🔀 :: [#544] - WorkspaceInfo를 사용하는 유스케이스 파라미터 수정

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCase.kt
@@ -27,7 +27,7 @@ class CreateApplicationUseCase(
     private val createContainerService: CreateContainerService,
     private val deleteApplicationDirectoryService: DeleteApplicationDirectoryService
 ) : CoroutineScope by CoroutineScope(Dispatchers.IO) {
-    fun execute(workspaceId: String, createApplicationReqDto: CreateApplicationReqDto): CreateApplicationResDto {
+    fun execute(createApplicationReqDto: CreateApplicationReqDto): CreateApplicationResDto {
         val workspace = workspaceInfo.workspace
             ?: throw WorkspaceNotFoundException()
 

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCase.kt
@@ -12,7 +12,7 @@ class GetAllApplicationUseCase(
     private val queryApplicationPort: QueryApplicationPort,
     private val workspaceInfo: WorkspaceInfo
 ) {
-    fun execute(workspaceId: String, labels: List<String>?): ApplicationListResDto {
+    fun execute(labels: List<String>?): ApplicationListResDto {
         val workspace = workspaceInfo.workspace
             ?: throw WorkspaceNotFoundException()
 

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
@@ -35,7 +35,7 @@ class ApplicationWebAdapter(
         @PathVariable workspaceId: String,
         @Validated @RequestBody createApplicationRequest: CreateApplicationRequest
     ): ResponseEntity<CreateApplicationResponse> =
-        createApplicationUseCase.execute(workspaceId, createApplicationRequest.toDto())
+        createApplicationUseCase.execute(createApplicationRequest.toDto())
             .run { ResponseEntity(toResponse(), HttpStatus.CREATED) }
 
     @PostMapping("/{applicationId}/run")
@@ -68,7 +68,7 @@ class ApplicationWebAdapter(
         @PathVariable workspaceId: String,
         @RequestParam(required = false) labels: List<String>? = null
     ): ResponseEntity<ApplicationListResponse> =
-        getAllApplicationUseCase.execute(workspaceId, labels)
+        getAllApplicationUseCase.execute(labels)
             .let { ResponseEntity.ok(it.toResponse()) }
 
     @GetMapping("/{applicationId}")

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
@@ -55,7 +55,7 @@ class CreateApplicationUseCaseTest(
         )
 
         `when`("usecase를 실행하면") {
-            createApplicationUseCase.execute(targetWorkspaceId, request)
+            createApplicationUseCase.execute(request)
             createApplicationUseCase.coroutineContext.cancel()
 
             then("요청의 이름을 가진 애플리케이션이 존재해야함") {
@@ -85,7 +85,7 @@ class CreateApplicationUseCaseTest(
 
             then("에러가 발생해야함") {
                 shouldThrow<AlreadyExistsApplicationException> {
-                    createApplicationUseCase.execute(targetWorkspaceId, existsApplicationRequest)
+                    createApplicationUseCase.execute(existsApplicationRequest)
                 }
             }
         }
@@ -109,7 +109,7 @@ class CreateApplicationUseCaseTest(
             then("에러가 발생해야함") {
                 shouldThrow<WorkspaceNotFoundException> {
                     workspaceInfo.workspace = queryWorkspacePort.findById(notFoundWorkspaceId)
-                    createApplicationUseCase.execute(notFoundWorkspaceId, request)
+                    createApplicationUseCase.execute(request)
                 }
             }
         }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCaseTest.kt
@@ -40,7 +40,7 @@ class GetAllApplicationUseCaseTest(
         val applicationList = queryApplicationPort.findAllByWorkspace(workspace)
 
         `when`("usecase를 실행할때") {
-            val result = getAllApplicationUseCase.execute(workspace.id, null)
+            val result = getAllApplicationUseCase.execute(null)
             val target = ApplicationListResDto(applicationList.map { it.toDto() })
             then("result는 target이랑 같아야함") {
                 result shouldBe target

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -46,10 +46,10 @@ class ApplicationWebAdapterTest : BehaviorSpec({
         )
 
         `when`("createApplication 메서드를 실행할때") {
-            every { createApplicationUseCase.execute(testWorkspaceId, any()) } returns CreateApplicationResDto("testApplicationId")
+            every { createApplicationUseCase.execute(any()) } returns CreateApplicationResDto("testApplicationId")
             val result = applicationWebAdapter.createApplication(testWorkspaceId, request)
             then("상태코드가 201이여야함") {
-                verify { createApplicationUseCase.execute(testWorkspaceId, any()) }
+                verify { createApplicationUseCase.execute(any()) }
                 result.statusCode shouldBe HttpStatus.CREATED
             }
             then("응답은 생성된 애플리케이션 아이디를 반환해야함") {
@@ -76,7 +76,7 @@ class ApplicationWebAdapterTest : BehaviorSpec({
         val list = listOf(applicationResponse)
         val responseDto = ApplicationListResDto(list)
         `when`("getAllApplication 메서드를 실행할때") {
-            every { getAllApplicationUseCase.execute(testWorkspaceId, null) } returns responseDto
+            every { getAllApplicationUseCase.execute(null) } returns responseDto
             val response = applicationWebAdapter.getAllApplication(testWorkspaceId)
             then("응답바디는 targetResponse와 같아야하고 status는 200이여야함") {
                 val targetResponse = responseDto.toResponse()


### PR DESCRIPTION
## 개요
* WorksspaceInfo를 사용하는 유스케이스 파라미터를 수정합니다.
## 작업내용
* 애플리케이션 생성 유스케이스에 workspaceId 파라미터 제거
* 애플리케이션 조회 유스케이스에 workspaceId 파라미터 제거
* 애플리케이션 어뎁터에서 workspaceId를 전달하지 않도록 수정
* 테스트 코드에서 메서드 호출 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [ ] pr에서 작업할 내용외에 작업한 내용이 있나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **리팩터**
	- 응용 프로그램 생성 및 조회 API의 인터페이스가 간소화되었습니다.  
	- 이제 API 호출 시 별도의 워크스페이스 식별자를 입력할 필요 없이 단일 요청 객체로 작업이 처리됩니다.  
	- 백엔드 로직은 기존과 동일하게 작동하며, 전반적인 사용 경험이 한층 단순해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->