### PR TITLE
🔀 :: [#559] - 이메일 인증 확인 로직을 어노테이션 기반의 AOP로 처리할 수 있도록 리펙토링

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/annotation/CheckEmailCertificate.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/annotation/CheckEmailCertificate.kt
@@ -1,0 +1,7 @@
+package com.dcd.server.core.common.annotation
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION)
+annotation class CheckEmailCertificate(
+    val target: String
+)

--- a/src/main/kotlin/com/dcd/server/core/common/aop/EmailCertificateAspect.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/aop/EmailCertificateAspect.kt
@@ -6,10 +6,8 @@ import com.dcd.server.core.common.aop.exception.NotCertificateEmailException
 import com.dcd.server.core.common.aop.util.CustomExpressionParser
 import com.dcd.server.core.common.error.BasicException
 import com.dcd.server.core.common.error.ErrorCode
-import com.dcd.server.core.domain.auth.exception.UserNotFoundException
 import com.dcd.server.core.domain.auth.spi.CommandEmailAuthPort
 import com.dcd.server.core.domain.auth.spi.QueryEmailAuthPort
-import com.dcd.server.core.domain.user.spi.QueryUserPort
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation.Around
 import org.aspectj.lang.annotation.Aspect
@@ -22,8 +20,7 @@ import kotlin.reflect.full.memberProperties
 @Component
 class EmailCertificateAspect(
     private val queryEmailAuthPort: QueryEmailAuthPort,
-    private val commandEmailAuthPort: CommandEmailAuthPort,
-    private val queryUserPort: QueryUserPort
+    private val commandEmailAuthPort: CommandEmailAuthPort
 ) {
     @Pointcut("@annotation(com.dcd.server.core.common.annotation.CheckEmailCertificate)")
     fun checkEmailCertificatePointcut() {}
@@ -41,8 +38,6 @@ class EmailCertificateAspect(
         val email = getFieldValue(parameterObject, "email")
             ?: throw InvalidParsingObjectFieldException()
 
-        if (queryUserPort.existsByEmail(email).not())
-            throw UserNotFoundException()
         val emailAuthList = queryEmailAuthPort.findByEmail(email)
             .filter { it.certificate }
         if (emailAuthList.isEmpty())

--- a/src/main/kotlin/com/dcd/server/core/common/aop/EmailCertificateAspect.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/aop/EmailCertificateAspect.kt
@@ -1,16 +1,22 @@
 package com.dcd.server.core.common.aop
 
+import com.dcd.server.core.common.annotation.CheckEmailCertificate
+import com.dcd.server.core.common.aop.exception.InvalidParsingObjectFieldException
 import com.dcd.server.core.common.aop.exception.NotCertificateEmailException
-import com.dcd.server.core.domain.auth.dto.request.NonAuthChangePasswordReqDto
-import com.dcd.server.core.domain.auth.dto.request.SignUpReqDto
+import com.dcd.server.core.common.aop.util.CustomExpressionParser
+import com.dcd.server.core.common.error.BasicException
+import com.dcd.server.core.common.error.ErrorCode
 import com.dcd.server.core.domain.auth.exception.UserNotFoundException
 import com.dcd.server.core.domain.auth.spi.CommandEmailAuthPort
 import com.dcd.server.core.domain.auth.spi.QueryEmailAuthPort
 import com.dcd.server.core.domain.user.spi.QueryUserPort
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
 import org.aspectj.lang.annotation.Aspect
-import org.aspectj.lang.annotation.Before
 import org.aspectj.lang.annotation.Pointcut
+import org.aspectj.lang.reflect.MethodSignature
 import org.springframework.stereotype.Component
+import kotlin.reflect.full.memberProperties
 
 @Aspect
 @Component
@@ -19,30 +25,40 @@ class EmailCertificateAspect(
     private val commandEmailAuthPort: CommandEmailAuthPort,
     private val queryUserPort: QueryUserPort
 ) {
-    @Pointcut("execution(* com.dcd.server.core.domain.auth.usecase.SignUpUseCase.execute(..)) " + "&& args(signUpReqDto)")
-    fun signupUseCasePointcut(signUpReqDto: SignUpReqDto) {}
+    @Pointcut("@annotation(com.dcd.server.core.common.annotation.CheckEmailCertificate)")
+    fun checkEmailCertificatePointcut() {}
 
-    @Pointcut("execution(* com.dcd.server.core.domain.auth.usecase.NonAuthChangePasswordUseCase.execute(..))" + "&& args(nonAuthChangePasswordReqDto)")
-    fun changePasswordUseCasePointcut(nonAuthChangePasswordReqDto: NonAuthChangePasswordReqDto) {}
+    @Around("checkEmailCertificatePointcut()")
+    fun checkEmailCertificate(joinPoint: ProceedingJoinPoint): Any? {
+        val signature = joinPoint.signature as MethodSignature
+        val method = signature.method
+        val annotation = method.getAnnotation(CheckEmailCertificate::class.java)
 
-    @Before("signupUseCasePointcut(signUpReqDto)")
-    private fun checkEmailCertificate(signUpReqDto: SignUpReqDto) {
-        val emailAuthList = queryEmailAuthPort.findByEmail(signUpReqDto.email)
-            .filter { it.certificate }
-        if (emailAuthList.isEmpty())
-            throw NotCertificateEmailException()
-        commandEmailAuthPort.deleteByCode(emailAuthList[0].code)
-    }
+        val parameterObject =
+            CustomExpressionParser.getDynamicValue(signature.parameterNames, joinPoint.args, annotation.target)
+                ?: throw BasicException(ErrorCode.BAD_REQUEST)
 
-    @Before("changePasswordUseCasePointcut(nonAuthChangePasswordReqDto)")
-    private fun checkEmailCertificate(nonAuthChangePasswordReqDto: NonAuthChangePasswordReqDto) {
-        val email = nonAuthChangePasswordReqDto.email
+        val email = getFieldValue(parameterObject, "email")
+            ?: throw InvalidParsingObjectFieldException()
+
         if (queryUserPort.existsByEmail(email).not())
             throw UserNotFoundException()
         val emailAuthList = queryEmailAuthPort.findByEmail(email)
             .filter { it.certificate }
         if (emailAuthList.isEmpty())
             throw NotCertificateEmailException()
+
+        val result = joinPoint.proceed()
+
         commandEmailAuthPort.deleteByCode(emailAuthList[0].code)
+
+        return result
+    }
+
+    private fun getFieldValue(obj: Any, fieldName: String): String? {
+        return obj::class.memberProperties
+            .firstOrNull { it.name == fieldName }
+            ?.getter
+            ?.call(obj) as? String
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/common/aop/exception/InvalidParsingObjectFieldException.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/aop/exception/InvalidParsingObjectFieldException.kt
@@ -1,0 +1,6 @@
+package com.dcd.server.core.common.aop.exception
+
+import com.dcd.server.core.common.error.BasicException
+import com.dcd.server.core.common.error.ErrorCode
+
+class InvalidParsingObjectFieldException : BasicException(ErrorCode.INVALID_PARSING_OBJECT_FIELD)

--- a/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
@@ -49,4 +49,5 @@ enum class ErrorCode(
     CONTAINER_NOT_CREATED("해당 애플리케이션의 이미지를 컨테이너로 빌드할 수 없음", 500),
     IMAGE_NOT_BUILT("해당 애플리케이션을 이미지로 빌드할 수 없음", 500),
     INTERNAL_ERROR("서버 내부 에러", 500),
+    INVALID_PARSING_OBJECT_FIELD("파싱할 필드가 올바르게 설정되어있지 않는 객체임", 500),
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/NonAuthChangePasswordUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/NonAuthChangePasswordUseCase.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.core.domain.auth.usecase
 
+import com.dcd.server.core.common.annotation.CheckEmailCertificate
 import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.domain.auth.dto.request.NonAuthChangePasswordReqDto
 import com.dcd.server.core.domain.auth.exception.UserNotFoundException
@@ -13,6 +14,7 @@ class NonAuthChangePasswordUseCase(
     private val commandUserPort: CommandUserPort,
     private val passwordEncoder: PasswordEncoder
 ) {
+    @CheckEmailCertificate("#nonAuthChangePasswordReqDto")
     fun execute(nonAuthChangePasswordReqDto: NonAuthChangePasswordReqDto) {
         val user = queryUserPort.findByEmail(nonAuthChangePasswordReqDto.email)
             ?: throw UserNotFoundException()

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/SignUpUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/SignUpUseCase.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.core.domain.auth.usecase
 
+import com.dcd.server.core.common.annotation.CheckEmailCertificate
 import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.common.service.SecurityService
 import com.dcd.server.core.domain.auth.dto.extension.toEntity
@@ -14,6 +15,7 @@ class SignUpUseCase(
     private val commandUserPort: CommandUserPort,
     private val queryUserPort: QueryUserPort
 ) {
+    @CheckEmailCertificate("#signUpReqDto")
     fun execute(signUpReqDto: SignUpReqDto) {
         if(queryUserPort.existsByEmail(signUpReqDto.email))
             throw AlreadyExistsUserException()

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/NonAuthChangePasswordUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/NonAuthChangePasswordUseCaseTest.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.core.domain.auth.usecase
 
+import com.dcd.server.core.common.aop.exception.NotCertificateEmailException
 import com.dcd.server.core.domain.auth.dto.request.NonAuthChangePasswordReqDto
 import com.dcd.server.core.domain.auth.exception.UserNotFoundException
 import com.dcd.server.core.domain.auth.model.EmailAuth
@@ -50,8 +51,24 @@ class NonAuthChangePasswordUseCaseTest(
             val notFoundUserEmail = "notFoundUser"
             val nonAuthChangePasswordReqDto = NonAuthChangePasswordReqDto(email = notFoundUserEmail, newPassword = "newPassword")
 
+            val emailAuth = EmailAuth(email = notFoundUserEmail, code = "notFoundEmail", certificate = true)
+            commandEmailAuthPort.save(emailAuth)
+
             then("UserNotFoundException이 발생해야함") {
                 shouldThrow<UserNotFoundException> {
+                    nonAuthChangePasswordUseCase.execute(nonAuthChangePasswordReqDto)
+                }
+            }
+
+            commandEmailAuthPort.deleteByCode("notFoundEmail")
+        }
+
+        `when`("이메일 인증코드가 존재하지 않는 유저일때") {
+            val notFoundUserEmail = "notFoundUser"
+            val nonAuthChangePasswordReqDto = NonAuthChangePasswordReqDto(email = notFoundUserEmail, newPassword = "newPassword")
+
+            then("UserNotFoundException이 발생해야함") {
+                shouldThrow<NotCertificateEmailException> {
                     nonAuthChangePasswordUseCase.execute(nonAuthChangePasswordReqDto)
                 }
             }


### PR DESCRIPTION
## 개요
* 이메일 인증 확인 로직을 어노테이션 기반의 AOP로 처리할 수 있도록 리펙토링합니다.
## 작업내용
* CheckEmailCertificate 어노테이션 추가
* InvalidParsingObjectFieldException 추가
* 이메일 인증 확인 로직을 어노테이션 포인트 컷으로 처리하도록 수정
* 이메일 인증 확인이 필요한 유스케이스에 CheckEmailCertificate 적용
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [ ] pr에서 작업할 내용외에 작업한 내용이 있나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - 회원 가입 및 비밀번호 변경 과정에서 이메일 인증 검증 기능이 추가되어, 보안성이 향상되었습니다.
- **Refactor**
  - 기존의 다중 검증 로직을 단일화하여 보다 효율적인 이메일 인증 처리가 구현되었습니다.
- **Chores**
  - 오류 상황에 대해 명확한 피드백을 제공할 수 있도록 새로운 에러 코드와 예외 처리가 도입되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->