### PR TITLE
🔀 :: [#565] - 이메일 인증 코드에 사용 용도 필드 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/annotation/CheckEmailCertificate.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/annotation/CheckEmailCertificate.kt
@@ -1,7 +1,10 @@
 package com.dcd.server.core.common.annotation
 
+import com.dcd.server.core.domain.auth.model.enums.EmailAuthUsage
+
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.FUNCTION)
 annotation class CheckEmailCertificate(
-    val target: String
+    val target: String,
+    val usage: EmailAuthUsage
 )

--- a/src/main/kotlin/com/dcd/server/core/common/aop/EmailCertificateAspect.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/aop/EmailCertificateAspect.kt
@@ -39,7 +39,7 @@ class EmailCertificateAspect(
             ?: throw InvalidParsingObjectFieldException()
 
         val emailAuthList = queryEmailAuthPort.findByEmail(email)
-            .filter { it.certificate }
+            .filter { it.certificate && it.usage == annotation.usage}
         if (emailAuthList.isEmpty())
             throw NotCertificateEmailException()
 

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/dto/request/EmailSendReqDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/dto/request/EmailSendReqDto.kt
@@ -1,5 +1,8 @@
 package com.dcd.server.core.domain.auth.dto.request
 
+import com.dcd.server.core.domain.auth.model.enums.EmailAuthUsage
+
 data class EmailSendReqDto(
-    val email: String
+    val email: String,
+    val usage: EmailAuthUsage
 )

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/model/EmailAuth.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/model/EmailAuth.kt
@@ -1,9 +1,11 @@
 package com.dcd.server.core.domain.auth.model
 
+import com.dcd.server.core.domain.auth.model.enums.EmailAuthUsage
 import java.util.*
 
 data class EmailAuth(
     val email: String,
     val code: String = UUID.randomUUID().toString().split("-")[0],
-    val certificate: Boolean = false
+    val certificate: Boolean = false,
+    val usage: EmailAuthUsage
 )

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/model/enums/EmailAuthUsage.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/model/enums/EmailAuthUsage.kt
@@ -1,0 +1,6 @@
+package com.dcd.server.core.domain.auth.model.enums
+
+enum class EmailAuthUsage {
+    CHANGE_PASSWORD,
+    SIGNUP
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/service/EmailSendService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/service/EmailSendService.kt
@@ -1,5 +1,7 @@
 package com.dcd.server.core.domain.auth.service
 
+import com.dcd.server.core.domain.auth.model.enums.EmailAuthUsage
+
 interface EmailSendService {
-    suspend fun sendEmail(email: String)
+    suspend fun sendEmail(email: String, usage: EmailAuthUsage)
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/service/impl/EmailSendServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/service/impl/EmailSendServiceImpl.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.core.domain.auth.service.impl
 
 import com.dcd.server.core.domain.auth.model.EmailAuth
+import com.dcd.server.core.domain.auth.model.enums.EmailAuthUsage
 import com.dcd.server.core.domain.auth.service.EmailSendService
 import com.dcd.server.core.domain.auth.spi.CommandEmailAuthPort
 import kotlinx.coroutines.Dispatchers
@@ -14,8 +15,8 @@ class EmailSendServiceImpl(
     private val commandEmailAuthPort: CommandEmailAuthPort,
     private val emailSender: JavaMailSender,
 ) : EmailSendService{
-    override suspend fun sendEmail(email: String) {
-        val emailAuth = EmailAuth(email = email)
+    override suspend fun sendEmail(email: String, usage: EmailAuthUsage) {
+        val emailAuth = EmailAuth(email = email, usage = usage)
         val code = emailAuth.code
 
         withContext(Dispatchers.IO) {

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/AuthMailSendUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/AuthMailSendUseCase.kt
@@ -13,7 +13,7 @@ class AuthMailSendUseCase(
 ) : CoroutineScope by CoroutineScope(Dispatchers.IO){
     fun execute(emailSendReqDto: EmailSendReqDto) {
         launch {
-            emailSendService.sendEmail(emailSendReqDto.email)
+            emailSendService.sendEmail(emailSendReqDto.email, emailSendReqDto.usage)
         }
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/NonAuthChangePasswordUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/NonAuthChangePasswordUseCase.kt
@@ -4,6 +4,7 @@ import com.dcd.server.core.common.annotation.CheckEmailCertificate
 import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.domain.auth.dto.request.NonAuthChangePasswordReqDto
 import com.dcd.server.core.domain.auth.exception.UserNotFoundException
+import com.dcd.server.core.domain.auth.model.enums.EmailAuthUsage
 import com.dcd.server.core.domain.user.spi.CommandUserPort
 import com.dcd.server.core.domain.user.spi.QueryUserPort
 import org.springframework.security.crypto.password.PasswordEncoder
@@ -14,7 +15,7 @@ class NonAuthChangePasswordUseCase(
     private val commandUserPort: CommandUserPort,
     private val passwordEncoder: PasswordEncoder
 ) {
-    @CheckEmailCertificate("#nonAuthChangePasswordReqDto")
+    @CheckEmailCertificate("#nonAuthChangePasswordReqDto", EmailAuthUsage.CHANGE_PASSWORD)
     fun execute(nonAuthChangePasswordReqDto: NonAuthChangePasswordReqDto) {
         val user = queryUserPort.findByEmail(nonAuthChangePasswordReqDto.email)
             ?: throw UserNotFoundException()

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/SignUpUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/SignUpUseCase.kt
@@ -6,6 +6,7 @@ import com.dcd.server.core.common.service.SecurityService
 import com.dcd.server.core.domain.auth.dto.extension.toEntity
 import com.dcd.server.core.domain.auth.dto.request.SignUpReqDto
 import com.dcd.server.core.domain.auth.exception.AlreadyExistsUserException
+import com.dcd.server.core.domain.auth.model.enums.EmailAuthUsage
 import com.dcd.server.core.domain.user.spi.CommandUserPort
 import com.dcd.server.core.domain.user.spi.QueryUserPort
 
@@ -15,7 +16,7 @@ class SignUpUseCase(
     private val commandUserPort: CommandUserPort,
     private val queryUserPort: QueryUserPort
 ) {
-    @CheckEmailCertificate("#signUpReqDto")
+    @CheckEmailCertificate("#signUpReqDto", EmailAuthUsage.SIGNUP)
     fun execute(signUpReqDto: SignUpReqDto) {
         if(queryUserPort.existsByEmail(signUpReqDto.email))
             throw AlreadyExistsUserException()

--- a/src/main/kotlin/com/dcd/server/persistence/auth/adapter/EmailAuthAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/auth/adapter/EmailAuthAdapter.kt
@@ -7,12 +7,14 @@ fun EmailAuth.toEntity(): EmailAuthEntity =
     EmailAuthEntity(
         email = this.email,
         code = this.code,
-        certificate = this.certificate
+        certificate = this.certificate,
+        usage = this.usage
     )
 
 fun EmailAuthEntity.toDomain(): EmailAuth =
     EmailAuth(
         email = this.email,
         code = this.code,
-        certificate = this.certificate
+        certificate = this.certificate,
+        usage = this.usage
     )

--- a/src/main/kotlin/com/dcd/server/persistence/auth/entity/EmailAuthEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/auth/entity/EmailAuthEntity.kt
@@ -1,5 +1,8 @@
 package com.dcd.server.persistence.auth.entity
 
+import com.dcd.server.core.domain.auth.model.enums.EmailAuthUsage
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import org.springframework.data.annotation.Id
 import org.springframework.data.redis.core.RedisHash
 import org.springframework.data.redis.core.index.Indexed
@@ -11,5 +14,7 @@ class EmailAuthEntity(
     @Id
     @Indexed
     val code: String,
-    val certificate: Boolean
+    val certificate: Boolean,
+    @Enumerated(EnumType.STRING)
+    val usage: EmailAuthUsage
 )

--- a/src/main/kotlin/com/dcd/server/persistence/auth/entity/EmailAuthEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/auth/entity/EmailAuthEntity.kt
@@ -1,8 +1,6 @@
 package com.dcd.server.persistence.auth.entity
 
 import com.dcd.server.core.domain.auth.model.enums.EmailAuthUsage
-import jakarta.persistence.EnumType
-import jakarta.persistence.Enumerated
 import org.springframework.data.annotation.Id
 import org.springframework.data.redis.core.RedisHash
 import org.springframework.data.redis.core.index.Indexed
@@ -15,6 +13,5 @@ class EmailAuthEntity(
     @Indexed
     val code: String,
     val certificate: Boolean,
-    @Enumerated(EnumType.STRING)
     val usage: EmailAuthUsage
 )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/auth/data/exetension/AuthRequestDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/auth/data/exetension/AuthRequestDataExtension.kt
@@ -5,7 +5,8 @@ import com.dcd.server.presentation.domain.auth.data.request.*
 
 fun EmailSendRequest.toDto(): EmailSendReqDto =
     EmailSendReqDto(
-        email = this.email
+        email = this.email,
+        usage = this.usage
     )
 
 fun CertificateMailRequest.toDto(): CertificateMailReqDto =

--- a/src/main/kotlin/com/dcd/server/presentation/domain/auth/data/request/EmailSendRequest.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/auth/data/request/EmailSendRequest.kt
@@ -1,10 +1,12 @@
 package com.dcd.server.presentation.domain.auth.data.request
 
+import com.dcd.server.core.domain.auth.model.enums.EmailAuthUsage
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
 
 data class EmailSendRequest(
     @field:NotBlank
     @field:Email
-    val email: String
+    val email: String,
+    val usage: EmailAuthUsage
 )

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/service/EmailSendServiceTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/service/EmailSendServiceTest.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.core.domain.auth.service
 
+import com.dcd.server.core.domain.auth.model.enums.EmailAuthUsage
 import com.dcd.server.core.domain.auth.service.impl.EmailSendServiceImpl
 import com.dcd.server.core.domain.auth.spi.CommandEmailAuthPort
 import io.kotest.core.spec.style.BehaviorSpec
@@ -17,7 +18,7 @@ class EmailSendServiceTest : BehaviorSpec({
     given("이메일이 주어지고") {
         val testEmail = "testEmail"
         `when`("이메일을 보낼때") {
-            emailSendService.sendEmail(testEmail)
+            emailSendService.sendEmail(testEmail, EmailAuthUsage.SIGNUP)
             every { commandEmailAuthPort.save(any()) } returns Unit
             then("메일을 보내고 mailAuth를 save해야함") {
                 verify { mailSender.send(any<MimeMessage>()) }

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/service/VerifyEmailAuthServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/service/VerifyEmailAuthServiceImplTest.kt
@@ -4,6 +4,7 @@ import com.dcd.server.core.domain.auth.exception.ExpiredCodeException
 import com.dcd.server.core.domain.auth.exception.InvalidAuthCodeException
 import com.dcd.server.core.domain.auth.exception.NotFoundAuthCodeException
 import com.dcd.server.core.domain.auth.model.EmailAuth
+import com.dcd.server.core.domain.auth.model.enums.EmailAuthUsage
 import com.dcd.server.core.domain.auth.service.impl.VerifyEmailAuthServiceImpl
 import com.dcd.server.core.domain.auth.spi.CommandEmailAuthPort
 import com.dcd.server.core.domain.auth.spi.QueryEmailAuthPort
@@ -40,7 +41,7 @@ class VerifyEmailAuthServiceImplTest : BehaviorSpec({
             }
 
             every { queryEmailAuthPort.existsByCodeAndEmail(testEmail, testCode) } returns true
-            every { queryEmailAuthPort.findByCode(testCode) } returns EmailAuth(testEmail, testCode, false)
+            every { queryEmailAuthPort.findByCode(testCode) } returns EmailAuth(testEmail, testCode, false, EmailAuthUsage.SIGNUP)
             every { commandEmailAuthPort.save(any()) } answers { callOriginal() }
             serviceImpl.verifyCode(testEmail, testCode)
             then("코드도 올바르면 업데이트 되야함") {

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/AuthMailSendUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/AuthMailSendUseCaseTest.kt
@@ -2,6 +2,7 @@ package com.dcd.server.core.domain.auth.usecase
 
 import com.dcd.server.ServerApplication
 import com.dcd.server.core.domain.auth.dto.request.EmailSendReqDto
+import com.dcd.server.core.domain.auth.model.enums.EmailAuthUsage
 import com.dcd.server.core.domain.auth.service.EmailSendService
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.BehaviorSpec
@@ -19,11 +20,11 @@ class AuthMailSendUseCaseTest(
 
     given("EmailSendRequestData가 주어지고") {
         val testEmail = "testEmail"
-        val request = EmailSendReqDto(testEmail)
+        val request = EmailSendReqDto(testEmail, EmailAuthUsage.SIGNUP)
         `when`("execute메서드를 실행할때") {
             authMailSendUseCase.execute(request)
             then("emailSendService의 sendEmail메서드를 실행해아함") {
-                coVerify { emailSendService.sendEmail(testEmail) }
+                coVerify { emailSendService.sendEmail(testEmail, EmailAuthUsage.SIGNUP) }
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/AuthenticateMailUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/AuthenticateMailUseCaseTest.kt
@@ -5,6 +5,7 @@ import com.dcd.server.core.domain.auth.dto.request.CertificateMailReqDto
 import com.dcd.server.core.domain.auth.exception.InvalidAuthCodeException
 import com.dcd.server.core.domain.auth.exception.NotFoundAuthCodeException
 import com.dcd.server.core.domain.auth.model.EmailAuth
+import com.dcd.server.core.domain.auth.model.enums.EmailAuthUsage
 import com.dcd.server.core.domain.auth.spi.CommandEmailAuthPort
 import com.dcd.server.core.domain.auth.spi.QueryEmailAuthPort
 import io.kotest.assertions.throwables.shouldThrow
@@ -27,7 +28,7 @@ class AuthenticateMailUseCaseTest(
     val targetCode = "testCode"
 
     beforeSpec {
-        val emailAuth = EmailAuth(email = targetEmail, code = targetCode)
+        val emailAuth = EmailAuth(email = targetEmail, code = targetCode, usage = EmailAuthUsage.SIGNUP)
         commandEmailAuthPort.save(emailAuth)
     }
 

--- a/src/test/kotlin/com/dcd/server/persistence/auth/EmailAuthPersistenceAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/persistence/auth/EmailAuthPersistenceAdapterTest.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.persistence.auth
 
 import com.dcd.server.core.domain.auth.model.EmailAuth
+import com.dcd.server.core.domain.auth.model.enums.EmailAuthUsage
 import com.dcd.server.persistence.auth.adapter.toEntity
 import com.dcd.server.persistence.auth.repository.EmailAuthRepository
 import io.kotest.core.spec.style.BehaviorSpec
@@ -17,7 +18,7 @@ class EmailAuthPersistenceAdapterTest : BehaviorSpec({
     given("이메일 인증객체가 주어지고") {
         val testCode = "testCode"
         val testEmail = "testEmail"
-        val emailAuth = EmailAuth(testEmail, testCode)
+        val emailAuth = EmailAuth(testEmail, testCode, usage = EmailAuthUsage.SIGNUP)
         val emailAuthEntity = emailAuth.toEntity()
 
         `when`("save를 실행할때") {

--- a/src/test/kotlin/com/dcd/server/presentation/domain/auth/AuthWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/auth/AuthWebAdapterTest.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.presentation.domain.auth
 
 import com.dcd.server.core.domain.auth.dto.response.TokenResDto
+import com.dcd.server.core.domain.auth.model.enums.EmailAuthUsage
 import com.dcd.server.core.domain.auth.usecase.*
 import com.dcd.server.presentation.domain.auth.data.exetension.toDto
 import com.dcd.server.presentation.domain.auth.data.exetension.toReissueResponse
@@ -36,7 +37,7 @@ class AuthWebAdapterTest : BehaviorSpec({
 
     given("EmailSendRequest가 주어지고") {
         val testEmail = "testEmail"
-        val request = EmailSendRequest(testEmail)
+        val request = EmailSendRequest(testEmail, EmailAuthUsage.SIGNUP)
 
         `when`("sendEmail 메서드를 실행할때") {
             every { authMailSendUseCase.execute(any()) } returns Unit


### PR DESCRIPTION
## 개요
* 이메일 인증 코드에 사용 용도의 필드를 추가합니다.
## 작업내용
* EmailAuthUsage 추가
* 이메일 인증 코드에 usage 필드 추가
* 이메일 인증 코드 전송시 usage를 사용하도록 수정
* 이메일 인증 코드 검증 joinPoint에서 usage를 검사하도록 수정
* 테스트 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [ ] pr에서 작업할 내용외에 작업한 내용이 있나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 이메일 인증 프로세스가 강화되어, 회원가입 및 비밀번호 변경 등 각 상황에 맞는 인증 절차가 보다 정확해졌습니다.
  - 이메일 전송 요청에 사용 목적 정보가 추가되어, 인증 요청의 명확성과 보안성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->