### PR TITLE
🔀 :: [#630] - 웹소켓 설정 관련 리펙토링

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/socket/SocketHandler.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/socket/SocketHandler.kt
@@ -1,0 +1,6 @@
+package com.dcd.server.core.common.socket
+
+import org.springframework.web.socket.handler.TextWebSocketHandler
+
+abstract class SocketHandler : TextWebSocketHandler() {
+}

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/WebSocketConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/WebSocketConfig.kt
@@ -9,11 +9,11 @@ import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry
 
 @Configuration
 class WebSocketConfig(
-    private val socketHAndler: SocketHandler,
+    private val socketHandler: SocketHandler,
     private val webSocketInterceptor: WebSocketInterceptor
 ) : WebSocketConfigurer {
     override fun registerWebSocketHandlers(registry: WebSocketHandlerRegistry) {
-        registry.addHandler(socketHAndler, "/application/exec")
+        registry.addHandler(socketHandler, "/application/exec")
             .addInterceptors(webSocketInterceptor)
             .setAllowedOrigins("*")
     }

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/WebSocketConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/WebSocketConfig.kt
@@ -1,6 +1,6 @@
 package com.dcd.server.infrastructure.global.config
 
-import com.dcd.server.infrastructure.global.filter.WebSocketFilter
+import com.dcd.server.infrastructure.global.socket.interceptor.WebSocketInterceptor
 import com.dcd.server.infrastructure.global.jwt.adapter.ParseTokenAdapter
 import com.dcd.server.infrastructure.global.socket.ApplicationSocketHandler
 import org.springframework.context.annotation.Configuration
@@ -11,11 +11,11 @@ import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry
 @Configuration
 class WebSocketConfig(
     private val dockerWebSocketHandler: ApplicationSocketHandler,
-    private val parseTokenAdapter: ParseTokenAdapter
+    private val webSocketInterceptor: WebSocketInterceptor
 ) : WebSocketConfigurer {
     override fun registerWebSocketHandlers(registry: WebSocketHandlerRegistry) {
         registry.addHandler(dockerWebSocketHandler, "/application/exec")
-            .addInterceptors(WebSocketFilter(parseTokenAdapter))
+            .addInterceptors(webSocketInterceptor)
             .setAllowedOrigins("*")
     }
 }

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/WebSocketConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/WebSocketConfig.kt
@@ -1,8 +1,7 @@
 package com.dcd.server.infrastructure.global.config
 
+import com.dcd.server.core.common.socket.SocketHandler
 import com.dcd.server.infrastructure.global.socket.interceptor.WebSocketInterceptor
-import com.dcd.server.infrastructure.global.jwt.adapter.ParseTokenAdapter
-import com.dcd.server.infrastructure.global.socket.ApplicationSocketHandler
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry
@@ -10,11 +9,11 @@ import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry
 
 @Configuration
 class WebSocketConfig(
-    private val dockerWebSocketHandler: ApplicationSocketHandler,
+    private val socketHAndler: SocketHandler,
     private val webSocketInterceptor: WebSocketInterceptor
 ) : WebSocketConfigurer {
     override fun registerWebSocketHandlers(registry: WebSocketHandlerRegistry) {
-        registry.addHandler(dockerWebSocketHandler, "/application/exec")
+        registry.addHandler(socketHAndler, "/application/exec")
             .addInterceptors(webSocketInterceptor)
             .setAllowedOrigins("*")
     }

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/socket/interceptor/WebSocketInterceptor.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/socket/interceptor/WebSocketInterceptor.kt
@@ -1,4 +1,4 @@
-package com.dcd.server.infrastructure.global.filter
+package com.dcd.server.infrastructure.global.socket.interceptor
 
 import com.dcd.server.core.common.error.BasicException
 import com.dcd.server.infrastructure.global.jwt.adapter.ParseTokenAdapter
@@ -12,7 +12,7 @@ import org.springframework.web.socket.WebSocketHandler
 import org.springframework.web.socket.server.HandshakeInterceptor
 import java.lang.Exception
 
-class WebSocketFilter(
+class WebSocketInterceptor(
     private val parseTokenAdapter: ParseTokenAdapter
 ) : HandshakeInterceptor {
     override fun beforeHandshake(

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/socket/interceptor/WebSocketInterceptor.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/socket/interceptor/WebSocketInterceptor.kt
@@ -7,11 +7,13 @@ import com.dcd.server.presentation.domain.application.exception.InvalidConnectio
 import org.springframework.http.HttpStatusCode
 import org.springframework.http.server.ServerHttpRequest
 import org.springframework.http.server.ServerHttpResponse
+import org.springframework.stereotype.Component
 import org.springframework.web.socket.CloseStatus
 import org.springframework.web.socket.WebSocketHandler
 import org.springframework.web.socket.server.HandshakeInterceptor
 import java.lang.Exception
 
+@Component
 class WebSocketInterceptor(
     private val parseTokenAdapter: ParseTokenAdapter
 ) : HandshakeInterceptor {

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationSocketHandler.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationSocketHandler.kt
@@ -1,6 +1,7 @@
-package com.dcd.server.infrastructure.global.socket
+package com.dcd.server.presentation.domain.application
 
 import com.dcd.server.core.common.error.BasicException
+import com.dcd.server.core.common.socket.SocketHandler
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.usecase.ExecuteCommandUseCase
 import com.dcd.server.presentation.domain.application.exception.InvalidConnectionInfoException
@@ -8,12 +9,11 @@ import org.springframework.stereotype.Component
 import org.springframework.web.socket.CloseStatus
 import org.springframework.web.socket.TextMessage
 import org.springframework.web.socket.WebSocketSession
-import org.springframework.web.socket.handler.TextWebSocketHandler
 
 @Component
 class ApplicationSocketHandler(
     private val executeCommandUseCase: ExecuteCommandUseCase
-) : TextWebSocketHandler() {
+) : SocketHandler() {
     @Throws(Exception::class)
     override fun handleTextMessage(session: WebSocketSession, message: TextMessage) {
         val applicationId = (session.attributes["applicationId"] as? String


### PR DESCRIPTION
## 개요
* 웹소켓 설정에 관련된 부분을 리펙토링합니다.
## 작업내용
* 기존 웹소켓 필터를 interceptor라는 네이밍으로 수정후 패키지 이동
* WebsocketInteceptor를 Component로 등록
* TextWebSocketHandler를 상속하는 SocketHandler 추상 클래스 추가
* ApplicationSocketHandler가 SocketHandler를 상속하고, presentation에 위치하도록 수정
* WebSocketConfig에서 SocketHandler를 주입받도록 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - WebSocket 관련 구성요소의 네이밍과 구조가 개선되었습니다.
  - WebSocket 필터가 인터셉터로 변경되어 관리 방식이 개선되었습니다.
  - 핸들러 및 인터셉터 클래스의 패키지 위치와 상속 구조가 일관성 있게 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->