### PR TITLE
🔀 :: [#550] - 계층 관련 리펙토링

### DIFF
--- a/src/main/kotlin/com/dcd/server/infrastructure/global/command/adapter/CommandAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/command/adapter/CommandAdapter.kt
@@ -1,4 +1,4 @@
-package com.dcd.server.core.common.command.adapter
+package com.dcd.server.infrastructure.global.command.adapter
 
 import com.dcd.server.core.common.command.CommandPort
 import org.slf4j.LoggerFactory
@@ -34,19 +34,19 @@ class CommandAdapter : CommandPort {
         val p = Runtime.getRuntime().exec(shellScriptCmd)
         val br = BufferedReader(InputStreamReader(p.inputStream))
 
-        return try {
+        try {
             val result = br.readLines()
             p.waitFor()
             result.forEach {
                 log.debug(it)
             }
-            result
+            return result
         } catch (ex: IOException) {
             log.error("명령어 실행 중 IO 오류 발생: ${ex.message}")
-            emptyList()
+            return emptyList()
         } catch (ex: InterruptedException) {
             log.error("명령어 실행이 중단됨: ${ex.message}")
-            emptyList()
+            return emptyList()
         } finally {
             br.close()
             p.destroy()

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/filter/ExceptionFilter.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/filter/ExceptionFilter.kt
@@ -2,8 +2,7 @@ package com.dcd.server.infrastructure.global.filter
 
 import com.dcd.server.core.common.error.BasicException
 import com.dcd.server.core.common.error.ErrorCode
-import com.dcd.server.infrastructure.global.error.response.ErrorResponse
-import com.dcd.server.presentation.domain.application.exception.InvalidConnectionInfoException
+import com.dcd.server.presentation.common.error.response.ErrorResponse
 import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.FilterChain
 import jakarta.servlet.ServletException
@@ -11,7 +10,6 @@ import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.slf4j.LoggerFactory
 import org.springframework.web.filter.OncePerRequestFilter
-import org.springframework.web.socket.server.HandshakeFailureException
 
 class ExceptionFilter(
     private val objectMapper: ObjectMapper

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/security/CustomAccessDeniedHandler.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/security/CustomAccessDeniedHandler.kt
@@ -1,7 +1,7 @@
 package com.dcd.server.infrastructure.global.security
 
 import com.dcd.server.core.common.error.ErrorCode
-import com.dcd.server.infrastructure.global.error.response.ErrorResponse
+import com.dcd.server.presentation.common.error.response.ErrorResponse
 import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/security/CustomAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/security/CustomAuthenticationEntryPoint.kt
@@ -1,7 +1,7 @@
 package com.dcd.server.infrastructure.global.security
 
 import com.dcd.server.core.common.error.ErrorCode
-import com.dcd.server.infrastructure.global.error.response.ErrorResponse
+import com.dcd.server.presentation.common.error.response.ErrorResponse
 import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse

--- a/src/main/kotlin/com/dcd/server/presentation/common/error/handler/BasicExceptionHandler.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/common/error/handler/BasicExceptionHandler.kt
@@ -1,7 +1,7 @@
-package com.dcd.server.infrastructure.global.error.handler
+package com.dcd.server.presentation.common.error.handler
 
 import com.dcd.server.core.common.error.BasicException
-import com.dcd.server.infrastructure.global.error.response.ErrorResponse
+import com.dcd.server.presentation.common.error.response.ErrorResponse
 import jakarta.servlet.http.HttpServletRequest
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus

--- a/src/main/kotlin/com/dcd/server/presentation/common/error/handler/SpringExceptionHandler.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/common/error/handler/SpringExceptionHandler.kt
@@ -1,7 +1,7 @@
-package com.dcd.server.infrastructure.global.error.handler
+package com.dcd.server.presentation.common.error.handler
 
 import com.dcd.server.core.common.error.ErrorCode
-import com.dcd.server.infrastructure.global.error.response.ErrorResponse
+import com.dcd.server.presentation.common.error.response.ErrorResponse
 import jakarta.servlet.http.HttpServletRequest
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatusCode

--- a/src/main/kotlin/com/dcd/server/presentation/common/error/response/ErrorResponse.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/common/error/response/ErrorResponse.kt
@@ -1,4 +1,4 @@
-package com.dcd.server.infrastructure.global.error.response
+package com.dcd.server.presentation.common.error.response
 
 import com.dcd.server.core.common.error.ErrorCode
 

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/CreateDockerFileServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/CreateDockerFileServiceImplTest.kt
@@ -4,7 +4,7 @@ import com.dcd.server.core.common.file.FileContent
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.impl.CreateDockerFileServiceImpl
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
-import com.dcd.server.core.common.command.adapter.CommandAdapter
+import com.dcd.server.infrastructure.global.command.adapter.CommandAdapter
 import com.dcd.server.core.domain.application.spi.CheckExitValuePort
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe


### PR DESCRIPTION
## 개요
* 계층 관련한 리펙토링을 진행합니다.
## 작업내용
* CommandAdapter를 infrastructure 계층으로 이동
* 예외 핸들링 로직을 presentation 계층으로 이동
* ErrorResponse 임포트 경로 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [ ] pr에서 작업할 내용외에 작업한 내용이 있나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?
## 기타
* CustomAccessDeniedHandler, CustomAuthenticationEntryPoint, ExceptionFilter의 계층 위치를 어디로 해야될까....

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩터**
  - 내부 오류 및 예외 처리 로직을 개선하여 코드 일관성과 유지보수성을 높였습니다.
  - 시스템 구성 요소의 모듈화와 조직 구조를 재정비했습니다.
  
- **Chores**
  - 내부 의존성 및 참조 업데이트를 통해 테스트와 통합의 일관성을 확보했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->