### PR TITLE
🔀 :: [#606] - 환경변수 주입시 요청에 없는 환경변수를 제거하도록 수정

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/PutApplicationEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/PutApplicationEnvUseCase.kt
@@ -6,6 +6,7 @@ import com.dcd.server.core.common.data.WorkspaceInfo
 import com.dcd.server.core.common.service.EncryptService
 import com.dcd.server.core.domain.application.dto.request.PutApplicationEnvReqDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
+import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.env.model.ApplicationEnv
 import com.dcd.server.core.domain.env.spi.CommandApplicationEnvPort
@@ -83,5 +84,14 @@ class PutApplicationEnvUseCase(
 
             commandApplicationEnvPort.saveAll(applicationEnvList, application)
         }
+    }
+
+    private fun deleteUnusedEnv(
+        putApplicationEnvReqDto: PutApplicationEnvReqDto,
+        application: Application,
+    ) {
+        val putEnvKeyList = putApplicationEnvReqDto.envList.map { it.key }
+        val deletedEnv = application.env.filterNot { it.key in putEnvKeyList }
+        commandApplicationEnvPort.deleteAll(deletedEnv)
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/PutApplicationEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/PutApplicationEnvUseCase.kt
@@ -25,6 +25,7 @@ class PutApplicationEnvUseCase(
     fun execute(id: String, putApplicationEnvReqDto: PutApplicationEnvReqDto) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
+        deleteUnusedEnv(putApplicationEnvReqDto, application)
 
         val applicationEnvList = putApplicationEnvReqDto.envList.map { putEnv ->
             val envValue =
@@ -59,6 +60,8 @@ class PutApplicationEnvUseCase(
         val applicationList = queryApplicationPort.findAllByWorkspace(workspace, labels)
 
         applicationList.forEach { application ->
+            deleteUnusedEnv(putApplicationEnvReqDto, application)
+
             val applicationEnvList = putApplicationEnvReqDto.envList.map { putEnv ->
                 val envValue =
                     if (putEnv.encryption)

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/PutGlobalEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/PutGlobalEnvUseCase.kt
@@ -8,6 +8,7 @@ import com.dcd.server.core.domain.env.spi.CommandGlobalEnvPort
 import com.dcd.server.core.domain.env.spi.QueryGlobalEnvPort
 import com.dcd.server.core.domain.workspace.dto.request.PutGlobalEnvReqDto
 import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
+import com.dcd.server.core.domain.workspace.model.Workspace
 import com.dcd.server.core.domain.workspace.service.ValidateWorkspaceOwnerService
 import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
 
@@ -50,5 +51,14 @@ class PutGlobalEnvUseCase(
         }
 
         commandGlobalEnvPort.saveAll(globalEnvList, workspace)
+    }
+
+    private fun deleteUnusedEnv(
+        putGlobalEnvReqDto: PutGlobalEnvReqDto,
+        workspace: Workspace,
+    ) {
+        val putEnvKeyList = putGlobalEnvReqDto.envList.map { it.key }
+        val deletedEnv = workspace.globalEnv.filterNot { it.key in putEnvKeyList }
+        commandGlobalEnvPort.deleteAll(deletedEnv)
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/PutGlobalEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/workspace/usecase/PutGlobalEnvUseCase.kt
@@ -26,6 +26,7 @@ class PutGlobalEnvUseCase(
             ?: throw WorkspaceNotFoundException())
 
         validateWorkspaceOwnerService.validateOwner(workspace)
+        deleteUnusedEnv(putGlobalEnvReqDto, workspace)
 
         val globalEnvList = putGlobalEnvReqDto.envList.map { putEnv ->
             val envValue =

--- a/src/main/kotlin/com/dcd/server/presentation/domain/auth/AuthWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/auth/AuthWebAdapter.kt
@@ -29,7 +29,7 @@ class AuthWebAdapter(
     private val nonAuthChangePasswordUseCase: NonAuthChangePasswordUseCase
 ) {
     @PostMapping("/email")
-    @Limit(target = "#emailSendRequest.email+#email", capacity = 5)
+    @Limit(target = "#emailSendRequest.email", capacity = 5)
     fun sendAuthEmail(
         @Validated
         @RequestBody


### PR DESCRIPTION
## 개요
* 환경변수 주입시 요청에 존재하지 않는 환경변수는 제거되도록 수정합니다.
## 작업내용
* 이메일 전송시 Limit의 표현식 수정
* env 주입시 요청에 작성되지 않은 환경변수는 제거하는 메서드 추가
* 환경변수 주입시 deleteUnusedEnv 메서드를 호출하는 로직 추가
* 전역 환경변수 주입시 요청에 작성되지 않은 환경변수는 제거하는 메서드 추가
* 전역 환경변수 주입시 deleteUnusedEnv 메서드를 호출하는 로직 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용외에 작업한 내용이 있나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 애플리케이션 및 워크스페이스 환경 변수 업데이트 시, 요청에 포함되지 않은 기존 환경 변수가 자동으로 삭제됩니다.

- **버그 수정**
  - 인증 이메일 전송 시, 이메일별로 보다 정확하게 전송 제한이 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->