### PR TITLE
🔀 :: [#644] - 도메인 엔티티 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/domain/model/Domain.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/domain/model/Domain.kt
@@ -1,0 +1,10 @@
+package com.dcd.server.core.domain.domain.model
+
+import com.dcd.server.core.domain.application.model.Application
+
+data class Domain(
+    val id: String,
+    val name: String,
+    val description: String,
+    val application: Application?
+)

--- a/src/main/kotlin/com/dcd/server/core/domain/domain/spi/CommandDomainPort.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/domain/spi/CommandDomainPort.kt
@@ -1,0 +1,9 @@
+package com.dcd.server.core.domain.domain.spi
+
+import com.dcd.server.core.domain.domain.model.Domain
+
+interface CommandDomainPort {
+    fun save(domain: Domain)
+    fun delete(domain: Domain)
+    fun saveAll(domainList: List<Domain>)
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/domain/spi/DomainPort.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/domain/spi/DomainPort.kt
@@ -1,0 +1,5 @@
+package com.dcd.server.core.domain.domain.spi
+
+interface DomainPort :
+    CommandDomainPort,
+    QueryDomainPort

--- a/src/main/kotlin/com/dcd/server/core/domain/domain/spi/QueryDomainPort.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/domain/spi/QueryDomainPort.kt
@@ -1,0 +1,8 @@
+package com.dcd.server.core.domain.domain.spi
+
+import com.dcd.server.core.domain.domain.model.Domain
+
+interface QueryDomainPort {
+    fun findAll(): List<Domain>
+    fun findById(id: String): Domain?
+}

--- a/src/main/kotlin/com/dcd/server/persistence/domain/DomainPersistenceAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/domain/DomainPersistenceAdapter.kt
@@ -1,0 +1,35 @@
+package com.dcd.server.persistence.domain
+
+import com.dcd.server.core.domain.domain.model.Domain
+import com.dcd.server.core.domain.domain.spi.DomainPort
+import com.dcd.server.persistence.domain.adapter.toDomain
+import com.dcd.server.persistence.domain.adapter.toEntity
+import com.dcd.server.persistence.domain.repository.DomainRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+import java.util.*
+
+@Component
+class DomainPersistenceAdapter(
+    private val domainRepository: DomainRepository
+) : DomainPort {
+    override fun save(domain: Domain) {
+        domainRepository.save(domain.toEntity())
+    }
+
+    override fun delete(domain: Domain) {
+        domainRepository.delete(domain.toEntity())
+    }
+
+    override fun saveAll(domainList: List<Domain>) {
+        domainRepository.saveAll(domainList.map { it.toEntity() })
+    }
+
+    override fun findAll(): List<Domain> =
+        domainRepository.findAll()
+            .map { it.toDomain() }
+
+    override fun findById(id: String): Domain? =
+        domainRepository.findByIdOrNull(UUID.fromString(id))
+            ?.toDomain()
+}

--- a/src/main/kotlin/com/dcd/server/persistence/domain/adapter/DomainAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/domain/adapter/DomainAdapter.kt
@@ -1,0 +1,23 @@
+package com.dcd.server.persistence.domain.adapter
+
+import com.dcd.server.core.domain.domain.model.Domain
+import com.dcd.server.persistence.application.adapter.toDomain
+import com.dcd.server.persistence.application.adapter.toEntity
+import com.dcd.server.persistence.domain.entity.DomainJpaEntity
+import java.util.UUID
+
+fun Domain.toEntity(): DomainJpaEntity =
+    DomainJpaEntity(
+        id = UUID.fromString(this.id),
+        name = this.name,
+        description = this.description,
+        application = this.application?.toEntity()
+    )
+
+fun DomainJpaEntity.toDomain(): Domain =
+    Domain(
+        id = this.id.toString(),
+        name = this.name,
+        description = this.description,
+        application = this.application?.toDomain()
+    )

--- a/src/main/kotlin/com/dcd/server/persistence/domain/entity/DomainJpaEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/domain/entity/DomainJpaEntity.kt
@@ -1,0 +1,21 @@
+package com.dcd.server.persistence.domain.entity
+
+import com.dcd.server.persistence.application.entity.ApplicationJpaEntity
+import jakarta.persistence.*
+import org.hibernate.annotations.GenericGenerator
+import java.util.*
+
+@Entity
+@Table(name = "domain_entity")
+class DomainJpaEntity(
+    @Id
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Column(columnDefinition = "BINARY(16)")
+    val id: UUID,
+    val name: String,
+    val description: String,
+    val domain: String,
+    @OneToOne
+    @JoinColumn(name = "application_id")
+    val application: ApplicationJpaEntity
+)

--- a/src/main/kotlin/com/dcd/server/persistence/domain/entity/DomainJpaEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/domain/entity/DomainJpaEntity.kt
@@ -14,7 +14,6 @@ class DomainJpaEntity(
     val id: UUID,
     val name: String,
     val description: String,
-    val domain: String,
     @OneToOne
     @JoinColumn(name = "application_id")
     val application: ApplicationJpaEntity

--- a/src/main/kotlin/com/dcd/server/persistence/domain/entity/DomainJpaEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/domain/entity/DomainJpaEntity.kt
@@ -15,6 +15,6 @@ class DomainJpaEntity(
     val name: String,
     val description: String,
     @OneToOne
-    @JoinColumn(name = "application_id")
-    val application: ApplicationJpaEntity
+    @JoinColumn(name = "application_id", nullable = true)
+    val application: ApplicationJpaEntity?
 )

--- a/src/main/kotlin/com/dcd/server/persistence/domain/repository/DomainRepository.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/domain/repository/DomainRepository.kt
@@ -1,0 +1,8 @@
+package com.dcd.server.persistence.domain.repository
+
+import com.dcd.server.persistence.domain.entity.DomainJpaEntity
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface DomainRepository : JpaRepository<DomainJpaEntity, UUID> {
+}


### PR DESCRIPTION
## 개요
* 도메인 엔티티를 추가합니다.
  * 도메인은 dcd의 서브도메인을 사용하여 dcd에 위치한 애플리케이션이 외부의 트래픽(Https)를 받을수있도록 설정합니다.
## 작업내용
* 도메인 엔티티 추가
  * 도메인 엔티티의 application필드를 nullable하게 수정
  * 도메인 엔티티에서 name이 서브도메인을 칭하도록 지정
* 도메인 레포지토리 추가
* 도메인 모델 추가
* 도메인 어뎁터 추가
* 도메인 포트 추가
* 도메인 영속성 어뎁터 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?
## 기타
* `Domain`이라는 네이밍을 사용하는게 적절한걸까...?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 도메인 엔터티의 생성, 조회, 저장, 삭제를 지원하는 기능이 추가되었습니다.
  * 도메인 정보를 데이터베이스에 저장하고 불러올 수 있는 기능이 제공됩니다.  
  * 도메인과 애플리케이션 간 연관 관계를 설정할 수 있습니다.  
  * 여러 도메인 정보를 일괄 저장하는 기능이 지원됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->