### PR TITLE
🔀 :: [#616] - RedisLimitAdapter 리펙토링

### DIFF
--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/RedisConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/RedisConfig.kt
@@ -3,7 +3,6 @@ package com.dcd.server.infrastructure.global.config
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
-import io.lettuce.core.RedisClient
 import org.redisson.Redisson
 import org.redisson.api.RedissonClient
 import org.redisson.config.Config
@@ -40,10 +39,6 @@ class RedisConfig {
         config.useSingleServer().setAddress("redis://$host:$port")
         return Redisson.create(config)
     }
-
-    @Bean
-    fun redisClient(): RedisClient =
-        RedisClient.create("redis://$host:$port")
 
     @Bean
     fun cacheManager(redisConnectionFactory: RedisConnectionFactory): RedisCacheManager {

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/bucket4j/RedisLimitAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/bucket4j/RedisLimitAdapter.kt
@@ -9,13 +9,14 @@ import io.github.bucket4j.redis.lettuce.Bucket4jLettuce
 import io.lettuce.core.RedisClient
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Primary
+import org.springframework.data.redis.connection.RedisConnectionFactory
 import org.springframework.stereotype.Component
 import java.time.Duration
 
 @Primary
 @Component
 class RedisLimitAdapter(
-    redisClient: RedisClient
+    redisConnectionFactory: RedisConnectionFactory
 ) : LimitPort {
     private val logger = LoggerFactory.getLogger(RedisLimitAdapter::class.simpleName)
     private val bucketProxy = Bucket4jLettuce.casBasedBuilder(redisClient).build()

--- a/src/test/kotlin/com/dcd/server/infrastructure/global/thirdparty/bucket4j/RedisLimitAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/infrastructure/global/thirdparty/bucket4j/RedisLimitAdapterTest.kt
@@ -1,0 +1,30 @@
+package com.dcd.server.infrastructure.global.thirdparty.bucket4j
+
+import com.dcd.server.core.common.annotation.Limit
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class RedisLimitAdapterTest(
+    private val redisLimitAdapter: RedisLimitAdapter
+) : BehaviorSpec({
+    given("테스트할 Limit 어노테이션이 주어지고") {
+        val targetLimitAnnotation = Limit(target = "test")
+
+        `when`("어노테이션에 설정된 횟수 초과로 토큰을 소비할때") {
+            val capacity = targetLimitAnnotation.capacity
+            for (i in 0 until capacity) {
+                redisLimitAdapter.consumer(targetLimitAnnotation.target, targetLimitAnnotation)
+            }
+
+            then("반환값이 false여야함") {
+                redisLimitAdapter.consumer(targetLimitAnnotation.target, targetLimitAnnotation) shouldBe false
+            }
+        }
+    }
+})


### PR DESCRIPTION
## 개요
* RedisLimitAdapter 리펙토링합니다.
  * ReidsClient를 내부에서 생성하도록 수정
## 작업내용
* RedisClient Bean 제거
* RedisLimitAdapter에서 RedisConnectionFactory를 주입받도록 수정
* init을 통해서 bucketProxy를 초기화하도록 수정
* RedisLimitAdapterTest 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩터링**
  - Redis 연결 방식이 변경되어, Redis 관련 설정 및 어댑터의 생성자와 내부 구현이 개선되었습니다.

- **테스트**
  - Redis 기반 속도 제한 기능에 대한 새로운 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->