### PR TITLE
🔀 :: [#567] - AOP에 적용된 표현식 수정

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/AddApplicationEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/AddApplicationEnvUseCase.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.core.domain.application.usecase
 
+import com.dcd.server.core.common.annotation.Lock
 import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.common.data.WorkspaceInfo
 import com.dcd.server.core.domain.application.dto.request.AddApplicationEnvReqDto
@@ -15,6 +16,7 @@ class AddApplicationEnvUseCase(
     private val commandApplicationPort: CommandApplicationPort,
     private val workspaceInfo: WorkspaceInfo
 ) {
+    @Lock("#id")
     fun execute(id: String, addApplicationEnvReqDto: AddApplicationEnvReqDto) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
@@ -27,6 +29,7 @@ class AddApplicationEnvUseCase(
         commandApplicationPort.save(application.copy(env = envMutable))
     }
 
+    @Lock("#labels")
     fun execute(labels: List<String>, addApplicationEnvReqDto: AddApplicationEnvReqDto) {
         val workspace = workspaceInfo.workspace
             ?: throw WorkspaceNotFoundException()

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationEnvUseCase.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.core.domain.application.usecase
 
+import com.dcd.server.core.common.annotation.Lock
 import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.common.data.WorkspaceInfo
 import com.dcd.server.core.domain.application.exception.ApplicationEnvNotFoundException
@@ -14,6 +15,7 @@ class DeleteApplicationEnvUseCase(
     private val commandApplicationPort: CommandApplicationPort,
     private val workspaceInfo: WorkspaceInfo
 ) {
+    @Lock("#id+#key")
     fun execute(id: String, key: String) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
@@ -23,6 +25,7 @@ class DeleteApplicationEnvUseCase(
         commandApplicationPort.save(application.copy(env = updatedEnv))
     }
 
+    @Lock("#labels+#key")
     fun execute(labels: List<String>, key: String) {
         val workspace = (workspaceInfo.workspace
             ?: throw WorkspaceNotFoundException())

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationEnvUseCase.kt
@@ -25,7 +25,7 @@ class DeleteApplicationEnvUseCase(
         commandApplicationPort.save(application.copy(env = updatedEnv))
     }
 
-    @Lock("#labels+#key")
+    @Lock("'labels_'+#key")
     fun execute(labels: List<String>, key: String) {
         val workspace = (workspaceInfo.workspace
             ?: throw WorkspaceNotFoundException())

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationEnvUseCase.kt
@@ -34,7 +34,7 @@ class UpdateApplicationEnvUseCase(
         )
     }
 
-    @Lock("#labels+#envKey")
+    @Lock("'labels_'+#envKey")
     fun execute(labels: List<String>, envKey: String, updateApplicationEnvReqDto: UpdateApplicationEnvReqDto) {
         val workspace = (workspaceInfo.workspace
             ?: throw WorkspaceNotFoundException())

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/NonAuthChangePasswordUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/NonAuthChangePasswordUseCase.kt
@@ -15,7 +15,7 @@ class NonAuthChangePasswordUseCase(
     private val commandUserPort: CommandUserPort,
     private val passwordEncoder: PasswordEncoder
 ) {
-    @CheckEmailCertificate("#nonAuthChangePasswordReqDto", EmailAuthUsage.CHANGE_PASSWORD)
+    @CheckEmailCertificate("#nonAuthChangePasswordReqDto.email", EmailAuthUsage.CHANGE_PASSWORD)
     fun execute(nonAuthChangePasswordReqDto: NonAuthChangePasswordReqDto) {
         val user = queryUserPort.findByEmail(nonAuthChangePasswordReqDto.email)
             ?: throw UserNotFoundException()

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/SignUpUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/SignUpUseCase.kt
@@ -16,7 +16,7 @@ class SignUpUseCase(
     private val commandUserPort: CommandUserPort,
     private val queryUserPort: QueryUserPort
 ) {
-    @CheckEmailCertificate("#signUpReqDto", EmailAuthUsage.SIGNUP)
+    @CheckEmailCertificate("#signUpReqDto.email", EmailAuthUsage.SIGNUP)
     fun execute(signUpReqDto: SignUpReqDto) {
         if(queryUserPort.existsByEmail(signUpReqDto.email))
             throw AlreadyExistsUserException()

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/AddGlobalEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/AddGlobalEnvUseCase.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.core.domain.workspace.usecase
 
+import com.dcd.server.core.common.annotation.Lock
 import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.domain.workspace.dto.request.AddGlobalEnvReqDto
 import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
@@ -13,6 +14,7 @@ class AddGlobalEnvUseCase(
     private val commandWorkspacePort: CommandWorkspacePort,
     private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService
 ) {
+    @Lock("#workspaceId")
     fun execute(workspaceId: String, addGlobalEnvReqDto: AddGlobalEnvReqDto) {
         val workspace = (queryWorkspacePort.findById(workspaceId)
             ?: throw WorkspaceNotFoundException())

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteGlobalEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/DeleteGlobalEnvUseCase.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.core.domain.workspace.usecase
 
+import com.dcd.server.core.common.annotation.Lock
 import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.domain.workspace.exception.GlobalEnvNotFoundException
 import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
@@ -13,6 +14,7 @@ class DeleteGlobalEnvUseCase(
     private val commandWorkspacePort: CommandWorkspacePort,
     private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService
 ) {
+    @Lock("#workspaceId+#key")
     fun execute(workspaceId: String, key: String) {
         val workspace = (queryWorkspacePort.findById(workspaceId)
             ?: throw WorkspaceNotFoundException())

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/UpdateGlobalEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/UpdateGlobalEnvUseCase.kt
@@ -15,7 +15,7 @@ class UpdateGlobalEnvUseCase(
     private val commandWorkspacePort: CommandWorkspacePort,
     private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService
 ) {
-    @Lock("#workspaceId+#enbKey")
+    @Lock("#workspaceId+#envKey")
     fun execute(workspaceId: String, envKey: String, updateGlobalEnvReqDto: UpdateGlobalEnvReqDto) {
         val workspace = (queryWorkspacePort.findById(workspaceId)
             ?: throw WorkspaceNotFoundException())

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/UpdateGlobalEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/UpdateGlobalEnvUseCase.kt
@@ -15,7 +15,7 @@ class UpdateGlobalEnvUseCase(
     private val commandWorkspacePort: CommandWorkspacePort,
     private val validateWorkspaceOwnerService: ValidateWorkspaceOwnerService
 ) {
-    @Lock("#workspaceId")
+    @Lock("#workspaceId+#enbKey")
     fun execute(workspaceId: String, envKey: String, updateGlobalEnvReqDto: UpdateGlobalEnvReqDto) {
         val workspace = (queryWorkspacePort.findById(workspaceId)
             ?: throw WorkspaceNotFoundException())


### PR DESCRIPTION
## 개요
* AOP에 적용된 표현식을 수정합니다.
## 작업내용
* EmailCertificateAspect에서 표현식으로 바로 email을 받도록 수정
* CheckEmailCertificate 어노테이션을 사용하는 표현식 수정
* 환경변수 추가 로직에 Lock 적용
* 황경변수 삭제 로직에 Lock 적용
* 전역 환경변수 수정 로직의 Lock 표현식 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [ ] pr에서 작업할 내용외에 작업한 내용이 있나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 환경 관리 작업 시 동시성 제어가 강화되어 여러 작업이 원활하고 안정적으로 처리됩니다.
  
- **리팩토링**
  - 사용자 인증 및 비밀번호 변경 과정에서 이메일 확인 절차를 세분화하여, 보다 정확하고 일관된 인증 흐름을 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->