### PR TITLE
🔀 :: [#626] - 도메인 연결시 생성되는 Nginx 파일 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,3 +21,14 @@ services:
     ports:
       - 6378:6379
     command: ["redis-server", "--requirepass", "$REDIS_PASSWORD"]
+  proxy:
+    container_name: dcd-nginx
+    image: nginx:latest
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/conf:/etc/nginx/conf.d:ro
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    restart: unless-stopped

--- a/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
@@ -91,10 +91,14 @@ object FileContent {
 
     fun getApplicationHttpConfig(application: Application, domain: String): String =
         "server {\n" +
-            "\tlisten: 80;\n" +
+            "\tlisten: 443;\n" +
             "\tserver-name: $domain;\n\n" +
+
+            "\tssl_certificate /etc/nginx/conf.d/ssl/certificate/fullchain.pem;\n" +
+            "\tssl_certificate_key /etc/nginx/conf.d/ssl/certificate/privkey.pem;\n\n" +
+
             "\tlocation / {\n" +
-                "\t\tproxy_pass: http://localhost:${application.externalPort};\n" +
+                "\t\tproxy_pass: http://host.docker.internal:${application.externalPort};\n" +
             "\t}\n" +
         "}\n"
 

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/SetApplicationDomainUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/SetApplicationDomainUseCase.kt
@@ -18,7 +18,7 @@ class SetApplicationDomainUseCase(
     private val generateHttpConfigService: GenerateHttpConfigService,
     private val rebootNginxService: RebootNginxService
 ) {
-    @Lock("#applicationId")
+    @Lock("#applicationId", waitTime = 1000 * 60 * 3, leaseTime = 1000 * 60 * 3)
     fun execute(applicationId: String, setDomainReqDto: SetDomainReqDto) {
         val domain = setDomainReqDto.domain
         require(domain.matches(Regex("^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\\.)+[a-zA-Z]{2,}$"))) {


### PR DESCRIPTION
## 개요
* 도메인 연결시 생성되는 Nginx 파일의 내용및 락 점유 관련 설정을 추가합니다.
## 작업내용
* 애플리케이션을 http로 외부에 개방할때 생성되는 nginx 프록시 설정 파일 수정
* 도커 컴포즈 파일에 dcd 프록시 서버관련 설정 추가
* 애플리케이션 http 도메인 개방 유스케이스의 락 점유시간및 대기시간 설정 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?