### PR TITLE
🔀 :: [#581] - 리스트 응답 객체 리펙토링

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/data/dto/response/ListResDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/data/dto/response/ListResDto.kt
@@ -1,0 +1,5 @@
+package com.dcd.server.core.common.data.dto.response
+
+data class ListResDto<T>(
+    val list: List<T>
+)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/response/ApplicationListResDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/response/ApplicationListResDto.kt
@@ -1,5 +1,0 @@
-package com.dcd.server.core.domain.application.dto.response
-
-data class ApplicationListResDto(
-    val list: List<ApplicationResDto>
-)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/response/ApplicationTypeListResDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/response/ApplicationTypeListResDto.kt
@@ -1,5 +1,0 @@
-package com.dcd.server.core.domain.application.dto.response
-
-data class ApplicationTypeListResDto(
-    val list: List<String>
-)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCase.kt
@@ -4,7 +4,6 @@ import com.dcd.server.core.common.annotation.ReadOnlyUseCase
 import com.dcd.server.core.common.data.WorkspaceInfo
 import com.dcd.server.core.common.data.dto.response.ListResDto
 import com.dcd.server.core.domain.application.dto.extenstion.toDto
-import com.dcd.server.core.domain.application.dto.response.ApplicationListResDto
 import com.dcd.server.core.domain.application.dto.response.ApplicationResDto
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCase.kt
@@ -2,8 +2,10 @@ package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.ReadOnlyUseCase
 import com.dcd.server.core.common.data.WorkspaceInfo
+import com.dcd.server.core.common.data.dto.response.ListResDto
 import com.dcd.server.core.domain.application.dto.extenstion.toDto
 import com.dcd.server.core.domain.application.dto.response.ApplicationListResDto
+import com.dcd.server.core.domain.application.dto.response.ApplicationResDto
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
 
@@ -12,11 +14,11 @@ class GetAllApplicationUseCase(
     private val queryApplicationPort: QueryApplicationPort,
     private val workspaceInfo: WorkspaceInfo
 ) {
-    fun execute(labels: List<String>?): ApplicationListResDto {
+    fun execute(labels: List<String>?): ListResDto<ApplicationResDto> {
         val workspace = workspaceInfo.workspace
             ?: throw WorkspaceNotFoundException()
 
-        return ApplicationListResDto(
+        return ListResDto(
             queryApplicationPort
                 .findAllByWorkspace(workspace, labels)
                 .map { it.toDto() }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationTypeUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationTypeUseCase.kt
@@ -1,14 +1,14 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.ReadOnlyUseCase
-import com.dcd.server.core.domain.application.dto.response.ApplicationTypeListResDto
+import com.dcd.server.core.common.data.dto.response.ListResDto
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 
 @ReadOnlyUseCase
 class GetApplicationTypeUseCase {
-    fun execute(): ApplicationTypeListResDto {
+    fun execute(): ListResDto<String> {
         val typeList = ApplicationType.values().map { it.name }
 
-        return ApplicationTypeListResDto(typeList)
+        return ListResDto(typeList)
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/user/dto/response/UserListResDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/user/dto/response/UserListResDto.kt
@@ -1,5 +1,0 @@
-package com.dcd.server.core.domain.user.dto.response
-
-data class UserListResDto(
-    val list: List<UserResDto>
-)

--- a/src/main/kotlin/com/dcd/server/core/domain/user/usecase/GetUserByStatusUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/user/usecase/GetUserByStatusUseCase.kt
@@ -1,8 +1,9 @@
 package com.dcd.server.core.domain.user.usecase
 
 import com.dcd.server.core.common.annotation.ReadOnlyUseCase
+import com.dcd.server.core.common.data.dto.response.ListResDto
 import com.dcd.server.core.domain.user.dto.extension.toDto
-import com.dcd.server.core.domain.user.dto.response.UserListResDto
+import com.dcd.server.core.domain.user.dto.response.UserResDto
 import com.dcd.server.core.domain.user.model.enums.Status
 import com.dcd.server.core.domain.user.spi.QueryUserPort
 
@@ -10,10 +11,10 @@ import com.dcd.server.core.domain.user.spi.QueryUserPort
 class GetUserByStatusUseCase(
     private val queryUserPort: QueryUserPort
 ) {
-    fun execute(status: Status): UserListResDto {
+    fun execute(status: Status): ListResDto<UserResDto> {
         val userResDtoList = queryUserPort.findByStatus(status)
             .map { it.toDto() }
 
-        return UserListResDto(userResDtoList)
+        return ListResDto(userResDtoList)
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/dto/response/WorkspaceListResDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/dto/response/WorkspaceListResDto.kt
@@ -1,5 +1,0 @@
-package com.dcd.server.core.domain.workspace.dto.response
-
-data class WorkspaceListResDto(
-    val list: List<WorkspaceSimpleResDto>
-)

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/GetAllWorkspaceUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/GetAllWorkspaceUseCase.kt
@@ -1,11 +1,11 @@
 package com.dcd.server.core.domain.workspace.usecase
 
 import com.dcd.server.core.common.annotation.ReadOnlyUseCase
+import com.dcd.server.core.common.data.dto.response.ListResDto
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.user.service.GetCurrentUserService
-import com.dcd.server.core.domain.workspace.dto.extension.toDto
 import com.dcd.server.core.domain.workspace.dto.extension.toSimpleDto
-import com.dcd.server.core.domain.workspace.dto.response.WorkspaceListResDto
+import com.dcd.server.core.domain.workspace.dto.response.WorkspaceSimpleResDto
 import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
 
 @ReadOnlyUseCase
@@ -14,12 +14,12 @@ class GetAllWorkspaceUseCase(
     private val queryWorkspacePort: QueryWorkspacePort,
     private val queryApplicationPort: QueryApplicationPort
 ) {
-    fun execute(): WorkspaceListResDto {
+    fun execute(): ListResDto<WorkspaceSimpleResDto> {
         val user = getCurrentUserService.getCurrentUser()
         val workspaceDtoList = queryWorkspacePort.findByUser(user).map {
             val applicationList = queryApplicationPort.findAllByWorkspace(it)
             it.toSimpleDto(applicationList)
         }
-        return WorkspaceListResDto(workspaceDtoList)
+        return ListResDto(workspaceDtoList)
     }
 }

--- a/src/main/kotlin/com/dcd/server/presentation/common/data/response/ListResponse.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/common/data/response/ListResponse.kt
@@ -1,0 +1,5 @@
+package com.dcd.server.presentation.common.data.response
+
+data class ListResponse<T>(
+    val list: List<T>
+)

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationStaticWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationStaticWebAdapter.kt
@@ -4,6 +4,7 @@ import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.usecase.GetApplicationTypeUseCase
 import com.dcd.server.core.domain.application.usecase.GetAvailableVersionUseCase
 import com.dcd.server.presentation.common.annotation.WebAdapter
+import com.dcd.server.presentation.common.data.response.ListResponse
 import com.dcd.server.presentation.domain.application.data.exetension.toResponse
 import com.dcd.server.presentation.domain.application.data.response.ApplicationTypeListResponse
 import com.dcd.server.presentation.domain.application.data.response.AvailableVersionResponse
@@ -22,7 +23,7 @@ class ApplicationStaticWebAdapter(
             .let { ResponseEntity.ok(it.toResponse()) }
 
     @GetMapping("/types")
-    fun getApplicationTypes(): ResponseEntity<ApplicationTypeListResponse> =
+    fun getApplicationTypes(): ResponseEntity<ListResponse<String>> =
         getApplicationTypeUseCase.execute()
-            .let { ResponseEntity.ok(it.toResponse()) }
+            .let { ResponseEntity.ok(ListResponse(it.list)) }
 }

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationStaticWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationStaticWebAdapter.kt
@@ -6,7 +6,6 @@ import com.dcd.server.core.domain.application.usecase.GetAvailableVersionUseCase
 import com.dcd.server.presentation.common.annotation.WebAdapter
 import com.dcd.server.presentation.common.data.response.ListResponse
 import com.dcd.server.presentation.domain.application.data.exetension.toResponse
-import com.dcd.server.presentation.domain.application.data.response.ApplicationTypeListResponse
 import com.dcd.server.presentation.domain.application.data.response.AvailableVersionResponse
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
@@ -3,6 +3,7 @@ package com.dcd.server.presentation.domain.application
 import com.dcd.server.core.common.annotation.WorkspaceOwnerVerification
 import com.dcd.server.core.domain.application.usecase.*
 import com.dcd.server.presentation.common.annotation.WebAdapter
+import com.dcd.server.presentation.common.data.response.ListResponse
 import com.dcd.server.presentation.domain.application.data.exetension.toDto
 import com.dcd.server.presentation.domain.application.data.exetension.toResponse
 import com.dcd.server.presentation.domain.application.data.request.*
@@ -67,9 +68,9 @@ class ApplicationWebAdapter(
     fun getAllApplication(
         @PathVariable workspaceId: String,
         @RequestParam(required = false) labels: List<String>? = null
-    ): ResponseEntity<ApplicationListResponse> =
+    ): ResponseEntity<ListResponse<ApplicationResponse>> =
         getAllApplicationUseCase.execute(labels)
-            .let { ResponseEntity.ok(it.toResponse()) }
+            .let { ResponseEntity.ok(ListResponse(it.list.map { resDto -> resDto.toResponse() })) }
 
     @GetMapping("/{applicationId}")
     @WorkspaceOwnerVerification("#workspaceId")

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationResponseDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationResponseDataExtension.kt
@@ -1,6 +1,5 @@
 package com.dcd.server.presentation.domain.application.data.exetension
 
-import com.dcd.server.core.domain.application.dto.extenstion.toWorkspaceDto
 import com.dcd.server.core.domain.application.dto.response.*
 import com.dcd.server.core.domain.workspace.dto.response.WorkspaceApplicationResDto
 import com.dcd.server.presentation.domain.application.data.response.*
@@ -20,11 +19,6 @@ fun ApplicationResDto.toResponse(): ApplicationResponse =
         status = this.status,
         failureReason = this.failureReason,
         labels = this.labels
-    )
-
-fun ApplicationListResDto.toResponse(): ApplicationListResponse =
-    ApplicationListResponse(
-        list = this.list.map { it.toResponse() }
     )
 
 fun ApplicationProfileResDto.toResponse(): ApplicationProfileResponse =
@@ -63,9 +57,4 @@ fun CommandResultResDto.toResponse(): CommandResultResponse =
 fun CreateApplicationResDto.toResponse(): CreateApplicationResponse =
     CreateApplicationResponse(
         applicationId = this.applicationId
-    )
-
-fun ApplicationTypeListResDto.toResponse(): ApplicationTypeListResponse =
-    ApplicationTypeListResponse(
-        list = this.list
     )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/response/ApplicationListResponse.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/response/ApplicationListResponse.kt
@@ -1,5 +1,0 @@
-package com.dcd.server.presentation.domain.application.data.response
-
-data class ApplicationListResponse(
-    val list: List<ApplicationResponse>
-)

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/response/ApplicationTypeListResponse.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/response/ApplicationTypeListResponse.kt
@@ -1,5 +1,0 @@
-package com.dcd.server.presentation.domain.application.data.response
-
-data class ApplicationTypeListResponse(
-    val list: List<String>
-)

--- a/src/main/kotlin/com/dcd/server/presentation/domain/user/UserWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/user/UserWebAdapter.kt
@@ -6,11 +6,13 @@ import com.dcd.server.core.domain.user.usecase.ChangeUserStatusUseCase
 import com.dcd.server.core.domain.user.usecase.GetUserByStatusUseCase
 import com.dcd.server.core.domain.user.usecase.GetUserProfileUseCase
 import com.dcd.server.presentation.common.annotation.WebAdapter
+import com.dcd.server.presentation.common.data.response.ListResponse
 import com.dcd.server.presentation.domain.user.data.exetension.toDto
 import com.dcd.server.presentation.domain.user.data.exetension.toResponse
 import com.dcd.server.presentation.domain.user.data.request.PasswordChangeRequest
 import com.dcd.server.presentation.domain.user.data.response.UserListResponse
 import com.dcd.server.presentation.domain.user.data.response.UserProfileResponse
+import com.dcd.server.presentation.domain.user.data.response.UserResponse
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
@@ -43,7 +45,7 @@ class UserWebAdapter(
             .run { ResponseEntity.ok().build() }
 
     @GetMapping
-    fun getUserByStatus(@RequestParam status: Status): ResponseEntity<UserListResponse> =
+    fun getUserByStatus(@RequestParam status: Status): ResponseEntity<ListResponse<UserResponse>> =
         getUserStatusUseCase.execute(status)
-            .let { ResponseEntity.ok(it.toResponse()) }
+            .let { ResponseEntity.ok(ListResponse(it.list.map { resDto -> resDto.toResponse() })) }
 }

--- a/src/main/kotlin/com/dcd/server/presentation/domain/user/UserWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/user/UserWebAdapter.kt
@@ -10,7 +10,6 @@ import com.dcd.server.presentation.common.data.response.ListResponse
 import com.dcd.server.presentation.domain.user.data.exetension.toDto
 import com.dcd.server.presentation.domain.user.data.exetension.toResponse
 import com.dcd.server.presentation.domain.user.data.request.PasswordChangeRequest
-import com.dcd.server.presentation.domain.user.data.response.UserListResponse
 import com.dcd.server.presentation.domain.user.data.response.UserProfileResponse
 import com.dcd.server.presentation.domain.user.data.response.UserResponse
 import org.springframework.http.ResponseEntity

--- a/src/main/kotlin/com/dcd/server/presentation/domain/user/data/exetension/UserResponseDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/user/data/exetension/UserResponseDataExtension.kt
@@ -1,9 +1,7 @@
 package com.dcd.server.presentation.domain.user.data.exetension
 
-import com.dcd.server.core.domain.user.dto.response.UserListResDto
 import com.dcd.server.core.domain.user.dto.response.UserProfileResDto
 import com.dcd.server.core.domain.user.dto.response.UserResDto
-import com.dcd.server.presentation.domain.user.data.response.UserListResponse
 import com.dcd.server.presentation.domain.user.data.response.UserProfileResponse
 import com.dcd.server.presentation.domain.user.data.response.UserResponse
 import com.dcd.server.presentation.domain.workspace.data.exetension.toResponse
@@ -20,9 +18,4 @@ fun UserProfileResDto.toResponse(): UserProfileResponse =
     UserProfileResponse(
         user = this.user.toResponse(),
         workspaces = this.workspaces.map { it.toResponse() }
-    )
-
-fun UserListResDto.toResponse(): UserListResponse =
-    UserListResponse(
-        list = this.list.map { it.toResponse() }
     )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/user/data/response/UserListResponse.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/user/data/response/UserListResponse.kt
@@ -1,5 +1,0 @@
-package com.dcd.server.presentation.domain.user.data.response
-
-data class UserListResponse(
-    val list: List<UserResponse>
-)

--- a/src/main/kotlin/com/dcd/server/presentation/domain/workspace/WorkspaceWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/workspace/WorkspaceWebAdapter.kt
@@ -2,6 +2,7 @@ package com.dcd.server.presentation.domain.workspace
 
 import com.dcd.server.core.domain.workspace.usecase.*
 import com.dcd.server.presentation.common.annotation.WebAdapter
+import com.dcd.server.presentation.common.data.response.ListResponse
 import com.dcd.server.presentation.domain.workspace.data.exetension.toDto
 import com.dcd.server.presentation.domain.workspace.data.exetension.toResponse
 import com.dcd.server.presentation.domain.workspace.data.request.AddGlobalEnvRequest
@@ -11,6 +12,7 @@ import com.dcd.server.presentation.domain.workspace.data.request.UpdateWorkspace
 import com.dcd.server.presentation.domain.workspace.data.response.CreateWorkspaceResponse
 import com.dcd.server.presentation.domain.workspace.data.response.WorkspaceListResponse
 import com.dcd.server.presentation.domain.workspace.data.response.WorkspaceResponse
+import com.dcd.server.presentation.domain.workspace.data.response.WorkspaceSimpleResponse
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
@@ -36,9 +38,9 @@ class WorkspaceWebAdapter(
             .run { ResponseEntity(this.toResponse(), HttpStatus.CREATED) }
 
     @GetMapping
-    fun getAllWorkspace(): ResponseEntity<WorkspaceListResponse> =
+    fun getAllWorkspace(): ResponseEntity<ListResponse<WorkspaceSimpleResponse>> =
         getAllWorkspaceUseCase.execute()
-            .let { ResponseEntity.ok(it.toResponse()) }
+            .let { ResponseEntity.ok(ListResponse(it.list.map { resDto -> resDto.toResponse() })) }
 
     @GetMapping("/{workspaceId}")
     fun getOneWorkspace(@PathVariable workspaceId: String): ResponseEntity<WorkspaceResponse> =

--- a/src/main/kotlin/com/dcd/server/presentation/domain/workspace/WorkspaceWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/workspace/WorkspaceWebAdapter.kt
@@ -10,7 +10,6 @@ import com.dcd.server.presentation.domain.workspace.data.request.CreateWorkspace
 import com.dcd.server.presentation.domain.workspace.data.request.UpdateGlobalEnvRequest
 import com.dcd.server.presentation.domain.workspace.data.request.UpdateWorkspaceRequest
 import com.dcd.server.presentation.domain.workspace.data.response.CreateWorkspaceResponse
-import com.dcd.server.presentation.domain.workspace.data.response.WorkspaceListResponse
 import com.dcd.server.presentation.domain.workspace.data.response.WorkspaceResponse
 import com.dcd.server.presentation.domain.workspace.data.response.WorkspaceSimpleResponse
 import org.springframework.http.HttpStatus

--- a/src/main/kotlin/com/dcd/server/presentation/domain/workspace/data/exetension/WorkspaceResponseDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/workspace/data/exetension/WorkspaceResponseDataExtension.kt
@@ -23,11 +23,6 @@ fun WorkspaceSimpleResDto.toResponse(): WorkspaceSimpleResponse =
         applicationList = this.applicationList.map { it.toResponse() }
     )
 
-fun WorkspaceListResDto.toResponse(): WorkspaceListResponse =
-    WorkspaceListResponse(
-        list = this.list.map { it.toResponse() }
-    )
-
 fun WorkspaceProfileResDto.toResponse(): WorkspaceProfileResponse =
     WorkspaceProfileResponse(
         id = this.id,

--- a/src/main/kotlin/com/dcd/server/presentation/domain/workspace/data/response/WorkspaceListResponse.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/workspace/data/response/WorkspaceListResponse.kt
@@ -1,5 +1,0 @@
-package com.dcd.server.presentation.domain.workspace.data.response
-
-data class WorkspaceListResponse(
-    val list: List<WorkspaceSimpleResponse>
-)

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCaseTest.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.data.WorkspaceInfo
+import com.dcd.server.core.common.data.dto.response.ListResDto
 import com.dcd.server.core.domain.application.dto.extenstion.toDto
 import com.dcd.server.core.domain.application.dto.response.ApplicationListResDto
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
@@ -41,7 +42,7 @@ class GetAllApplicationUseCaseTest(
 
         `when`("usecase를 실행할때") {
             val result = getAllApplicationUseCase.execute(null)
-            val target = ApplicationListResDto(applicationList.map { it.toDto() })
+            val target = ListResDto(applicationList.map { it.toDto() })
             then("result는 target이랑 같아야함") {
                 result shouldBe target
             }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCaseTest.kt
@@ -3,7 +3,6 @@ package com.dcd.server.core.domain.application.usecase
 import com.dcd.server.core.common.data.WorkspaceInfo
 import com.dcd.server.core.common.data.dto.response.ListResDto
 import com.dcd.server.core.domain.application.dto.extenstion.toDto
-import com.dcd.server.core.domain.application.dto.response.ApplicationListResDto
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.user.spi.QueryUserPort
 import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -1,11 +1,13 @@
 package com.dcd.server.presentation.domain.application
 
+import com.dcd.server.core.common.data.dto.response.ListResDto
 import com.dcd.server.core.domain.application.dto.request.ExecuteCommandReqDto
 import com.dcd.server.core.domain.application.dto.request.UpdateApplicationReqDto
 import com.dcd.server.core.domain.application.dto.response.*
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.usecase.*
+import com.dcd.server.presentation.common.data.response.ListResponse
 import com.dcd.server.presentation.domain.application.data.exetension.toResponse
 import com.dcd.server.presentation.domain.application.data.request.*
 import io.kotest.core.spec.style.BehaviorSpec
@@ -74,12 +76,12 @@ class ApplicationWebAdapterTest : BehaviorSpec({
             failureReason = null
         )
         val list = listOf(applicationResponse)
-        val responseDto = ApplicationListResDto(list)
+        val responseDto = ListResDto(list)
         `when`("getAllApplication 메서드를 실행할때") {
             every { getAllApplicationUseCase.execute(null) } returns responseDto
             val response = applicationWebAdapter.getAllApplication(testWorkspaceId)
             then("응답바디는 targetResponse와 같아야하고 status는 200이여야함") {
-                val targetResponse = responseDto.toResponse()
+                val targetResponse = ListResponse(responseDto.list.map { it.toResponse() })
                 response.body shouldBe targetResponse
                 response.statusCode shouldBe HttpStatus.OK
             }

--- a/src/test/kotlin/com/dcd/server/presentation/domain/user/UserWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/user/UserWebAdapterTest.kt
@@ -3,7 +3,6 @@ package com.dcd.server.presentation.domain.user
 import com.dcd.server.core.common.data.dto.response.ListResDto
 import com.dcd.server.core.domain.auth.model.Role
 import com.dcd.server.core.domain.user.dto.extension.toDto
-import com.dcd.server.core.domain.user.dto.response.UserListResDto
 import com.dcd.server.core.domain.user.dto.response.UserProfileResDto
 import com.dcd.server.core.domain.user.model.enums.Status
 import com.dcd.server.core.domain.user.model.User

--- a/src/test/kotlin/com/dcd/server/presentation/domain/user/UserWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/user/UserWebAdapterTest.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.presentation.domain.user
 
+import com.dcd.server.core.common.data.dto.response.ListResDto
 import com.dcd.server.core.domain.auth.model.Role
 import com.dcd.server.core.domain.user.dto.extension.toDto
 import com.dcd.server.core.domain.user.dto.response.UserListResDto
@@ -10,6 +11,7 @@ import com.dcd.server.core.domain.user.usecase.ChangePasswordUseCase
 import com.dcd.server.core.domain.user.usecase.ChangeUserStatusUseCase
 import com.dcd.server.core.domain.user.usecase.GetUserByStatusUseCase
 import com.dcd.server.core.domain.user.usecase.GetUserProfileUseCase
+import com.dcd.server.presentation.common.data.response.ListResponse
 import com.dcd.server.presentation.domain.user.data.exetension.toResponse
 import com.dcd.server.presentation.domain.user.data.request.PasswordChangeRequest
 import io.kotest.core.spec.style.BehaviorSpec
@@ -78,15 +80,15 @@ class UserWebAdapterTest : BehaviorSpec({
 
         `when`("getUserByStatus 메서드를 실행할때") {
             val user = UserGenerator.generateUser()
-            val userListResDto = UserListResDto(listOf(user.toDto()))
+            val userListResDto = listOf(user.toDto())
 
-            every { getUserByStatusUseCase.execute(status) } returns userListResDto
+            every { getUserByStatusUseCase.execute(status) } returns ListResDto(userListResDto)
 
             val response = userWebAdapter.getUserByStatus(status)
 
             then("상태코드는 200이여야하고, 바디는 userListDto의 정보랑 같아야함") {
                 response.statusCode shouldBe HttpStatus.OK
-                response.body shouldBe userListResDto.toResponse()
+                response.body shouldBe ListResponse(userListResDto.map { it.toResponse() })
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/presentation/domain/workspace/WorkspaceWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/workspace/WorkspaceWebAdapterTest.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.presentation.domain.workspace
 
+import com.dcd.server.core.common.data.dto.response.ListResDto
 import com.dcd.server.core.domain.user.dto.response.UserResDto
 import com.dcd.server.core.domain.user.model.enums.Status
 import com.dcd.server.core.domain.workspace.dto.request.AddGlobalEnvReqDto
@@ -9,6 +10,7 @@ import com.dcd.server.core.domain.workspace.dto.request.UpdateWorkspaceReqDto
 import com.dcd.server.core.domain.workspace.dto.response.CreateWorkspaceResDto
 import com.dcd.server.core.domain.workspace.dto.response.WorkspaceListResDto
 import com.dcd.server.core.domain.workspace.dto.response.WorkspaceResDto
+import com.dcd.server.core.domain.workspace.dto.response.WorkspaceSimpleResDto
 import com.dcd.server.core.domain.workspace.usecase.*
 import com.dcd.server.presentation.domain.workspace.data.exetension.toDto
 import com.dcd.server.presentation.domain.workspace.data.exetension.toResponse
@@ -53,8 +55,8 @@ class WorkspaceWebAdapterTest : BehaviorSpec({
     }
 
     given("WorkspaceListResDto가 주어지고") {
-        val responseDto = WorkspaceListResDto(list = listOf())
-        every { getAllWorkspaceUseCase.execute() } returns responseDto
+        val responseDto = listOf<WorkspaceSimpleResDto>()
+        every { getAllWorkspaceUseCase.execute() } returns ListResDto(responseDto)
         `when`("getAllWorkspace 메서드를 실행할때") {
             val result = workspaceWebAdapter.getAllWorkspace()
             then("usecase를 실행해야함") {

--- a/src/test/kotlin/com/dcd/server/presentation/domain/workspace/WorkspaceWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/workspace/WorkspaceWebAdapterTest.kt
@@ -8,7 +8,6 @@ import com.dcd.server.core.domain.workspace.dto.request.CreateWorkspaceReqDto
 import com.dcd.server.core.domain.workspace.dto.request.UpdateGlobalEnvReqDto
 import com.dcd.server.core.domain.workspace.dto.request.UpdateWorkspaceReqDto
 import com.dcd.server.core.domain.workspace.dto.response.CreateWorkspaceResDto
-import com.dcd.server.core.domain.workspace.dto.response.WorkspaceListResDto
 import com.dcd.server.core.domain.workspace.dto.response.WorkspaceResDto
 import com.dcd.server.core.domain.workspace.dto.response.WorkspaceSimpleResDto
 import com.dcd.server.core.domain.workspace.usecase.*


### PR DESCRIPTION
## 개요
* 리스트를 응답하는 객체를 제네릭을 적용해서 공통 객체로 분리합니다.
## 작업내용
* ListResDto 추가
* ListResponse 추가
* List 조회 유스케이스에서 ListResDto를 사용하도록 수정
* List 조회 엔드포인트에서 ListResponse를 사용하도록 수정
* 테스트 수정
* 각 도메인의 List 응답 dto 제거
* 각 도메인의 List 응답 객체 제거
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [ ] pr에서 작업할 내용외에 작업한 내용이 있나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 다양한 데이터 목록을 반환할 수 있는 범용 리스트 응답 포맷이 도입되었습니다.

- **리팩터링**
  - 기존에 각 도메인별로 분리되어 있던 리스트 응답 포맷이 하나의 범용 리스트 응답 포맷으로 통합되었습니다.
  - 여러 API의 반환 타입이 통합된 리스트 응답 포맷으로 변경되었습니다.

- **테스트**
  - 변경된 응답 포맷에 맞게 테스트 코드가 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->