### PR TITLE
🔀 :: [#563] - 엔티티의 id를 UUID로 수정

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/user/spi/QueryUserPort.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/user/spi/QueryUserPort.kt
@@ -7,7 +7,6 @@ interface QueryUserPort {
     fun findById(id: String): User?
     fun findByEmail(email: String): User?
     fun existsByEmail(email: String): Boolean
-    fun exitsById(userId: String): Boolean
-
+    fun existsById(userId: String): Boolean
     fun findByStatus(status: Status): List<User>
 }

--- a/src/main/kotlin/com/dcd/server/persistence/application/ApplicationPersistenceAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/application/ApplicationPersistenceAdapter.kt
@@ -10,6 +10,7 @@ import com.dcd.server.persistence.application.repository.ApplicationRepository
 import com.dcd.server.persistence.workspace.adapter.toEntity
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
+import java.util.UUID
 
 @Component
 class ApplicationPersistenceAdapter(
@@ -37,7 +38,7 @@ class ApplicationPersistenceAdapter(
     }
 
     override fun findById(id: String): Application? =
-        applicationRepository.findByIdOrNull(id)
+        applicationRepository.findByIdOrNull(UUID.fromString(id))
             ?.toDomain()
 
     override fun existsByExternalPort(externalPort: Int): Boolean =

--- a/src/main/kotlin/com/dcd/server/persistence/application/adapter/ApplicationAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/application/adapter/ApplicationAdapter.kt
@@ -2,14 +2,13 @@ package com.dcd.server.persistence.application.adapter
 
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.persistence.application.entity.ApplicationJpaEntity
-import com.dcd.server.persistence.user.adapter.toDomain
-import com.dcd.server.persistence.user.adapter.toEntity
 import com.dcd.server.persistence.workspace.adapter.toDomain
 import com.dcd.server.persistence.workspace.adapter.toEntity
+import java.util.*
 
 fun Application.toEntity(): ApplicationJpaEntity =
     ApplicationJpaEntity(
-        id = this.id,
+        id = UUID.fromString(this.id),
         name = this.name,
         description = this.description,
         applicationType = this.applicationType,
@@ -26,7 +25,7 @@ fun Application.toEntity(): ApplicationJpaEntity =
 
 fun ApplicationJpaEntity.toDomain(): Application =
     Application(
-        id = this.id,
+        id = this.id.toString(),
         name = this.name,
         description = this.description,
         applicationType = this.applicationType,

--- a/src/main/kotlin/com/dcd/server/persistence/application/entity/ApplicationJpaEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/application/entity/ApplicationJpaEntity.kt
@@ -5,13 +5,17 @@ import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.persistence.user.entity.UserJpaEntity
 import com.dcd.server.persistence.workspace.entity.WorkspaceJpaEntity
 import jakarta.persistence.*
+import org.hibernate.annotations.GenericGenerator
+import java.util.UUID
 
 
 @Entity
 @Table(name = "application_entity")
 class ApplicationJpaEntity(
     @Id
-    val id: String,
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Column(columnDefinition = "BINARY(16)")
+    val id: UUID,
     val name: String,
     val description: String?,
     @Enumerated(EnumType.STRING)

--- a/src/main/kotlin/com/dcd/server/persistence/application/repository/ApplicationRepository.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/application/repository/ApplicationRepository.kt
@@ -6,8 +6,9 @@ import com.dcd.server.persistence.workspace.entity.WorkspaceJpaEntity
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
+import java.util.*
 
-interface ApplicationRepository : JpaRepository<ApplicationJpaEntity, String> {
+interface ApplicationRepository : JpaRepository<ApplicationJpaEntity, UUID> {
     fun findAllByWorkspace(workspace: WorkspaceJpaEntity): List<ApplicationJpaEntity>
     @Query("select app from ApplicationJpaEntity app join app.labels label where app.workspace = :workspace and label IN :labels")
     fun findAllByWorkspaceAndLabels(

--- a/src/main/kotlin/com/dcd/server/persistence/user/UserPersistenceAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/user/UserPersistenceAdapter.kt
@@ -8,6 +8,7 @@ import com.dcd.server.persistence.user.adapter.toEntity
 import com.dcd.server.persistence.user.repository.UserRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
+import java.util.*
 
 @Component
 class UserPersistenceAdapter(
@@ -18,11 +19,11 @@ class UserPersistenceAdapter(
     }
 
     override fun delete(user: User) {
-        userRepository.deleteById(user.id)
+        userRepository.deleteById(UUID.fromString(user.id))
     }
 
     override fun findById(id: String): User? =
-        userRepository.findByIdOrNull(id)
+        userRepository.findByIdOrNull(UUID.fromString(id))
             ?.toDomain()
 
     override fun findByEmail(email: String): User? =
@@ -33,7 +34,7 @@ class UserPersistenceAdapter(
         userRepository.existsByEmail(email)
 
     override fun exitsById(userId: String): Boolean =
-        userRepository.existsById(userId)
+        userRepository.existsById(UUID.fromString(userId))
 
     override fun findByStatus(status: Status): List<User> =
         userRepository.findAllByStatus(status)

--- a/src/main/kotlin/com/dcd/server/persistence/user/UserPersistenceAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/user/UserPersistenceAdapter.kt
@@ -33,7 +33,7 @@ class UserPersistenceAdapter(
     override fun existsByEmail(email: String): Boolean =
         userRepository.existsByEmail(email)
 
-    override fun exitsById(userId: String): Boolean =
+    override fun existsById(userId: String): Boolean =
         userRepository.existsById(UUID.fromString(userId))
 
     override fun findByStatus(status: Status): List<User> =

--- a/src/main/kotlin/com/dcd/server/persistence/user/adapter/UserAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/user/adapter/UserAdapter.kt
@@ -2,10 +2,11 @@ package com.dcd.server.persistence.user.adapter
 
 import com.dcd.server.core.domain.user.model.User
 import com.dcd.server.persistence.user.entity.UserJpaEntity
+import java.util.*
 
 fun User.toEntity(): UserJpaEntity =
     UserJpaEntity(
-        id = this.id,
+        id = UUID.fromString(this.id),
         email = this.email,
         name = this.name,
         password = this.password,
@@ -15,7 +16,7 @@ fun User.toEntity(): UserJpaEntity =
 
 fun UserJpaEntity.toDomain(): User =
     User(
-        id = this.id,
+        id = this.id.toString(),
         email = this.email,
         name = this.name,
         password = this.password,

--- a/src/main/kotlin/com/dcd/server/persistence/user/entity/UserJpaEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/user/entity/UserJpaEntity.kt
@@ -3,13 +3,16 @@ package com.dcd.server.persistence.user.entity
 import com.dcd.server.core.domain.auth.model.Role
 import com.dcd.server.core.domain.user.model.enums.Status
 import jakarta.persistence.*
+import org.hibernate.annotations.GenericGenerator
 import java.util.*
 
 @Entity
 @Table(name = "user_entity")
 class UserJpaEntity(
     @Id
-    val id: String = UUID.randomUUID().toString(),
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Column(columnDefinition = "BINARY(16)")
+    val id: UUID = UUID.randomUUID(),
     val email: String,
     val password: String,
     val name: String,

--- a/src/main/kotlin/com/dcd/server/persistence/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/user/repository/UserRepository.kt
@@ -3,8 +3,9 @@ package com.dcd.server.persistence.user.repository
 import com.dcd.server.core.domain.user.model.enums.Status
 import com.dcd.server.persistence.user.entity.UserJpaEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import java.util.*
 
-interface UserRepository : JpaRepository<UserJpaEntity, String> {
+interface UserRepository : JpaRepository<UserJpaEntity, UUID> {
     fun findByEmail(email: String): UserJpaEntity?
     fun existsByEmail(email: String): Boolean
     fun findAllByStatus(status: Status): List<UserJpaEntity>

--- a/src/main/kotlin/com/dcd/server/persistence/workspace/WorkspacePersistenceAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/workspace/WorkspacePersistenceAdapter.kt
@@ -9,6 +9,7 @@ import com.dcd.server.persistence.workspace.adapter.toEntity
 import com.dcd.server.persistence.workspace.repository.WorkspaceRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
+import java.util.UUID
 
 @Component
 class WorkspacePersistenceAdapter(
@@ -16,7 +17,7 @@ class WorkspacePersistenceAdapter(
 ) : WorkspacePort {
     override fun findById(id: String): Workspace? {
         return workspaceRepository
-            .findByIdOrNull(id)
+            .findByIdOrNull(UUID.fromString(id))
             ?.toDomain()
     }
 

--- a/src/main/kotlin/com/dcd/server/persistence/workspace/adapter/WorkspaceAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/workspace/adapter/WorkspaceAdapter.kt
@@ -4,10 +4,11 @@ import com.dcd.server.core.domain.workspace.model.Workspace
 import com.dcd.server.persistence.user.adapter.toDomain
 import com.dcd.server.persistence.user.adapter.toEntity
 import com.dcd.server.persistence.workspace.entity.WorkspaceJpaEntity
+import java.util.*
 
 fun Workspace.toEntity(): WorkspaceJpaEntity =
     WorkspaceJpaEntity(
-        id = this.id,
+        id = UUID.fromString(this.id),
         title = this.title,
         description = this.description,
         globalEnv = this.globalEnv,
@@ -16,7 +17,7 @@ fun Workspace.toEntity(): WorkspaceJpaEntity =
 
 fun WorkspaceJpaEntity.toDomain(): Workspace =
     Workspace(
-        id = this.id,
+        id = this.id.toString(),
         title = this.title,
         description = this.description,
         globalEnv = this.globalEnv,

--- a/src/main/kotlin/com/dcd/server/persistence/workspace/entity/WorkspaceJpaEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/workspace/entity/WorkspaceJpaEntity.kt
@@ -2,13 +2,16 @@ package com.dcd.server.persistence.workspace.entity
 
 import com.dcd.server.persistence.user.entity.UserJpaEntity
 import jakarta.persistence.*
+import org.hibernate.annotations.GenericGenerator
 import java.util.UUID
 
 @Entity
 @Table(name = "workspace_entity")
 class WorkspaceJpaEntity(
     @Id
-    val id: String = UUID.randomUUID().toString(),
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Column(columnDefinition = "BINARY(16)")
+    val id: UUID = UUID.randomUUID(),
     val title: String,
     val description: String,
     @ElementCollection(fetch = FetchType.EAGER)

--- a/src/main/kotlin/com/dcd/server/persistence/workspace/repository/WorkspaceRepository.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/workspace/repository/WorkspaceRepository.kt
@@ -3,8 +3,9 @@ package com.dcd.server.persistence.workspace.repository
 import com.dcd.server.persistence.user.entity.UserJpaEntity
 import com.dcd.server.persistence.workspace.entity.WorkspaceJpaEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
 
-interface WorkspaceRepository : JpaRepository<WorkspaceJpaEntity, String> {
+interface WorkspaceRepository : JpaRepository<WorkspaceJpaEntity, UUID> {
     fun findAllByOwner(user: UserJpaEntity): List<WorkspaceJpaEntity>
     fun existsByTitle(title: String): Boolean
 }

--- a/src/test/kotlin/com/dcd/server/core/common/service/SecurityServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/common/service/SecurityServiceImplTest.kt
@@ -21,7 +21,7 @@ class SecurityServiceImplTest(
     private val authDetailsService: AuthDetailsService,
     private val passwordEncoder: PasswordEncoder
 ) : BehaviorSpec({
-    val targetUserId = "user2"
+    val targetUserId = "1e1973eb-3fb9-47ac-9342-c16cd63ffc6f"
 
     beforeContainer {
         val userDetails = authDetailsService.loadUserByUsername(targetUserId)

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/AddApplicationEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/AddApplicationEnvUseCaseTest.kt
@@ -12,6 +12,7 @@ import io.kotest.matchers.shouldNotBe
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
 
 @Transactional
 @SpringBootTest
@@ -24,7 +25,7 @@ class AddApplicationEnvUseCaseTest(
 ) : BehaviorSpec({
     var targetApplicationId = ""
     beforeSpec {
-        val targetUser = queryUserPort.findById("user1")!!
+        val targetUser = queryUserPort.findById("923a6407-a5f8-4e1e-bffd-0621910ddfc8")!!
 
         val workspace = queryWorkspacePort.findByUser(targetUser).first()
         val application = queryApplicationPort.findAllByWorkspace(workspace).first()
@@ -47,7 +48,7 @@ class AddApplicationEnvUseCaseTest(
     }
 
     given("존재하지 않는 애플리케이션 아이디가 주어지고") {
-        val notFoundApplicationId = "notFoundApplicationId"
+        val notFoundApplicationId = UUID.randomUUID().toString()
         val request = AddApplicationEnvReqDto(
             envList = mapOf(Pair("testA", "testB"))
         )

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
@@ -36,7 +36,7 @@ class CreateApplicationUseCaseTest(
     val targetWorkspaceId = UUID.randomUUID().toString()
 
     beforeTest {
-        val user = queryUserPort.findById("user2")!!
+        val user = queryUserPort.findById("1e1973eb-3fb9-47ac-9342-c16cd63ffc6f")!!
         val workspace = WorkspaceGenerator.generateWorkspace(id = targetWorkspaceId, user = user)
         commandWorkspacePort.save(workspace)
         workspaceInfo.workspace = workspace
@@ -92,7 +92,7 @@ class CreateApplicationUseCaseTest(
     }
 
     given("존재하지 않는 워크스페이스 아이디가 주어지고") {
-        val notFoundWorkspaceId = "notFoundWorkspaceId"
+        val notFoundWorkspaceId = UUID.randomUUID().toString()
         val request = CreateApplicationReqDto(
             name = "testCreateApplication",
             description = "testDescription",

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationEnvUseCaseTest.kt
@@ -14,6 +14,7 @@ import io.kotest.matchers.shouldBe
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
 
 @Transactional
 @SpringBootTest
@@ -25,11 +26,11 @@ class DeleteApplicationEnvUseCaseTest(
     private val commandWorkspacePort: CommandWorkspacePort,
     private val queryApplicationPort: QueryApplicationPort
 ) : BehaviorSpec({
-    val applicationId = "testId"
+    val applicationId = "2fb0f315-8272-422f-8e9f-c4f765c022b2"
     val key = "testKey"
 
     beforeContainer {
-        val user = queryUserPort.findById("user2")!!
+        val user = queryUserPort.findById("1e1973eb-3fb9-47ac-9342-c16cd63ffc6f")!!
         val workspace = WorkspaceGenerator.generateWorkspace(user = user)
         commandWorkspacePort.save(workspace)
         val application = ApplicationGenerator.generateApplication(id = applicationId, env = mapOf(Pair("testKey", "testValue")), workspace = workspace)
@@ -59,7 +60,7 @@ class DeleteApplicationEnvUseCaseTest(
     }
 
     given("존재하지 않는 애플리케이션의 아이디가 주어지고") {
-        val notFoundApplicationId = "notFoundApplicationId"
+        val notFoundApplicationId = UUID.randomUUID().toString()
 
         `when`("유스케이스를 실행하면") {
 

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationUseCaseTest.kt
@@ -24,7 +24,7 @@ class DeleteApplicationUseCaseTest(
     private val queryApplicationPort: QueryApplicationPort,
     private val commandApplicationPort: CommandApplicationPort
 ) : BehaviorSpec({
-    val targetUserId = "user1"
+    val targetUserId = "923a6407-a5f8-4e1e-bffd-0621910ddfc8"
     var targetApplicationId = ""
 
     beforeSpec {

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCaseTest.kt
@@ -21,6 +21,7 @@ import io.kotest.matchers.shouldNotBe
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
 
 @Transactional
 @SpringBootTest
@@ -36,7 +37,7 @@ class DeployApplicationUseCaseTest(
     private val commandApplicationPort: CommandApplicationPort,
     private val queryApplicationPort: QueryApplicationPort
 ) : BehaviorSpec({
-    val targetApplicationId = "testApplicationId"
+    val targetApplicationId = UUID.randomUUID().toString()
 
     beforeSpec {
         val user = UserGenerator.generateUser()
@@ -76,7 +77,7 @@ class DeployApplicationUseCaseTest(
     }
 
     given("존재하지 않는 애플리케이션의 아이디가 주어지고") {
-        val notFoundApplicationId = "notFoundApplicationId"
+        val notFoundApplicationId = UUID.randomUUID().toString()
 
         `when`("유스케이스를 실행할때") {
 

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCaseTest.kt
@@ -26,7 +26,7 @@ class GetAllApplicationUseCaseTest(
     private val queryApplicationPort: QueryApplicationPort,
     private val workspaceInfo: WorkspaceInfo
 ) : BehaviorSpec({
-    val userId = "user1"
+    val userId = "923a6407-a5f8-4e1e-bffd-0621910ddfc8"
 
     beforeContainer {
         val userDetails = authDetailsService.loadUserByUsername(userId)

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCaseTest.kt
@@ -16,6 +16,7 @@ import io.kotest.matchers.collections.shouldContain
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
 
 @Transactional
 @SpringBootTest
@@ -28,7 +29,7 @@ class GetApplicationLogUseCaseTest(
     private val commandWorkspacePort: CommandWorkspacePort,
     private val commandApplicationPort: CommandApplicationPort
 ) : BehaviorSpec({
-    val targetApplicationId = "testApplicationId"
+    val targetApplicationId = UUID.randomUUID().toString()
 
     beforeSpec {
         val user = UserGenerator.generateUser()
@@ -54,7 +55,7 @@ class GetApplicationLogUseCaseTest(
     }
 
     given("존재하지 않는 애플리케이션 id가 주어지고") {
-        val notFoundApplicationId = "notFoundApplicationId"
+        val notFoundApplicationId = UUID.randomUUID().toString()
         `when`("유스케이스를 실행할때") {
 
             then("에러가 발생해야함") {

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCaseTest.kt
@@ -13,6 +13,7 @@ import io.kotest.matchers.equality.shouldBeEqualToComparingFields
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
+import java.util.*
 
 @Transactional
 @SpringBootTest
@@ -25,7 +26,7 @@ class GetOneApplicationUseCaseTest(
 ) : BehaviorSpec({
 
     given("애플리케이션이 주어지고") {
-        val user = queryUserPort.findById("user2")!!
+        val user = queryUserPort.findById("1e1973eb-3fb9-47ac-9342-c16cd63ffc6f")!!
         val workspace = WorkspaceGenerator.generateWorkspace(user = user)
         commandWorkspacePort.save(workspace)
         val application = ApplicationGenerator.generateApplication(workspace = workspace)
@@ -46,7 +47,7 @@ class GetOneApplicationUseCaseTest(
 
             then("에러가 발생해야함") {
                 shouldThrow<ApplicationNotFoundException> {
-                    getOneApplicationUseCase.execute("notFoundId")
+                    getOneApplicationUseCase.execute(UUID.randomUUID().toString())
                 }
             }
         }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/RunApplicationUseCaseTest.kt
@@ -20,6 +20,7 @@ import io.mockk.coVerify
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
 
 @Transactional
 @SpringBootTest
@@ -33,7 +34,7 @@ class RunApplicationUseCaseTest(
     private val commandWorkspacePort: CommandWorkspacePort,
     private val commandUserPort: CommandUserPort
 ) : BehaviorSpec({
-    val targetApplicationId = "testApplicationId"
+    val targetApplicationId = UUID.randomUUID().toString()
 
     beforeSpec {
         val user = UserGenerator.generateUser()
@@ -75,7 +76,7 @@ class RunApplicationUseCaseTest(
     }
 
     given("존재하지 않는 애플리케이션 아이디가 주어지고") {
-        val notFoundApplicationId = "notFoundApplicationId"
+        val notFoundApplicationId = UUID.randomUUID().toString()
 
         `when`("유스케이스를 실행할때") {
 

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/StopApplicationUseCaseTest.kt
@@ -20,6 +20,7 @@ import io.kotest.matchers.shouldNotBe
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
+import java.util.*
 
 @Transactional
 @SpringBootTest
@@ -33,7 +34,7 @@ class StopApplicationUseCaseTest(
     private val commandWorkspacePort: CommandWorkspacePort,
     private val commandApplicationPort: CommandApplicationPort
 ) : BehaviorSpec({
-    val targetApplicationId = "testApplicationId"
+    val targetApplicationId = UUID.randomUUID().toString()
 
     beforeSpec {
         val user = UserGenerator.generateUser()
@@ -75,7 +76,7 @@ class StopApplicationUseCaseTest(
     }
 
     given("존재하지 않는 애플리케이션이 주어지고") {
-        val notFoundApplicationId = "notFoundApplicationId"
+        val notFoundApplicationId = UUID.randomUUID().toString()
 
         `when`("유스케이스를 실행할때") {
 

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationEnvUseCaseTest.kt
@@ -17,6 +17,7 @@ import io.kotest.matchers.shouldNotBe
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
+import java.util.*
 
 @Transactional
 @SpringBootTest
@@ -28,11 +29,11 @@ class UpdateApplicationEnvUseCaseTest(
     private val queryUserPort: QueryUserPort,
     private val commandWorkspacePort: CommandWorkspacePort
 ) : BehaviorSpec({
-    val applicationId = "testId"
+    val applicationId = "2fb0f315-8272-422f-8e9f-c4f765c022b2"
     val key = "testKey"
 
     beforeContainer {
-        val user = queryUserPort.findById("user2")!!
+        val user = queryUserPort.findById("1e1973eb-3fb9-47ac-9342-c16cd63ffc6f")!!
         val workspace = WorkspaceGenerator.generateWorkspace(user = user)
         commandWorkspacePort.save(workspace)
         val application = ApplicationGenerator.generateApplication(id = applicationId, env = mapOf(Pair("testKey", "testValue")), workspace = workspace)
@@ -70,7 +71,7 @@ class UpdateApplicationEnvUseCaseTest(
     }
 
     given("존재하지 않는 애플리케이션 아이디가 존재하고") {
-        val notFoundAppId = "nfAppId"
+        val notFoundAppId = UUID.randomUUID().toString()
         val request = UpdateApplicationEnvReqDto(newValue = "newValue")
 
         `when`("유스케이스를 실행하면") {

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCaseTest.kt
@@ -19,6 +19,7 @@ import io.mockk.coVerify
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
 
 @Transactional
 @SpringBootTest
@@ -32,7 +33,7 @@ class UpdateApplicationUseCaseTest(
     @MockkBean(relaxed = true)
     private val commandPort: CommandPort
 ) : BehaviorSpec({
-    val targetUserId = "user1"
+    val targetUserId = "923a6407-a5f8-4e1e-bffd-0621910ddfc8"
 
     val updateReqDto = UpdateApplicationReqDto(name = "updated application", description = "dldl", applicationType = ApplicationType.SPRING_BOOT, githubUrl = null, version = "11", port = 8080)
 
@@ -72,7 +73,7 @@ class UpdateApplicationUseCaseTest(
     }
 
     given("존재하지 않는 애플리케이션 아이디가 주어지고") {
-        val notFoundApplicationId = "notFoundApplicationId"
+        val notFoundApplicationId = UUID.randomUUID().toString()
 
         `when`("usecase를 실행할때") {
 

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/ReissueTokenUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/ReissueTokenUseCaseTest.kt
@@ -18,6 +18,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
+import java.util.UUID
 
 @Transactional
 @SpringBootTest
@@ -30,7 +31,7 @@ class ReissueTokenUseCaseTest(
     private val parseTokenAdapter: ParseTokenAdapter,
     private val refreshTokenPort: CommandRefreshTokenPort
 ) : BehaviorSpec({
-    val userId = "user2"
+    val userId = "1e1973eb-3fb9-47ac-9342-c16cd63ffc6f"
     val token = "testRefreshToken"
     val ttl = 10000L
 
@@ -45,7 +46,7 @@ class ReissueTokenUseCaseTest(
 
         `when`("아무 문제 없이 실행될때") {
             every { parseTokenAdapter.getJwtType(token) } returns JwtPrefix.REFRESH
-            every { jwtPort.generateToken("user2") } returns targetTokenResDto
+            every { jwtPort.generateToken("1e1973eb-3fb9-47ac-9342-c16cd63ffc6f") } returns targetTokenResDto
             refreshTokenPort.save(refreshToken)
 
             val result = reissueTokenUseCase.execute(token)
@@ -63,7 +64,7 @@ class ReissueTokenUseCaseTest(
         }
 
         `when`("토큰에 있는 유저가 없을때") {
-            val notFoundToken = refreshToken.copy(userId = "notFoundUser", token = "notFoundRefreshToken", ttl)
+            val notFoundToken = refreshToken.copy(userId = UUID.randomUUID().toString(), token = "notFoundRefreshToken", ttl)
             refreshTokenPort.save(notFoundToken)
             every { parseTokenAdapter.getJwtType(notFoundToken.token) } returns JwtPrefix.REFRESH
 

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/SignInUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/SignInUseCaseTest.kt
@@ -37,7 +37,7 @@ class SignInUseCaseTest(
             val testPassword = "testPassword"
             val requestDto = SignInReqDto(testEmail, testPassword)
 
-            every { jwtPort.generateToken("user2") } returns targetTokenResDto
+            every { jwtPort.generateToken("1e1973eb-3fb9-47ac-9342-c16cd63ffc6f") } returns targetTokenResDto
             val result = signInUseCase.execute(requestDto)
 
             then("아무 이상이 없으면 주어진 responseDto를 반환해야됨") {

--- a/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangePasswordUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangePasswordUseCaseTest.kt
@@ -24,7 +24,7 @@ class ChangePasswordUseCaseTest(
     private val authDetailsService: AuthDetailsService
 ) : BehaviorSpec({
     beforeTest {
-        val userId = "user2"
+        val userId = "1e1973eb-3fb9-47ac-9342-c16cd63ffc6f"
         val userDetails = authDetailsService.loadUserByUsername(userId)
         val authenticationToken = UsernamePasswordAuthenticationToken(userDetails, "", userDetails.authorities)
         SecurityContextHolder.getContext().authentication = authenticationToken
@@ -39,7 +39,7 @@ class ChangePasswordUseCaseTest(
         `when`("usecase를 실행할때") {
             changePasswordUseCase.execute(passwordChangeReqDto)
             then("passwordChangeReqDto의 새 패스워드를 가진 유저를 저장해야함") {
-                val user = queryUserPort.findById("user2")
+                val user = queryUserPort.findById("1e1973eb-3fb9-47ac-9342-c16cd63ffc6f")
                 user shouldNotBe null
                 passwordEncoder.matches(passwordChangeReqDto.newPassword, user?.password)
             }

--- a/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangeUserStatusUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/user/usecase/ChangeUserStatusUseCaseTest.kt
@@ -11,6 +11,7 @@ import io.kotest.matchers.shouldNotBe
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
 
 @Transactional
 @SpringBootTest
@@ -22,7 +23,7 @@ class ChangeUserStatusUseCaseTest(
 ) : BehaviorSpec({
 
     given("존재하는 유저의 아이디가 주어지고") {
-        val userId = "user1"
+        val userId = "923a6407-a5f8-4e1e-bffd-0621910ddfc8"
         val status = Status.PENDING
 
         `when`("유스케이스를 실행할때") {
@@ -37,7 +38,7 @@ class ChangeUserStatusUseCaseTest(
     }
 
     given("존재하지 않는 유저의 아이디가 주어지고") {
-        val userId = "notFoundUser"
+        val userId = UUID.randomUUID().toString()
         val status = Status.PENDING
 
         `when`("유스케케이스를 실행할때") {

--- a/src/test/kotlin/com/dcd/server/core/domain/user/usecase/GetUserProfileUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/user/usecase/GetUserProfileUseCaseTest.kt
@@ -25,7 +25,7 @@ class GetUserProfileUseCaseTest(
     private val queryWorkspacePort: QueryWorkspacePort,
     private val queryApplicationPort: QueryApplicationPort
 ) : BehaviorSpec({
-    val userId = "user1"
+    val userId = "923a6407-a5f8-4e1e-bffd-0621910ddfc8"
     beforeTest {
         val userDetails = authDetailsService.loadUserByUsername(userId)
         val authenticationToken = UsernamePasswordAuthenticationToken(userDetails, "", userDetails.authorities)

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/AddGlobalEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/AddGlobalEnvUseCaseTest.kt
@@ -19,6 +19,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
 
 @Transactional
 @SpringBootTest
@@ -31,8 +32,8 @@ class AddGlobalEnvUseCaseTest(
     private val commandWorkspacePort: CommandWorkspacePort,
     private val commandUserPort: CommandUserPort
 ) : BehaviorSpec({
-    val userId = "user2"
-    val targetWorkspaceId = "testWorkspaceId"
+    val userId = "1e1973eb-3fb9-47ac-9342-c16cd63ffc6f"
+    val targetWorkspaceId = "d57b42f5-5cc4-440b-8dce-b4fc2e372eff"
 
     beforeContainer {
         val userDetails = authDetailsService.loadUserByUsername(userId)
@@ -75,7 +76,7 @@ class AddGlobalEnvUseCaseTest(
     }
 
     given("존재하지 않은 워크스페이스 아이디가 주어지고") {
-        val givenWorkspaceId = "notFoundWorkspace"
+        val givenWorkspaceId = UUID.randomUUID().toString()
         val testEnvList = mapOf("testKey" to "testValue")
         val addGlobalEnvReqDto = AddGlobalEnvReqDto(testEnvList)
 

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/CreateWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/CreateWorkspaceUseCaseTest.kt
@@ -26,7 +26,7 @@ class CreateWorkspaceUseCaseTest(
     @MockkBean(relaxed = true)
     private val commandPort: CommandPort
 ) : BehaviorSpec({
-    val userId = "user1"
+    val userId = "923a6407-a5f8-4e1e-bffd-0621910ddfc8"
 
     beforeContainer {
         val userDetails = authDetailsService.loadUserByUsername(userId)

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteGlobalEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteGlobalEnvUseCaseTest.kt
@@ -19,6 +19,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
 
 @Transactional
 @SpringBootTest
@@ -31,8 +32,8 @@ class DeleteGlobalEnvUseCaseTest(
     private val queryWorkspacePort: QueryWorkspacePort,
     private val commandUserPort: CommandUserPort
 ) : BehaviorSpec({
-    val userId = "user2"
-    val targetWorkspaceId = "testWorkspaceId"
+    val userId = "1e1973eb-3fb9-47ac-9342-c16cd63ffc6f"
+    val targetWorkspaceId = "d57b42f5-5cc4-440b-8dce-b4fc2e372eff"
 
     beforeContainer {
         val userDetails = authDetailsService.loadUserByUsername(userId)
@@ -85,7 +86,7 @@ class DeleteGlobalEnvUseCaseTest(
     }
 
     given("워크스페이스가 존재하지 않을때") {
-        val notFoundWorkspaceId = "notFoundWorkspaceId"
+        val notFoundWorkspaceId = UUID.randomUUID().toString()
         val key = "testEnvKey"
 
         `when`("유스케이스를 실행하면") {

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteWorkspaceUseCaseTest.kt
@@ -16,6 +16,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
 
 @Transactional
 @SpringBootTest
@@ -29,8 +30,8 @@ class DeleteWorkspaceUseCaseTest(
     @MockkBean(relaxed = true)
     private val commandPort: CommandPort
 ) : BehaviorSpec({
-    val userId = "user1"
-    val workspaceId = "testWorkspaceId"
+    val userId = "923a6407-a5f8-4e1e-bffd-0621910ddfc8"
+    val workspaceId = "d57b42f5-5cc4-440b-8dce-b4fc2e372eff"
 
     beforeContainer {
         val userDetails = authDetailsService.loadUserByUsername(userId)
@@ -54,10 +55,12 @@ class DeleteWorkspaceUseCaseTest(
     }
 
     given("워크스페이스 아이디를 가진 워크스페이스가 주어지지 않고") {
+        val notFoundWorkspaceId = UUID.randomUUID().toString()
+
         `when`("유스케이스를 실행할때") {
             then("WorkspaceNotFoundException이 발생해야함") {
                 shouldThrow<WorkspaceNotFoundException> {
-                    deleteWorkspaceUseCase.execute(workspaceId)
+                    deleteWorkspaceUseCase.execute(notFoundWorkspaceId)
                 }
             }
         }

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/GetAllWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/GetAllWorkspaceUseCaseTest.kt
@@ -22,7 +22,7 @@ class GetAllWorkspaceUseCaseTest(
     private val queryUserPort: QueryUserPort,
     private val commandWorkspacePort: CommandWorkspacePort
 ) : BehaviorSpec({
-    val userId = "user2"
+    val userId = "1e1973eb-3fb9-47ac-9342-c16cd63ffc6f"
     val firstWorkspaceId = UUID.randomUUID().toString()
     val secondWorkspaceId = UUID.randomUUID().toString()
 

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/GetWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/GetWorkspaceUseCaseTest.kt
@@ -24,8 +24,8 @@ class GetWorkspaceUseCaseTest(
     private val queryUserPort: QueryUserPort,
     private val commandWorkspacePort: CommandWorkspacePort
 ) : BehaviorSpec({
-    val userId = "user1"
-    val workspaceId = "testWorkspaceId"
+    val userId = "923a6407-a5f8-4e1e-bffd-0621910ddfc8"
+    val workspaceId = "1e1973eb-3fb9-47ac-9342-c16cd63ffc6f"
 
     beforeContainer {
         val userDetails = authDetailsService.loadUserByUsername(userId)

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/UpdateGlobalEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/UpdateGlobalEnvUseCaseTest.kt
@@ -20,6 +20,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
 
 @Transactional
 @SpringBootTest
@@ -32,8 +33,8 @@ class UpdateGlobalEnvUseCaseTest(
     private val queryWorkspacePort: QueryWorkspacePort,
     private val commandUserPort: CommandUserPort
 ) : BehaviorSpec({
-    val userId = "user1"
-    val targetWorkspaceId = "testWorkspaceId"
+    val userId = "923a6407-a5f8-4e1e-bffd-0621910ddfc8"
+    val targetWorkspaceId = "d57b42f5-5cc4-440b-8dce-b4fc2e372eff"
 
     beforeContainer {
         val userDetails = authDetailsService.loadUserByUsername(userId)
@@ -87,7 +88,7 @@ class UpdateGlobalEnvUseCaseTest(
     }
 
     given("워크스페이스가 존재하지 않을때") {
-        val notFoundWorkspaceId = "notFoundWorkspaceId"
+        val notFoundWorkspaceId = UUID.randomUUID().toString()
         val envKey = "testEnvKey"
         val updateGlobalEnvReqDto = UpdateGlobalEnvReqDto(newValue = "updatedValue")
 

--- a/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/UpdateWorkspaceUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/workspace/usecase/UpdateWorkspaceUseCaseTest.kt
@@ -21,6 +21,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
 
 @Transactional
 @SpringBootTest
@@ -35,8 +36,8 @@ class UpdateWorkspaceUseCaseTest(
     @MockkBean(relaxed = true)
     private val commandPort: CommandPort
 ) : BehaviorSpec({
-    val userId = "user1"
-    val workspaceId = "testWorkspaceId"
+    val userId = "923a6407-a5f8-4e1e-bffd-0621910ddfc8"
+    val workspaceId = "d57b42f5-5cc4-440b-8dce-b4fc2e372eff"
 
     beforeContainer {
         val userDetails = authDetailsService.loadUserByUsername(userId)
@@ -80,12 +81,13 @@ class UpdateWorkspaceUseCaseTest(
     }
 
     given("UpdateWorkspaceReqDto만 주어지고") {
+        val notFoundWorkspaceId = UUID.randomUUID().toString()
         val request = UpdateWorkspaceReqDto(title = "test title", description = "test description")
 
         `when`("유스케이스를 실행하면") {
             then("WorkspaceNotFoundException이 발생해야함") {
                 shouldThrow<WorkspaceNotFoundException> {
-                    updateWorkspaceUseCase.execute(workspaceId, request)
+                    updateWorkspaceUseCase.execute(notFoundWorkspaceId, request)
                 }
             }
         }

--- a/src/test/kotlin/com/dcd/server/persistence/application/ApplicationPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/persistence/application/ApplicationPersistenceAdapterTest.kt
@@ -72,12 +72,12 @@ class ApplicationPersistenceAdapterTest : BehaviorSpec({
             }
         }
         `when`("findById 메서드를 실행할때") {
-            every { applicationRepository.findByIdOrNull(id) } returns application.toEntity()
+            every { applicationRepository.findByIdOrNull(UUID.fromString(id)) } returns application.toEntity()
             var result = applicationPersistenceAdapter.findById(id)
             then("repository의 반환값이 applicationEntity라면 결과값은 application이 반환되야함") {
                 result shouldBe application
             }
-            every { applicationRepository.findByIdOrNull(id) } returns null
+            every { applicationRepository.findByIdOrNull(UUID.fromString(id)) } returns null
             result = applicationPersistenceAdapter.findById(id)
             then("repository의 반홥값이 null이라면 결과값은 null이 반환되어야함") {
                 result shouldBe null

--- a/src/test/kotlin/com/dcd/server/persistence/user/UserPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/persistence/user/UserPersistenceAdapterTest.kt
@@ -46,13 +46,13 @@ class UserPersistenceAdapterTest : BehaviorSpec({
 
         `when`("existsById 메서드를 사용할때") {
             every { userRepository.existsById(UUID.fromString(testUserId)) } returns true
-            var result = adapter.exitsById(testUserId)
+            var result = adapter.existsById(testUserId)
             then("해당 유저가 존재한다면 해당 true가 반환되어야힘") {
                 result shouldBe true
             }
 
             every { userRepository.existsById(UUID.fromString(testUserId)) } returns false
-            result = adapter.exitsById(testUserId)
+            result = adapter.existsById(testUserId)
             then("해당 유저가 존재하지 않는다면 false가 반환되어야함") {
                 result shouldBe false
             }

--- a/src/test/kotlin/com/dcd/server/persistence/user/UserPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/persistence/user/UserPersistenceAdapterTest.kt
@@ -11,13 +11,14 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.springframework.data.repository.findByIdOrNull
+import java.util.*
 
 class UserPersistenceAdapterTest : BehaviorSpec({
     val userRepository = mockk<UserRepository>()
     val adapter = UserPersistenceAdapter(userRepository)
 
     given("User가 주어질때") {
-        val testUserId = "testId"
+        val testUserId = UUID.randomUUID().toString()
         val testEmail = "test"
         val user = User(email = "another", password = "password", name = "another user", roles = mutableListOf(Role.ROLE_USER), status = Status.CREATED)
 
@@ -30,13 +31,13 @@ class UserPersistenceAdapterTest : BehaviorSpec({
         }
 
         `when`("findById 메서드를 사용할때") {
-            every { userRepository.findByIdOrNull(testUserId) } returns user.toEntity()
+            every { userRepository.findByIdOrNull(UUID.fromString(testUserId)) } returns user.toEntity()
             var result = adapter.findById(testUserId)
             then("해당 유저가 존재한다면 해당 유저가 조회되어야힘") {
                 result shouldBe user
             }
 
-            every { userRepository.findByIdOrNull(testUserId) } returns null
+            every { userRepository.findByIdOrNull(UUID.fromString(testUserId)) } returns null
             result = adapter.findById(testUserId)
             then("해당 유저가 존재하지 않는다면 null이 반환되어야함") {
                 result shouldBe null
@@ -44,13 +45,13 @@ class UserPersistenceAdapterTest : BehaviorSpec({
         }
 
         `when`("existsById 메서드를 사용할때") {
-            every { userRepository.existsById(testUserId) } returns true
+            every { userRepository.existsById(UUID.fromString(testUserId)) } returns true
             var result = adapter.exitsById(testUserId)
             then("해당 유저가 존재한다면 해당 true가 반환되어야힘") {
                 result shouldBe true
             }
 
-            every { userRepository.existsById(testUserId) } returns false
+            every { userRepository.existsById(UUID.fromString(testUserId)) } returns false
             result = adapter.exitsById(testUserId)
             then("해당 유저가 존재하지 않는다면 false가 반환되어야함") {
                 result shouldBe false

--- a/src/test/kotlin/com/dcd/server/persistence/workspace/WorkspacePersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/persistence/workspace/WorkspacePersistenceAdapterTest.kt
@@ -55,7 +55,7 @@ class WorkspacePersistenceAdapterTest : BehaviorSpec({
         }
 
         `when`("findById 메서드를 실행할때") {
-            every { workspaceRepository.findByIdOrNull(id) } returns workspace.toEntity()
+            every { workspaceRepository.findByIdOrNull(UUID.fromString(id)) } returns workspace.toEntity()
             val result = workspacePersistenceAdapter.findById(id)
             then("주어진 workspace가 반환되야함") {
                 result shouldBe workspace

--- a/src/test/kotlin/util/application/ApplicationGenerator.kt
+++ b/src/test/kotlin/util/application/ApplicationGenerator.kt
@@ -5,10 +5,11 @@ import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.workspace.model.Workspace
 import util.workspace.WorkspaceGenerator
+import java.util.*
 
 object ApplicationGenerator {
     fun generateApplication(
-        id: String = "testId",
+        id: String = UUID.randomUUID().toString(),
         name: String = "testName",
         description: String = "testDescription",
         applicationType: ApplicationType = ApplicationType.SPRING_BOOT,

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -1,3 +1,5 @@
+SET MODE MySQL;
+
 -- 테이블 생성
 drop table if exists application_entity cascade;
 drop table if exists application_env_entity cascade;
@@ -6,13 +8,13 @@ drop table if exists global_env_entity cascade;
 drop table if exists role_entity cascade;
 drop table if exists user_entity cascade;
 drop table if exists workspace_entity cascade;
-create table application_entity (external_port integer not null, port integer not null, application_type varchar(255) check (application_type in ('SPRING_BOOT','NEST_JS','MYSQL','MARIA_DB','REDIS')), description varchar(255), failure_reason varchar(255), github_url varchar(255), id varchar(255) not null, name varchar(255), status varchar(255) check (status in ('CREATED','PENDING','RUNNING','STOPPED','FAILURE')), version varchar(255), workspace_id varchar(255), primary key (id));
-create table application_env_entity (application_id varchar(255) not null, env_key varchar(255) not null, env_value varchar(255), primary key (application_id, env_key));
-create table application_label_entity (application_id varchar(255) not null, label varchar(255));
-create table global_env_entity (env_key varchar(255) not null, env_value varchar(255), workspace_id varchar(255) not null, primary key (env_key, workspace_id));
-create table role_entity (roles varchar(255) check (roles in ('ROLE_ADMIN','ROLE_DEVELOPER','ROLE_USER')), user_id varchar(255) not null);
-create table user_entity (email varchar(255), id varchar(255) not null, name varchar(255), password varchar(255), status varchar(255) check (status in ('PENDING','CREATED')), primary key (id));
-create table workspace_entity (description varchar(255), id varchar(255) not null, owner_id varchar(255), title varchar(255), primary key (id));
+create table application_entity (external_port integer not null, port integer not null, application_type varchar(255) check (application_type in ('SPRING_BOOT','NEST_JS','MYSQL','MARIA_DB','REDIS')), description varchar(255), failure_reason varchar(255), github_url varchar(255), id binary(16) not null, name varchar(255), status varchar(255) check (status in ('CREATED','PENDING','RUNNING','STOPPED','FAILURE')), version varchar(255), workspace_id binary(16), primary key (id));
+create table application_env_entity (application_id binary(16) not null, env_key varchar(255) not null, env_value varchar(255), primary key (application_id, env_key));
+create table application_label_entity (application_id binary(16) not null, label varchar(255));
+create table global_env_entity (env_key varchar(255) not null, env_value varchar(255), workspace_id binary(16) not null, primary key (env_key, workspace_id));
+create table role_entity (roles varchar(255) check (roles in ('ROLE_ADMIN','ROLE_DEVELOPER','ROLE_USER')), user_id binary(16) not null);
+create table user_entity (email varchar(255), id binary(16) not null, name varchar(255), password varchar(255), status varchar(255) check (status in ('PENDING','CREATED')), primary key (id));
+create table workspace_entity (description varchar(255), id binary(16) not null, owner_id binary(16), title varchar(255), primary key (id));
 alter table if exists application_entity add constraint FKn9drxkrx2h6wlorxfy00mr45h foreign key (workspace_id) references workspace_entity;
 alter table if exists application_env_entity add constraint FKb8anxni720qr9mk9neafwm7v foreign key (application_id) references application_entity;
 alter table if exists application_label_entity add constraint FKq6iovxq5tdx2i1lwrx34kg0b9 foreign key (application_id) references application_entity;
@@ -21,13 +23,13 @@ alter table if exists role_entity add constraint FKrot6fehcor0f3sux5s6kgl0a4 for
 alter table if exists workspace_entity add constraint FKlfxk1bhw5knckt8vv28xvx5g2 foreign key (owner_id) references user_entity;
 
 -- 유저 생성
-insert into user_entity (email,name,password,status,id) values ('ownerEmail','applicationOwner', '$2a$10$uOSckwMEixpnBwRVp6ZoeOG9hQPbxXp.I0UK6xTok8tKK7G5f6A46', 'CREATED','user1');
-insert into role_entity (user_id,roles) values ('user1', 'ROLE_USER');
-insert into user_entity (email,name,password,status,id) values ('testEmail','applicationOwner', '$2a$10$uOSckwMEixpnBwRVp6ZoeOG9hQPbxXp.I0UK6xTok8tKK7G5f6A46', 'CREATED','user2');
-insert into role_entity (user_id,roles) values ('user2', 'ROLE_USER');
+insert into user_entity (email,name,password,status,id) values ('ownerEmail','applicationOwner', '$2a$10$uOSckwMEixpnBwRVp6ZoeOG9hQPbxXp.I0UK6xTok8tKK7G5f6A46', 'CREATED',  X'923a6407a5f84e1ebffd0621910ddfc8');
+insert into role_entity (user_id,roles) values (X'923a6407a5f84e1ebffd0621910ddfc8', 'ROLE_USER');
+insert into user_entity (email,name,password,status,id) values ('testEmail','applicationOwner', '$2a$10$uOSckwMEixpnBwRVp6ZoeOG9hQPbxXp.I0UK6xTok8tKK7G5f6A46', 'CREATED', X'1e1973eb3fb947ac9342c16cd63ffc6f');
+insert into role_entity (user_id,roles) values (X'1e1973eb3fb947ac9342c16cd63ffc6f', 'ROLE_USER');
 
 -- 워크스페이스 생성
-insert into workspace_entity (description,owner_id,title,id) values ('testDescription', 'user1', 'testTitle', 'workspace1');
+insert into workspace_entity (description,owner_id,title,id) values ('testDescription', X'923a6407a5f84e1ebffd0621910ddfc8', 'testTitle', X'd57b42f55cc4440b8dceb4fc2e372eff');
 
 -- 애플리케이션 생성
-insert into application_entity (application_type,description,external_port,failure_reason,github_url,name,port,status,version,workspace_id,id) values ('SPRING_BOOT','testDescription', 8080, NULL, 'testUrl', 'testName', 8080, 'STOPPED','17','workspace1','testId');
+insert into application_entity (application_type,description,external_port,failure_reason,github_url,name,port,status,version,workspace_id,id) values ('SPRING_BOOT','testDescription', 8080, NULL, 'testUrl', 'testName', 8080, 'STOPPED','17', X'd57b42f55cc4440b8dceb4fc2e372eff', X'2fb0f3158272422f8e9fc4f765c022b2');


### PR DESCRIPTION
## 개요
* 엔티티의 id를 UUID로 리펙토링합니다.
## 작업내용
* 엔티티의 id를 UUID로 수정
* 엔티티 도메인 어뎁터에서 id가 UUID로 수정된 부분 반영
* persistence 어뎁터에서 id가 UUID로 수정된 부분 반영
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [ ] pr에서 작업할 내용외에 작업한 내용이 있나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- 데이터 저장 및 조회 과정에서 고유 식별자 관리 방식을 표준화하여 데이터 일관성과 시스템 안정성이 향상되었습니다.
	- 내부 데이터 변환 로직 개선을 통해 전반적인 신뢰성과 성능을 강화했습니다.
	- 테스트 케이스에서 사용자 및 응용 프로그램 ID를 UUID 형식으로 변경하여 보다 일관된 데이터 처리 방식을 적용했습니다.
	- SQL 스크립트에서 ID 필드의 데이터 유형을 문자열에서 이진 형식으로 변경하여 데이터베이스의 효율성을 높였습니다.
	- 사용자 및 응용 프로그램 관련 메서드의 ID 처리 방식을 UUID로 수정하여 데이터 일관성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->