### PR TITLE
🔀 :: [#561] - UseCase 어노테이션에서 rollbackFor, noRollbackFor 옵션을 직접 지정할 수 있도록 수정

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/annotation/ReadOnlyUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/annotation/ReadOnlyUseCase.kt
@@ -1,8 +1,16 @@
 package com.dcd.server.core.common.annotation
 
+import org.springframework.core.annotation.AliasFor
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
+import kotlin.reflect.KClass
 
 @Component
 @Transactional(readOnly = true, rollbackFor = [Exception::class])
-annotation class ReadOnlyUseCase()
+annotation class ReadOnlyUseCase(
+    @get:AliasFor(annotation = Transactional::class, attribute = "rollbackFor")
+    val rollbackFor: Array<KClass<out Throwable>> = [Exception::class],
+
+    @get:AliasFor(annotation = Transactional::class, attribute = "noRollbackFor")
+    val noRollbackFor: Array<KClass<out Throwable>> = []
+)

--- a/src/main/kotlin/com/dcd/server/core/common/annotation/ReadOnlyUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/annotation/ReadOnlyUseCase.kt
@@ -6,7 +6,7 @@ import org.springframework.transaction.annotation.Transactional
 import kotlin.reflect.KClass
 
 @Component
-@Transactional(readOnly = true, rollbackFor = [Exception::class])
+@Transactional(readOnly = true)
 annotation class ReadOnlyUseCase(
     @get:AliasFor(annotation = Transactional::class, attribute = "rollbackFor")
     val rollbackFor: Array<KClass<out Throwable>> = [Exception::class],

--- a/src/main/kotlin/com/dcd/server/core/common/annotation/UseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/annotation/UseCase.kt
@@ -6,7 +6,7 @@ import org.springframework.transaction.annotation.Transactional
 import kotlin.reflect.KClass
 
 @Component
-@Transactional(rollbackFor = [Exception::class])
+@Transactional
 annotation class UseCase(
     @get:AliasFor(annotation = Transactional::class, attribute = "rollbackFor")
     val rollbackFor: Array<KClass<out Throwable>> = [Exception::class],

--- a/src/main/kotlin/com/dcd/server/core/common/annotation/UseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/annotation/UseCase.kt
@@ -1,8 +1,16 @@
 package com.dcd.server.core.common.annotation
 
+import org.springframework.core.annotation.AliasFor
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
+import kotlin.reflect.KClass
 
 @Component
 @Transactional(rollbackFor = [Exception::class])
-annotation class UseCase()
+annotation class UseCase(
+    @get:AliasFor(annotation = Transactional::class, attribute = "rollbackFor")
+    val rollbackFor: Array<KClass<out Throwable>> = [Exception::class],
+
+    @get:AliasFor(annotation = Transactional::class, attribute = "noRollbackFor")
+    val noRollbackFor: Array<KClass<out Throwable>> = []
+)


### PR DESCRIPTION
## 개요
* UseCase 어노테이션에서 rollbackFor, noRollbackFor 옵션을 직접 지정할 수 있도록 리펙토링합니다.
## 작업내용
* ReadOnlyUseCase에 rollbackFor, noRollbackFor 필드 추가
* ReadOnlyUseCase의 Transactional에서 rollbackFor 설정 제거
* UseCase에 rollbackFor, noRollbackFor 필드 추가
* UseCase의 Transactional에서 rollbackFor 설정 제거
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [ ] pr에서 작업할 내용외에 작업한 내용이 있나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 트랜잭션 처리 방식이 강화되어, 오류 발생 시 롤백 정책을 보다 세밀하게 구성할 수 있게 되었습니다.
  - 기본 설정은 그대로 유지되며, 추가 옵션을 통해 특정 예외 상황에 대한 조정이 가능해져 시스템의 안정성과 유연성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->