### PR TITLE
🔀 :: [#608] - RedisKeyExpiredEvent 이벤트 리스너 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/infrastructure/global/listener/RedisEventListener.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/listener/RedisEventListener.kt
@@ -1,0 +1,23 @@
+package com.dcd.server.infrastructure.global.listener
+
+import org.springframework.context.event.EventListener
+import org.springframework.data.redis.core.RedisKeyExpiredEvent
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class RedisEventListener(
+    private val redisTemplate: StringRedisTemplate
+) {
+    @EventListener
+    @Transactional(rollbackFor = [Exception::class])
+    fun process(event: RedisKeyExpiredEvent<Any>) {
+        val expiredKey = event.source.toString()
+
+        val keyspacePrefix = expiredKey.substringBeforeLast(":")
+
+        // 관련 SET(키스페이스) 삭제
+        redisTemplate.delete(keyspacePrefix)
+    }
+}

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/listener/RedisEventListener.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/listener/RedisEventListener.kt
@@ -13,7 +13,7 @@ class RedisEventListener(
     @EventListener
     @Transactional(rollbackFor = [Exception::class])
     fun process(event: RedisKeyExpiredEvent<Any>) {
-        val expiredKey = event.source.toString()
+        val expiredKey = event.source.toString(Charsets.UTF_8)
 
         val keyspacePrefix = expiredKey.substringBeforeLast(":")
 

--- a/src/test/kotlin/com/dcd/server/infrastructure/global/listener/RedisEventListenerTest.kt
+++ b/src/test/kotlin/com/dcd/server/infrastructure/global/listener/RedisEventListenerTest.kt
@@ -1,0 +1,35 @@
+package com.dcd.server.infrastructure.global.listener
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.data.redis.core.RedisKeyExpiredEvent
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class RedisEventListenerTest(
+    private val redisTemplate: StringRedisTemplate,
+    private val eventPublisher: ApplicationEventPublisher
+) : BehaviorSpec({
+    given("keyspace fullkey가 주어지고") {
+        val givenKeyspace = "testKeyspace"
+        val givenFullKey = "$givenKeyspace:testKey"
+        val givenValue = "test"
+        redisTemplate.opsForValue().set(givenFullKey, givenValue)
+        redisTemplate.opsForSet().add(givenKeyspace, givenFullKey)
+
+        `when`("RedisKeyExpiredEvent가 발행되면") {
+            val givenEvent = RedisKeyExpiredEvent<Any>(givenFullKey.toByteArray())
+            eventPublisher.publishEvent(givenEvent)
+
+            then("연관된 SET이 삭제되어야함") {
+                redisTemplate.opsForSet().isMember(givenKeyspace, givenFullKey) shouldBe false
+            }
+        }
+    }
+})


### PR DESCRIPTION
## 개요
* Redis 키 만료 이벤트를 처리할 수 있는 리스너를 추가합니다.
## 작업내용
* RedisEventListener 추가
* RedisEventListener 테스트 추가
* 이벤트의 key를 받아올때 UTF-8을 적용하도록 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [ ] pr에서 작업할 내용외에 작업한 내용이 있나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - Redis 키 만료 이벤트를 감지하여 관련 데이터를 자동으로 정리하는 기능이 추가되었습니다.

- **테스트**
  - Redis 키 만료 이벤트 처리 동작을 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->