### PR TITLE
🔀 :: [#584] - List dto에 toResponse 확장함수 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/presentation/common/data/extension/ResponseExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/common/data/extension/ResponseExtension.kt
@@ -1,0 +1,10 @@
+package com.dcd.server.presentation.common.data.extension
+
+import com.dcd.server.core.common.data.dto.response.ListResDto
+import com.dcd.server.presentation.common.data.response.ListResponse
+
+fun <T, R> ListResDto<T>.toResponse(transform: (T) -> R): ListResponse<R> {
+    return ListResponse(
+        list = this.list.map(transform)
+    )
+}

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationStaticWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationStaticWebAdapter.kt
@@ -4,6 +4,7 @@ import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.usecase.GetApplicationTypeUseCase
 import com.dcd.server.core.domain.application.usecase.GetAvailableVersionUseCase
 import com.dcd.server.presentation.common.annotation.WebAdapter
+import com.dcd.server.presentation.common.data.extension.toResponse
 import com.dcd.server.presentation.common.data.response.ListResponse
 import com.dcd.server.presentation.domain.application.data.exetension.toResponse
 import com.dcd.server.presentation.domain.application.data.response.AvailableVersionResponse
@@ -24,5 +25,5 @@ class ApplicationStaticWebAdapter(
     @GetMapping("/types")
     fun getApplicationTypes(): ResponseEntity<ListResponse<String>> =
         getApplicationTypeUseCase.execute()
-            .let { ResponseEntity.ok(ListResponse(it.list)) }
+            .let { ResponseEntity.ok(it.toResponse { res -> res }) }
 }

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
@@ -3,6 +3,7 @@ package com.dcd.server.presentation.domain.application
 import com.dcd.server.core.common.annotation.WorkspaceOwnerVerification
 import com.dcd.server.core.domain.application.usecase.*
 import com.dcd.server.presentation.common.annotation.WebAdapter
+import com.dcd.server.presentation.common.data.extension.toResponse
 import com.dcd.server.presentation.common.data.response.ListResponse
 import com.dcd.server.presentation.domain.application.data.exetension.toDto
 import com.dcd.server.presentation.domain.application.data.exetension.toResponse
@@ -70,7 +71,7 @@ class ApplicationWebAdapter(
         @RequestParam(required = false) labels: List<String>? = null
     ): ResponseEntity<ListResponse<ApplicationResponse>> =
         getAllApplicationUseCase.execute(labels)
-            .let { ResponseEntity.ok(ListResponse(it.list.map { resDto -> resDto.toResponse() })) }
+            .let { ResponseEntity.ok(it.toResponse { resDto -> resDto.toResponse() }) }
 
     @GetMapping("/{applicationId}")
     @WorkspaceOwnerVerification("#workspaceId")

--- a/src/main/kotlin/com/dcd/server/presentation/domain/user/UserWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/user/UserWebAdapter.kt
@@ -6,6 +6,7 @@ import com.dcd.server.core.domain.user.usecase.ChangeUserStatusUseCase
 import com.dcd.server.core.domain.user.usecase.GetUserByStatusUseCase
 import com.dcd.server.core.domain.user.usecase.GetUserProfileUseCase
 import com.dcd.server.presentation.common.annotation.WebAdapter
+import com.dcd.server.presentation.common.data.extension.toResponse
 import com.dcd.server.presentation.common.data.response.ListResponse
 import com.dcd.server.presentation.domain.user.data.exetension.toDto
 import com.dcd.server.presentation.domain.user.data.exetension.toResponse
@@ -46,5 +47,5 @@ class UserWebAdapter(
     @GetMapping
     fun getUserByStatus(@RequestParam status: Status): ResponseEntity<ListResponse<UserResponse>> =
         getUserStatusUseCase.execute(status)
-            .let { ResponseEntity.ok(ListResponse(it.list.map { resDto -> resDto.toResponse() })) }
+            .let { ResponseEntity.ok(it.toResponse { resDto -> resDto.toResponse() }) }
 }

--- a/src/main/kotlin/com/dcd/server/presentation/domain/workspace/WorkspaceWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/workspace/WorkspaceWebAdapter.kt
@@ -2,6 +2,7 @@ package com.dcd.server.presentation.domain.workspace
 
 import com.dcd.server.core.domain.workspace.usecase.*
 import com.dcd.server.presentation.common.annotation.WebAdapter
+import com.dcd.server.presentation.common.data.extension.toResponse
 import com.dcd.server.presentation.common.data.response.ListResponse
 import com.dcd.server.presentation.domain.workspace.data.exetension.toDto
 import com.dcd.server.presentation.domain.workspace.data.exetension.toResponse
@@ -39,7 +40,7 @@ class WorkspaceWebAdapter(
     @GetMapping
     fun getAllWorkspace(): ResponseEntity<ListResponse<WorkspaceSimpleResponse>> =
         getAllWorkspaceUseCase.execute()
-            .let { ResponseEntity.ok(ListResponse(it.list.map { resDto -> resDto.toResponse() })) }
+            .let { ResponseEntity.ok(it.toResponse { resDto -> resDto.toResponse() }) }
 
     @GetMapping("/{workspaceId}")
     fun getOneWorkspace(@PathVariable workspaceId: String): ResponseEntity<WorkspaceResponse> =


### PR DESCRIPTION
## 개요
* ListDto에서 ListResponse로 래핑하는 확장함수를 추가합니다.
## 작업내용
* ListResDto를 ListResponse를 레핑하는 확장함수 추가
* ApplicationWebAdapter에 toResponse 적용
* UserWebAdapter에 toResponse 적용
* WorkspaceWebAdapter에 toResponse 적용
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [ ] pr에서 작업할 내용외에 작업한 내용이 있나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
    - 여러 엔드포인트에서 리스트 응답 생성 방식을 공통 확장 함수로 통일하여 코드가 간결해졌습니다.  
    - 수동 리스트 매핑 및 래핑 로직이 재사용 가능한 방식으로 개선되었습니다.  
    - 서비스 동작 및 반환 데이터에는 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->