### PR TITLE
🔀 :: [#552] - ExceptionFilter에서 ErrorResponse를 의존하지 않도록 리펙토링

### DIFF
--- a/src/main/kotlin/com/dcd/server/infrastructure/global/filter/ExceptionFilter.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/filter/ExceptionFilter.kt
@@ -4,7 +4,6 @@ import com.dcd.server.core.common.error.BasicException
 import com.dcd.server.core.common.error.ErrorCode
 import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.FilterChain
-import jakarta.servlet.ServletException
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.slf4j.LoggerFactory
@@ -27,11 +26,6 @@ class ExceptionFilter(
                 is BasicException -> {
                     logErrorResponse(ex.errorCode, ex)
                     writeErrorResponse(response, ex)
-                }
-                is ServletException -> {
-                    val errorCode = ErrorCode.BAD_REQUEST
-                    logErrorResponse(errorCode, ex)
-                    writeErrorResponse(response, BasicException(errorCode))
                 }
                 else -> {
                     ex.printStackTrace()

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/filter/ExceptionFilter.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/filter/ExceptionFilter.kt
@@ -2,7 +2,6 @@ package com.dcd.server.infrastructure.global.filter
 
 import com.dcd.server.core.common.error.BasicException
 import com.dcd.server.core.common.error.ErrorCode
-import com.dcd.server.presentation.common.error.response.ErrorResponse
 import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.FilterChain
 import jakarta.servlet.ServletException
@@ -52,7 +51,10 @@ class ExceptionFilter(
 
     private fun writeErrorResponse(response: HttpServletResponse, exception: BasicException) {
         val errorCode = exception.errorCode
-        val responseBody = objectMapper.writeValueAsString(ErrorResponse(errorCode))
+        val responseMap = mutableMapOf<String, Any>()
+        responseMap["status"] = errorCode.code
+        responseMap["message"] = errorCode.msg
+        val responseBody = objectMapper.writeValueAsString(responseMap)
         response.status = errorCode.code
         response.characterEncoding = Charsets.UTF_8.name()
         response.contentType = "application/json"

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/filter/ExceptionFilter.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/filter/ExceptionFilter.kt
@@ -39,6 +39,7 @@ class ExceptionFilter(
     }
 
     private fun logErrorResponse(errorCode: ErrorCode, ex: Exception) {
+        log.error("${errorCode.code}")
         log.error(errorCode.msg)
         log.error(ex.message)
     }

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/filter/ExceptionFilter.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/filter/ExceptionFilter.kt
@@ -46,10 +46,12 @@ class ExceptionFilter(
 
     private fun writeErrorResponse(response: HttpServletResponse, exception: BasicException) {
         val errorCode = exception.errorCode
+
         val responseMap = mutableMapOf<String, Any>()
         responseMap["status"] = errorCode.code
         responseMap["message"] = errorCode.msg
         val responseBody = objectMapper.writeValueAsString(responseMap)
+
         response.status = errorCode.code
         response.characterEncoding = Charsets.UTF_8.name()
         response.contentType = "application/json"

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/security/CustomAccessDeniedHandler.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/security/CustomAccessDeniedHandler.kt
@@ -22,14 +22,16 @@ class CustomAccessDeniedHandler(
         response: HttpServletResponse,
         accessDeniedException: AccessDeniedException?
     ) {
+        val errorCode = ErrorCode.INVALID_ROLE
         log.error(request.method)
         log.error(request.requestURI)
-        val errorCode = ErrorCode.INVALID_ROLE
         log.error(errorCode.msg)
+
         val responseMap = mutableMapOf<String, Any>()
         responseMap["status"] = errorCode.code
         responseMap["message"] = errorCode.msg
         val result = objectMapper.writeValueAsString(responseMap)
+
         response.characterEncoding = Charsets.UTF_8.name()
         response.status = errorCode.code
         response.contentType = MediaType.APPLICATION_JSON_VALUE

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/security/CustomAccessDeniedHandler.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/security/CustomAccessDeniedHandler.kt
@@ -26,7 +26,10 @@ class CustomAccessDeniedHandler(
         log.error(request.requestURI)
         val errorCode = ErrorCode.INVALID_ROLE
         log.error(errorCode.msg)
-        val result = objectMapper.writeValueAsString(ErrorResponse(errorCode))
+        val responseMap = mutableMapOf<String, Any>()
+        responseMap["status"] = errorCode.code
+        responseMap["message"] = errorCode.msg
+        val result = objectMapper.writeValueAsString(responseMap)
         response.characterEncoding = Charsets.UTF_8.name()
         response.status = errorCode.code
         response.contentType = MediaType.APPLICATION_JSON_VALUE

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/security/CustomAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/security/CustomAuthenticationEntryPoint.kt
@@ -27,7 +27,10 @@ class CustomAuthenticationEntryPoint(
         log.error(request.requestURI)
         val errorCode = ErrorCode.FORBIDDEN
         log.error(errorCode.msg)
-        val result = objectMapper.writeValueAsString(ErrorResponse(errorCode))
+        val responseMap = mutableMapOf<String, Any>()
+        responseMap["status"] = errorCode.code
+        responseMap["message"] = errorCode.msg
+        val result = objectMapper.writeValueAsString(responseMap)
         response.characterEncoding = Charsets.UTF_8.name()
         response.status = errorCode.code
         response.contentType = MediaType.APPLICATION_JSON_VALUE

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/security/CustomAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/security/CustomAuthenticationEntryPoint.kt
@@ -23,14 +23,16 @@ class CustomAuthenticationEntryPoint(
         response: HttpServletResponse,
         authException: AuthenticationException
     ) {
+        val errorCode = ErrorCode.FORBIDDEN
         log.error(request.method)
         log.error(request.requestURI)
-        val errorCode = ErrorCode.FORBIDDEN
         log.error(errorCode.msg)
+
         val responseMap = mutableMapOf<String, Any>()
         responseMap["status"] = errorCode.code
         responseMap["message"] = errorCode.msg
         val result = objectMapper.writeValueAsString(responseMap)
+
         response.characterEncoding = Charsets.UTF_8.name()
         response.status = errorCode.code
         response.contentType = MediaType.APPLICATION_JSON_VALUE


### PR DESCRIPTION
## 개요
* ExceptionFilter에서 ErrorResponse를 의존하지 않도록 리펙토링합니다.
## 작업내용
* ErrorResponse 대신 Map을 사용해서 직렬화하도록 수정
* ServletException을 500으로 처리하도록 수정
* logErrorResponse 메서드에서 errorCode의 응답 코드를 로깅하도록 수정
* AuthenticationEntryPoint, AccessDeniedHandler에서 Map을 사용해서 응답을 직렬화하도록 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [ ] pr에서 작업할 내용외에 작업한 내용이 있나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- 서버 에러 처리 및 응답 방식이 개선되어, 오류 발생 시 클라이언트에 일관된 JSON 형식의 메시지가 전달됩니다.
	- 인증 실패 및 접근 거부 상황에서 상태 코드와 메시지가 보다 명확하게 표시되어 사용자 경험이 향상되었습니다.
	- 향상된 로깅 방식을 통해 문제 진단 시 신속한 대응이 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->