### PR TITLE
🔀 :: [#575] - 애플리케이션 커맨드 실행 리펙토링

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/ExecContainerService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/ExecContainerService.kt
@@ -4,5 +4,6 @@ import com.dcd.server.core.domain.application.model.Application
 import org.springframework.web.socket.WebSocketSession
 
 interface ExecContainerService {
+    fun execCmd(application: Application, cmd: String): List<String>
     fun execCmd(application: Application, session: WebSocketSession, cmd: String)
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExecContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExecContainerServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.core.domain.application.service.impl
 
+import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.service.ExecContainerService
 import com.github.dockerjava.api.DockerClient
@@ -14,7 +15,14 @@ import java.util.Stack
 @Service
 class ExecContainerServiceImpl(
     private val dockerClient: DockerClient,
+    private val commandPort: CommandPort
 ) : ExecContainerService {
+    override fun execCmd(application: Application, cmd: String): List<String> =
+        commandPort
+            .executeShellCommandWithResult(
+                "docker exec ${application.containerName} sh -c 'cd / && $cmd'"
+            )
+
     override fun execCmd(application: Application, session: WebSocketSession, cmd: String) {
         val cmdArray = cmd.split(" ").toTypedArray()
 

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCase.kt
@@ -1,7 +1,6 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
-import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.domain.application.dto.request.ExecuteCommandReqDto
 import com.dcd.server.core.domain.application.dto.response.CommandResultResDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
@@ -20,8 +19,7 @@ import org.springframework.web.socket.WebSocketSession
 class ExecuteCommandUseCase(
     private val queryApplicationPort: QueryApplicationPort,
     private val execContainerService: ExecContainerService,
-    private val parseTokenAdapter: ParseTokenAdapter,
-    private val commandPort: CommandPort
+    private val parseTokenAdapter: ParseTokenAdapter
 ) {
     fun execute(applicationId: String, executeCommandReqDto: ExecuteCommandReqDto): CommandResultResDto {
         validateCmd(executeCommandReqDto.command)
@@ -32,8 +30,7 @@ class ExecuteCommandUseCase(
         if (application.status != ApplicationStatus.RUNNING)
             throw InvalidApplicationStatusException()
 
-        val result =
-            commandPort.executeShellCommandWithResult("docker exec ${application.containerName} sh -c 'cd / && ${executeCommandReqDto.command}'")
+        val result = execContainerService.execCmd(application, executeCommandReqDto.command)
 
         return CommandResultResDto(result)
     }


### PR DESCRIPTION
## 개요
* 애플리케이션에 커맨드를 실행할때 webSocket을 사용하지 않을때도 ExecContainerService를 사용하도록 수정합니다.
## 작업내용
* 애플리케이션에 단일 커맨드를 실행하는 인터페이스의 멤버 함수 추가
* 애플리케이션에 단일 커맨드를 실행하는 인터페이스의 멤버 함수 구현
* ExecuteCommandUseCase에서 커맨드 실행시 execContainerService를 사용하도록 수정
* 테스트 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [ ] pr에서 작업할 내용외에 작업한 내용이 있나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- WebSocket 세션 없이도 커맨드를 실행할 수 있는 기능이 추가되었습니다.
- **리팩토링**
	- 명령 실행 로직이 서비스 기반 방식으로 전환되어 처리 방식이 간소화되었습니다.
- **테스트**
	- 커맨드 실행 관련 테스트가 업데이트되어 새로운 기능을 반영합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->