### PR TITLE
🔀 :: [#620] - 도메인 연결시 파일 정상적으로 생성되지 않는 현상 수정

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
@@ -90,13 +90,13 @@ object FileContent {
         "fi\n"
 
     fun getApplicationHttpConfig(application: Application, domain: String): String =
-        "server {" +
+        "server {\n" +
             "\tlisten: 80;\n" +
             "\tserver-name: $domain;\n\n" +
             "\tlocation / {\n" +
                 "\t\tproxy_pass: http://localhost:${application.externalPort};\n" +
             "\t}\n" +
-        "}"
+        "}\n"
 
     private fun getEnvString(env: Map<String, String>): String {
         val envString = StringBuilder()

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GenerateHttpConfigServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GenerateHttpConfigServiceImpl.kt
@@ -15,6 +15,7 @@ class GenerateHttpConfigServiceImpl(
         val webServerConfig = FileContent.getApplicationHttpConfig(application, domain)
         val httpConfigDirectory = "./nginx/conf/${application.workspace.id}"
         val exitValue = commandPort.executeShellCommand(
+            "mkdir -p $httpConfigDirectory && " +
             "cat <<EOF > ${httpConfigDirectory}/${application.name.replace(" ", "-")}-http.conf \n ${webServerConfig}EOF"
         )
 

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GenerateHttpConfigServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GenerateHttpConfigServiceImpl.kt
@@ -13,13 +13,9 @@ class GenerateHttpConfigServiceImpl(
 ) : GenerateHttpConfigService {
     override fun generateWebServerConfig(application: Application, domain: String) {
         val webServerConfig = FileContent.getApplicationHttpConfig(application, domain)
+        val httpConfigDirectory = "./nginx/conf/${application.workspace.id}"
         val exitValue = commandPort.executeShellCommand(
-            "touch ./nginx/conf/${
-                application.name.replace(
-                    " ",
-                    "-"
-                )
-            }-http.conf >> EOF ${webServerConfig} >> EOF"
+            "cat <<EOF > ${httpConfigDirectory}/${application.name.replace(" ", "-")}-http.conf \n ${webServerConfig}EOF"
         )
 
         if (exitValue != 0)


### PR DESCRIPTION
## 개요
* 도메인 연결시 http 설정 파일이 정상적으로 생성되지 않는 현상을 수정합니다.
## 작업내용
* HttpConfig 파일의 생성 내용 수정
* http 설정 파일 생성 명령 수정
* 만약 해당 애플리케이션의 디렉토리가 없을때 해당하는 디렉토리를 생성하는 커맨드 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- HTTP 서버 구성 파일 생성 및 저장 방식이 개선되어, 파일이 올바른 위치에 정확히 생성되고 저장됩니다.
	- 생성되는 구성 파일의 형식이 더 깔끔하게 정렬되어 가독성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->