### PR TITLE
🔀 :: [#628] - Nginx 설정 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,6 @@ services:
     container_name: dcd-nginx
     image: nginx:latest
     ports:
-      - "80:80"
       - "443:443"
     volumes:
       - ./nginx/conf:/etc/nginx/conf.d:ro

--- a/nginx/conf/dcd.conf
+++ b/nginx/conf/dcd.conf
@@ -1,5 +1,4 @@
 server {
-    listen 80;
     listen 443 ssl;
     server_name dcd-api.dolong2.co.kr;
 


### PR DESCRIPTION
## 개요
* DCD 프록시를 담당하는 Nginx의 설정을 수정합니다.
## 작업내용
* nginx 설정에서 80 포트를 열지않도록 수정
* 도커 컴포즈에서 dcd-nginx의 80 포트를 개방하지 않도록 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **변경 사항**
  - 서비스가 이제 HTTPS(포트 443)만 지원하며, HTTP(포트 80)는 더 이상 제공되지 않습니다. 모든 트래픽이 암호화된 연결을 통해 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->