### PR TITLE
🔀 :: [#649] - 도메인 생성 테스트 추가

### DIFF
--- a/src/test/kotlin/com/dcd/server/core/domain/domain/usecase/CreateDomainUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/domain/usecase/CreateDomainUseCaseTest.kt
@@ -1,0 +1,63 @@
+package com.dcd.server.core.domain.domain.usecase
+
+import com.dcd.server.core.common.data.WorkspaceInfo
+import com.dcd.server.core.domain.domain.dto.request.CreateDomainReqDto
+import com.dcd.server.core.domain.domain.exception.AlreadyExistsDomainException
+import com.dcd.server.core.domain.domain.spi.CommandDomainPort
+import com.dcd.server.core.domain.domain.spi.QueryDomainPort
+import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+import util.domain.DomainGenerator
+
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class CreateDomainUseCaseTest(
+    private val createDomainUseCase: CreateDomainUseCase,
+    private val queryDomainPort: QueryDomainPort,
+    private val queryWorkspacePort: QueryWorkspacePort,
+    private val commandDomainPort: CommandDomainPort,
+    private val workspaceInfo: WorkspaceInfo
+) : BehaviorSpec({
+    beforeTest {
+        val workspace = queryWorkspacePort.findById("d57b42f5-5cc4-440b-8dce-b4fc2e372eff")
+        workspaceInfo.workspace = workspace
+    }
+
+    given("Domain 생성 요청이 주어지고") {
+        val testDomainReqDto = CreateDomainReqDto(
+            name = "test",
+            description = "test",
+        )
+
+        `when`("usecase를 실행할때") {
+            val response = createDomainUseCase.execute(testDomainReqDto)
+
+            then("응답값의 아이디를 가지는 도메인이 생성되어야함") {
+                val domain = queryDomainPort.findById(response.domainId)
+                domain shouldNotBe null
+                domain?.name shouldBe testDomainReqDto.name
+                domain?.description shouldBe testDomainReqDto.description
+                domain?.application shouldBe null
+                domain?.workspace shouldBe workspaceInfo.workspace
+            }
+        }
+
+        `when`("이미 같은 이름의 도메인이 존재할때") {
+            val alreadyExistsDomain = DomainGenerator.generateDomain(workspace = workspaceInfo.workspace!!)
+            commandDomainPort.save(alreadyExistsDomain)
+
+            then("에러가 발생해야함") {
+                shouldThrow<AlreadyExistsDomainException> {
+                    createDomainUseCase.execute(testDomainReqDto)
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/dcd/server/presentation/domain/domain/DomainWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/domain/DomainWebAdapterTest.kt
@@ -1,0 +1,37 @@
+package com.dcd.server.presentation.domain.domain
+
+import com.dcd.server.core.domain.domain.dto.request.CreateDomainReqDto
+import com.dcd.server.core.domain.domain.dto.response.CreateDomainResDto
+import com.dcd.server.core.domain.domain.usecase.CreateDomainUseCase
+import com.dcd.server.presentation.domain.domain.data.request.CreateDomainRequest
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import java.util.UUID
+
+class DomainWebAdapterTest : BehaviorSpec({
+    val workspaceId= UUID.randomUUID().toString()
+    val createDomainUseCase = mockk<CreateDomainUseCase>()
+
+    val domainWebAdapter = DomainWebAdapter(
+        createDomainUseCase = createDomainUseCase,
+    )
+
+    given("CreateDomainRequest가 주어지고") {
+        val request = CreateDomainRequest(
+            name = "domainName",
+            description = "domainDescription"
+        )
+
+        `when`("도메인 생성 메서드를 실행하면") {
+            val domainId = UUID.randomUUID().toString()
+            every { createDomainUseCase.execute(any() as CreateDomainReqDto) } returns CreateDomainResDto(domainId)
+
+            val response = domainWebAdapter.createDomain(workspaceId, request)
+            then("유스케이스에서 반환한 도메인 아이디를 본문에 담아야함") {
+                response.body?.domainId shouldBe domainId
+            }
+        }
+    }
+})

--- a/src/test/kotlin/util/domain/DomainGenerator.kt
+++ b/src/test/kotlin/util/domain/DomainGenerator.kt
@@ -1,0 +1,24 @@
+package util.domain
+
+import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.domain.model.Domain
+import com.dcd.server.core.domain.workspace.model.Workspace
+import util.workspace.WorkspaceGenerator
+import java.util.*
+
+object DomainGenerator {
+    fun generateDomain(
+        id: String = UUID.randomUUID().toString(),
+        name: String = "test",
+        description: String = "test",
+        workspace: Workspace = WorkspaceGenerator.generateWorkspace(),
+        application: Application? = null
+    ): Domain =
+        Domain(
+            id = id,
+            name = name,
+            description = description,
+            workspace = workspace,
+            application = application
+        )
+}

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -8,6 +8,7 @@ drop table if exists global_env_entity cascade;
 drop table if exists role_entity cascade;
 drop table if exists user_entity cascade;
 drop table if exists workspace_entity cascade;
+drop table if exists domain_entity cascade;
 create table application_entity (external_port integer not null, port integer not null, application_type varchar(255) check (application_type in ('SPRING_BOOT','NEST_JS','MYSQL','MARIA_DB','REDIS')), description varchar(255), failure_reason varchar(255), github_url varchar(255), id binary(16) not null, name varchar(255), status varchar(255) check (status in ('CREATED','PENDING','RUNNING','STOPPED','FAILURE')), version varchar(255), workspace_id binary(16), primary key (id));
 create table application_env_entity (id binary(16), application_id binary(16) not null, env_key varchar(255) not null, env_value varchar(255), encryption bit(1), primary key (id));
 create table application_label_entity (application_id binary(16) not null, label varchar(255));
@@ -15,12 +16,15 @@ create table global_env_entity (id binary(16), env_key varchar(255) not null, en
 create table role_entity (roles varchar(255) check (roles in ('ROLE_ADMIN','ROLE_DEVELOPER','ROLE_USER')), user_id binary(16) not null);
 create table user_entity (email varchar(255), id binary(16) not null, name varchar(255), password varchar(255), status varchar(255) check (status in ('PENDING','CREATED')), primary key (id));
 create table workspace_entity (description varchar(255), id binary(16) not null, owner_id binary(16), title varchar(255), primary key (id));
+create table domain_entity (id binary(16), name varchar(255), description varchar(255), application_id binary(16), workspace_id binary(16), primary key(id));
 alter table if exists application_entity add constraint FKn9drxkrx2h6wlorxfy00mr45h foreign key (workspace_id) references workspace_entity;
 alter table if exists application_env_entity add constraint FKb8anxni720qr9mk9neafwm7v foreign key (application_id) references application_entity;
 alter table if exists application_label_entity add constraint FKq6iovxq5tdx2i1lwrx34kg0b9 foreign key (application_id) references application_entity;
 alter table if exists global_env_entity add constraint FK694b15y5r7k158yn9c2rnftte foreign key (workspace_id) references workspace_entity;
 alter table if exists role_entity add constraint FKrot6fehcor0f3sux5s6kgl0a4 foreign key (user_id) references user_entity;
 alter table if exists workspace_entity add constraint FKlfxk1bhw5knckt8vv28xvx5g2 foreign key (owner_id) references user_entity;
+alter table if exists domain_entity add constraint FKh7b0t3y0a7x5boh75j8lanww6 foreign key (application_id) references application_entity;
+alter table if exists domain_entity add constraint FKgh6jr55192rq9v5byby652dry foreign key (workspace_id) references workspace_entity;
 
 -- 유저 생성
 insert into user_entity (email,name,password,status,id) values ('ownerEmail','applicationOwner', '$2a$10$uOSckwMEixpnBwRVp6ZoeOG9hQPbxXp.I0UK6xTok8tKK7G5f6A46', 'CREATED',  X'923a6407a5f84e1ebffd0621910ddfc8');


### PR DESCRIPTION
## 개요
* 도메인 생성에 관련된 테스트를 추가합니다.
## 작업내용
* DomainGenerator 추가
* 테스트 sql에 도메인 관련 sql 추가
* 도메인 생성 유스케이스 테스트 추가
* 도메인 생성 웹 어뎁터 테스트 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?