### PR TITLE
🔀 :: [#604] - 인증 메일 전송 API에 Limit 적용

### DIFF
--- a/src/main/kotlin/com/dcd/server/presentation/domain/auth/AuthWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/auth/AuthWebAdapter.kt
@@ -29,7 +29,7 @@ class AuthWebAdapter(
     private val nonAuthChangePasswordUseCase: NonAuthChangePasswordUseCase
 ) {
     @PostMapping("/email")
-    @Limit(target = "#emailSendRequest.email+#email")
+    @Limit(target = "#emailSendRequest.email+#email", capacity = 5)
     fun sendAuthEmail(
         @Validated
         @RequestBody

--- a/src/main/kotlin/com/dcd/server/presentation/domain/auth/AuthWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/auth/AuthWebAdapter.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.presentation.domain.auth
 
+import com.dcd.server.core.common.annotation.Limit
 import com.dcd.server.core.domain.auth.usecase.*
 import com.dcd.server.presentation.common.annotation.WebAdapter
 import com.dcd.server.presentation.domain.auth.data.exetension.toDto
@@ -28,6 +29,7 @@ class AuthWebAdapter(
     private val nonAuthChangePasswordUseCase: NonAuthChangePasswordUseCase
 ) {
     @PostMapping("/email")
+    @Limit(target = "#emailSendRequest.email+#email")
     fun sendAuthEmail(
         @Validated
         @RequestBody


### PR DESCRIPTION
## 개요
* 인증 메일 전송 API에 Limit 어노테이션을 적용합니다.
## 작업내용
* 인증 이메일 전송 API에 Limit 어노테이션 적용
* Limit 어노테이션의 capacity를 5로 설정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [ ] pr에서 작업할 내용외에 작업한 내용이 있나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?