### PR TITLE
🔀 :: [#647] - 도메인 생성 API 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
@@ -18,6 +18,7 @@ enum class ErrorCode(
     FAILURE_HTTP_CONFIG("Http 설정 생성에 실패함", 400),
     ALREADY_EXISTS_APPLICATION("이미 존재하는 이름의 애플리케이션", 400),
     ALREADY_EXISTS_WORKSPACE("이미 존재하는 워크스페이스", 400),
+    ALREADY_EXISTS_DOMAIN("이미 존재하는 도메인", 400),
 
     UNAUTHORIZED("권한이 없음", 401),
     EXPIRED_TOKEN("토큰이 만료됨", 401),

--- a/src/main/kotlin/com/dcd/server/core/domain/domain/dto/extension/DomainDtoExtension.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/domain/dto/extension/DomainDtoExtension.kt
@@ -1,0 +1,15 @@
+package com.dcd.server.core.domain.domain.dto.extension
+
+import com.dcd.server.core.domain.domain.dto.request.CreateDomainReqDto
+import com.dcd.server.core.domain.domain.model.Domain
+import com.dcd.server.core.domain.workspace.model.Workspace
+import java.util.UUID
+
+fun CreateDomainReqDto.toEntity(workspace: Workspace): Domain =
+    Domain(
+        id = UUID.randomUUID().toString(),
+        name = this.name,
+        description = this.description,
+        application = null,
+        workspace = workspace,
+    )

--- a/src/main/kotlin/com/dcd/server/core/domain/domain/dto/request/CreateDomainReqDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/domain/dto/request/CreateDomainReqDto.kt
@@ -1,0 +1,6 @@
+package com.dcd.server.core.domain.domain.dto.request
+
+data class CreateDomainReqDto(
+    val name: String,
+    val description: String
+)

--- a/src/main/kotlin/com/dcd/server/core/domain/domain/dto/respone/CreateDomainResDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/domain/dto/respone/CreateDomainResDto.kt
@@ -1,0 +1,5 @@
+package com.dcd.server.core.domain.domain.dto.respone
+
+data class CreateDomainResDto(
+    val domainId: String
+)

--- a/src/main/kotlin/com/dcd/server/core/domain/domain/exception/AlreadyExistsDomainException.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/domain/exception/AlreadyExistsDomainException.kt
@@ -1,0 +1,8 @@
+package com.dcd.server.core.domain.domain.exception
+
+import com.dcd.server.core.common.error.BasicException
+import com.dcd.server.core.common.error.ErrorCode
+
+class AlreadyExistsDomainException : BasicException(ErrorCode.ALREADY_EXISTS_DOMAIN) {
+
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/domain/model/Domain.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/domain/model/Domain.kt
@@ -1,10 +1,12 @@
 package com.dcd.server.core.domain.domain.model
 
 import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.workspace.model.Workspace
 
 data class Domain(
     val id: String,
     val name: String,
     val description: String,
-    val application: Application?
+    val application: Application?,
+    val workspace: Workspace,
 )

--- a/src/main/kotlin/com/dcd/server/core/domain/domain/spi/QueryDomainPort.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/domain/spi/QueryDomainPort.kt
@@ -5,4 +5,5 @@ import com.dcd.server.core.domain.domain.model.Domain
 interface QueryDomainPort {
     fun findAll(): List<Domain>
     fun findById(id: String): Domain?
+    fun existsByName(name: String): Boolean
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/domain/usecase/CreateDomainUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/domain/usecase/CreateDomainUseCase.kt
@@ -5,15 +5,22 @@ import com.dcd.server.core.common.data.WorkspaceInfo
 import com.dcd.server.core.domain.domain.dto.extension.toEntity
 import com.dcd.server.core.domain.domain.dto.request.CreateDomainReqDto
 import com.dcd.server.core.domain.domain.dto.respone.CreateDomainResDto
+import com.dcd.server.core.domain.domain.exception.AlreadyExistsDomainException
 import com.dcd.server.core.domain.domain.spi.CommandDomainPort
+import com.dcd.server.core.domain.domain.spi.QueryDomainPort
 import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
 
 @UseCase
 class CreateDomainUseCase(
     private val commandDomainPort: CommandDomainPort,
+    private val queryDomainPort: QueryDomainPort,
     private val workspaceInfo: WorkspaceInfo
 ) {
     fun execute(createDomainReqDto: CreateDomainReqDto): CreateDomainResDto {
+        //도메인은 워크스페이스에 관계없이 전역적으로 관리되어야함
+        if (queryDomainPort.existsByName(createDomainReqDto.name))
+            throw AlreadyExistsDomainException()
+
         val workspace = (workspaceInfo.workspace
             ?: throw WorkspaceNotFoundException())
 

--- a/src/main/kotlin/com/dcd/server/core/domain/domain/usecase/CreateDomainUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/domain/usecase/CreateDomainUseCase.kt
@@ -1,0 +1,25 @@
+package com.dcd.server.core.domain.domain.usecase
+
+import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.common.data.WorkspaceInfo
+import com.dcd.server.core.domain.domain.dto.extension.toEntity
+import com.dcd.server.core.domain.domain.dto.request.CreateDomainReqDto
+import com.dcd.server.core.domain.domain.dto.respone.CreateDomainResDto
+import com.dcd.server.core.domain.domain.spi.CommandDomainPort
+import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
+
+@UseCase
+class CreateDomainUseCase(
+    private val commandDomainPort: CommandDomainPort,
+    private val workspaceInfo: WorkspaceInfo
+) {
+    fun execute(createDomainReqDto: CreateDomainReqDto): CreateDomainResDto {
+        val workspace = (workspaceInfo.workspace
+            ?: throw WorkspaceNotFoundException())
+
+        val domain = createDomainReqDto.toEntity(workspace)
+        commandDomainPort.save(domain)
+
+        return CreateDomainResDto(domain.id)
+    }
+}

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
@@ -83,6 +83,9 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.PUT, "/workspace/{workspaceId}/env").authenticated()
                 it.requestMatchers(HttpMethod.DELETE, "/workspace/{workspaceId}/env").authenticated()
 
+                //domain
+                it.requestMatchers(HttpMethod.POST, "/{workspaceId}/domain").authenticated()
+
                 //user
                 it.requestMatchers(HttpMethod.GET, "/user/profile").authenticated()
                 it.requestMatchers(HttpMethod.PATCH, "/user/password").authenticated()

--- a/src/main/kotlin/com/dcd/server/persistence/domain/DomainPersistenceAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/domain/DomainPersistenceAdapter.kt
@@ -32,4 +32,7 @@ class DomainPersistenceAdapter(
     override fun findById(id: String): Domain? =
         domainRepository.findByIdOrNull(UUID.fromString(id))
             ?.toDomain()
+
+    override fun existsByName(name: String): Boolean =
+        domainRepository.existsByName(name)
 }

--- a/src/main/kotlin/com/dcd/server/persistence/domain/adapter/DomainAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/domain/adapter/DomainAdapter.kt
@@ -4,6 +4,10 @@ import com.dcd.server.core.domain.domain.model.Domain
 import com.dcd.server.persistence.application.adapter.toDomain
 import com.dcd.server.persistence.application.adapter.toEntity
 import com.dcd.server.persistence.domain.entity.DomainJpaEntity
+import com.dcd.server.persistence.user.adapter.toDomain
+import com.dcd.server.persistence.user.adapter.toEntity
+import com.dcd.server.persistence.workspace.adapter.toDomain
+import com.dcd.server.persistence.workspace.adapter.toEntity
 import java.util.UUID
 
 fun Domain.toEntity(): DomainJpaEntity =
@@ -11,7 +15,8 @@ fun Domain.toEntity(): DomainJpaEntity =
         id = UUID.fromString(this.id),
         name = this.name,
         description = this.description,
-        application = this.application?.toEntity()
+        application = this.application?.toEntity(),
+        workspace = this.workspace.toEntity()
     )
 
 fun DomainJpaEntity.toDomain(): Domain =
@@ -19,5 +24,6 @@ fun DomainJpaEntity.toDomain(): Domain =
         id = this.id.toString(),
         name = this.name,
         description = this.description,
-        application = this.application?.toDomain()
+        application = this.application?.toDomain(),
+        workspace = this.workspace.toDomain()
     )

--- a/src/main/kotlin/com/dcd/server/persistence/domain/entity/DomainJpaEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/domain/entity/DomainJpaEntity.kt
@@ -1,6 +1,8 @@
 package com.dcd.server.persistence.domain.entity
 
 import com.dcd.server.persistence.application.entity.ApplicationJpaEntity
+import com.dcd.server.persistence.user.entity.UserJpaEntity
+import com.dcd.server.persistence.workspace.entity.WorkspaceJpaEntity
 import jakarta.persistence.*
 import org.hibernate.annotations.GenericGenerator
 import java.util.*
@@ -16,5 +18,8 @@ class DomainJpaEntity(
     val description: String,
     @OneToOne
     @JoinColumn(name = "application_id", nullable = true)
-    val application: ApplicationJpaEntity?
+    val application: ApplicationJpaEntity?,
+    @ManyToOne
+    @JoinColumn(name = "workspace_id")
+    val workspace: WorkspaceJpaEntity,
 )

--- a/src/main/kotlin/com/dcd/server/persistence/domain/repository/DomainRepository.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/domain/repository/DomainRepository.kt
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 import java.util.UUID
 
 interface DomainRepository : JpaRepository<DomainJpaEntity, UUID> {
+    fun existsByName(name: String): Boolean
 }

--- a/src/main/kotlin/com/dcd/server/presentation/domain/domain/DomainWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/domain/DomainWebAdapter.kt
@@ -1,0 +1,30 @@
+package com.dcd.server.presentation.domain.domain
+
+import com.dcd.server.core.common.annotation.WorkspaceOwnerVerification
+import com.dcd.server.core.domain.domain.usecase.CreateDomainUseCase
+import com.dcd.server.presentation.domain.domain.data.dto.toDto
+import com.dcd.server.presentation.domain.domain.data.dto.toResponse
+import com.dcd.server.presentation.domain.domain.data.request.CreateDomainRequest
+import com.dcd.server.presentation.domain.domain.data.response.CreateDomainResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/{workspaceId}/domain")
+class DomainWebAdapter(
+    private val createDomainUseCase: CreateDomainUseCase
+) {
+    @PostMapping
+    @WorkspaceOwnerVerification("#workspaceId")
+    fun createDomain(
+        @PathVariable workspaceId: String,
+        @Validated @RequestBody createDomainRequest: CreateDomainRequest
+    ): ResponseEntity<CreateDomainResponse> =
+        createDomainUseCase.execute(createDomainRequest.toDto())
+            .let { ResponseEntity.ok(it.toResponse()) }
+}

--- a/src/main/kotlin/com/dcd/server/presentation/domain/domain/data/dto/DomainRequestDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/domain/data/dto/DomainRequestDataExtension.kt
@@ -1,0 +1,10 @@
+package com.dcd.server.presentation.domain.domain.data.dto
+
+import com.dcd.server.core.domain.domain.dto.request.CreateDomainReqDto
+import com.dcd.server.presentation.domain.domain.data.request.CreateDomainRequest
+
+fun CreateDomainRequest.toDto(): CreateDomainReqDto =
+    CreateDomainReqDto(
+        name = name,
+        description = description
+    )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/domain/data/dto/DomainResponseDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/domain/data/dto/DomainResponseDataExtension.kt
@@ -1,0 +1,9 @@
+package com.dcd.server.presentation.domain.domain.data.dto
+
+import com.dcd.server.core.domain.domain.dto.respone.CreateDomainResDto
+import com.dcd.server.presentation.domain.domain.data.response.CreateDomainResponse
+
+fun CreateDomainResDto.toResponse(): CreateDomainResponse =
+    CreateDomainResponse(
+        domainId = domainId
+    )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/domain/data/request/CreateDomainRequest.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/domain/data/request/CreateDomainRequest.kt
@@ -1,0 +1,10 @@
+package com.dcd.server.presentation.domain.domain.data.request
+
+import jakarta.validation.constraints.NotBlank
+
+data class CreateDomainRequest(
+    @field:NotBlank
+    val name: String,
+    @field:NotBlank
+    val description: String
+)

--- a/src/main/kotlin/com/dcd/server/presentation/domain/domain/data/response/CreateDomainResponse.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/domain/data/response/CreateDomainResponse.kt
@@ -1,0 +1,5 @@
+package com.dcd.server.presentation.domain.domain.data.response
+
+data class CreateDomainResponse(
+    val domainId: String,
+)


### PR DESCRIPTION
## 개요
* 도메인을 생성하는 API를 추가합니다.
## 작업내용
* 도메인 모델에 workspace 추가
* 도메인 생성 dto및 객체 추가
* 도메인 생성 유스케이스 추가
* 도메인 생성 엔드포인트 추가
* 도메인 이름 검증 로직 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [ ] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?
## 기타
* 도메인은 실질적으로 애플리케이션과 연결되기전까지는 아무런 역할을 하지 않음
  * 실질적인 도메인 설정에 관련된 파일이 생성X