### PR TITLE
🔀 :: [#651] - DCD 운영시 변경되야되는 설정 수정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
 	implementation ("org.redisson:redisson-spring-boot-starter:3.45.0")
 
 	//database
-	runtimeOnly("com.mysql:mysql-connector-j")
+	runtimeOnly("org.mariadb.jdbc:mariadb-java-client")
 	runtimeOnly("com.h2database:h2")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,7 @@
-version: "3.8"
-
 networks:
   default:
-    external:
-      name: dcd
+    name: dcd
+    external: true
 
 services:
   db:
@@ -20,7 +18,6 @@ services:
       - REDIS_DISABLE_COMMANDS=FLUSHDB,FLUSHALL
     ports:
       - 6378:6379
-    command: ["redis-server", "--requirepass", "$REDIS_PASSWORD"]
   proxy:
     container_name: dcd-nginx
     image: nginx:latest

--- a/nginx/conf/dcd.conf
+++ b/nginx/conf/dcd.conf
@@ -6,19 +6,13 @@ server {
     ssl_certificate_key /etc/nginx/conf.d/ssl/certificate/privkey.pem;
 
     location / {
-        proxy_pass http://host.docker.internal:8081;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    }
-
-    location /application/exec {
-        proxy_pass http://host.docker.internal:8081;
-        proxy_http_version 1.1;
+        # WebSocket 관련 헤더 설정
         proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
+        proxy_set_header Connection $connection_upgrade;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        proxy_pass http://host.docker.internal:8081;
     }
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -8,6 +8,11 @@ events {
 }
 
 http {
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      close;
+    }
+
     include             /etc/nginx/mime.types;
     default_type        application/octet-stream;
 

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/RedisConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/RedisConfig.kt
@@ -22,12 +22,16 @@ import java.time.Duration
 
 @Configuration
 @EnableRedisRepositories(enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP)
-class RedisConfig {
+class RedisConfig(
     @Value("\${spring.data.redis.host}")
-    private val host: String = ""
-
+    private val host: String,
     @Value("\${spring.data.redis.port}")
-    private val port = 0
+    private val port: Int,
+    @Value("\${spring.data.redis.username}")
+    private val redisUserName: String,
+    @Value("\${spring.data.redis.password}")
+    private val redisPassword: String
+) {
     @Bean
     fun redisConnectionFactory(): RedisConnectionFactory {
         return LettuceConnectionFactory(host, port)
@@ -36,7 +40,10 @@ class RedisConfig {
     @Bean
     fun redissonClient(): RedissonClient {
         val config = Config()
-        config.useSingleServer().setAddress("redis://$host:$port")
+        config.useSingleServer()
+            .setAddress("redis://$host:$port")
+            .setUsername(redisUserName)
+            .setPassword(redisPassword)
         return Redisson.create(config)
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,12 +7,12 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-    database: mysql
     show-sql: true
   data:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
+      username: ${REDIS_USERNAME}
       password: ${REDIS_PASSWORD}
   mail:
     host: smtp.gmail.com


### PR DESCRIPTION
## 개요
* DCD 운영시 변경되어야되는 설정들을 수정합니다.
## 작업내용
* yml 프로퍼티 수정
* DB maraidb를 사용함에따라 mysql대신 maraidb관련 라이브러리를 임포트하도록 수정
* docker-compose 설정에서 deprecated된 옵션들 수정
* nginx 설정에서 map을 통해 프로토콜 업그레이드를 지원하도록 수정
* redisson 설정시 유저네임, 패스워드를 세팅하도록 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * Redis 연결 시 사용자 이름과 비밀번호를 통한 인증 기능이 추가되었습니다.

* **버그 수정**
  * 데이터베이스 연결 드라이버가 MySQL에서 MariaDB로 변경되어 호환성이 개선되었습니다.

* **설정**
  * Nginx 및 Docker Compose 설정이 간소화되어 관리가 쉬워졌습니다.
  * Redis 서비스의 인증 관련 설정이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->