### PR TITLE
🔀 :: [#598] - aes 암호화 테스트 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/PutApplicationEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/PutApplicationEnvUseCase.kt
@@ -76,7 +76,7 @@ class PutApplicationEnvUseCase(
                     }
                     ?: ApplicationEnv(
                         key = putEnv.key,
-                        value = putEnv.value,
+                        value = envValue,
                         encryption = putEnv.encryption
                     )
             }

--- a/src/test/kotlin/com/dcd/server/infrastructure/global/security/EncryptAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/infrastructure/global/security/EncryptAdapterTest.kt
@@ -1,0 +1,32 @@
+package com.dcd.server.infrastructure.global.security
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class EncryptAdapterTest(
+    private val encryptAdapter: EncryptAdapter
+) : BehaviorSpec({
+    given("평문이 주어지고") {
+        val plainText = "Hello World"
+
+        `when`("평문을 암호화했을때") {
+            val encrypt = encryptAdapter.encrypt(plainText)
+
+            then("암호화된 스트링은 평문이랑 일치하지 않아야함") {
+                encrypt shouldNotBe plainText
+            }
+
+            then("복호화하면 평문이 나와야됨") {
+                val decrypt = encryptAdapter.decrypt(encrypt)
+                decrypt shouldBe plainText
+            }
+        }
+    }
+})


### PR DESCRIPTION
## 개요
* aes 암호화 테스트를 추가합니다.
## 작업내용
* EncryptAdapter 테스트 코드 추가
* env 주입시 암호화 여부를 판단한 환경변수 값을 주입하도록 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용외에 작업한 내용이 있나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 환경 변수 저장 시 암호화 설정에 따라 값이 일관되게 처리되도록 개선되었습니다.

- **테스트**
  - 암호화 및 복호화 기능의 정상 동작을 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->