### PR TITLE
🔀 :: [#646] - UUID 기본키 생성 전략 개선

### DIFF
--- a/src/main/kotlin/com/dcd/server/persistence/application/entity/ApplicationJpaEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/application/entity/ApplicationJpaEntity.kt
@@ -12,7 +12,6 @@ import java.util.UUID
 @Table(name = "application_entity")
 class ApplicationJpaEntity(
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(columnDefinition = "BINARY(16)")
     val id: UUID,
     val name: String,

--- a/src/main/kotlin/com/dcd/server/persistence/application/entity/ApplicationJpaEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/application/entity/ApplicationJpaEntity.kt
@@ -5,7 +5,6 @@ import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.persistence.env.entity.ApplicationEnvEntity
 import com.dcd.server.persistence.workspace.entity.WorkspaceJpaEntity
 import jakarta.persistence.*
-import org.hibernate.annotations.GenericGenerator
 import java.util.UUID
 
 
@@ -13,7 +12,7 @@ import java.util.UUID
 @Table(name = "application_entity")
 class ApplicationJpaEntity(
     @Id
-    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(columnDefinition = "BINARY(16)")
     val id: UUID,
     val name: String,

--- a/src/main/kotlin/com/dcd/server/persistence/domain/entity/DomainJpaEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/domain/entity/DomainJpaEntity.kt
@@ -1,17 +1,15 @@
 package com.dcd.server.persistence.domain.entity
 
 import com.dcd.server.persistence.application.entity.ApplicationJpaEntity
-import com.dcd.server.persistence.user.entity.UserJpaEntity
 import com.dcd.server.persistence.workspace.entity.WorkspaceJpaEntity
 import jakarta.persistence.*
-import org.hibernate.annotations.GenericGenerator
 import java.util.*
 
 @Entity
 @Table(name = "domain_entity")
 class DomainJpaEntity(
     @Id
-    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(columnDefinition = "BINARY(16)")
     val id: UUID,
     val name: String,

--- a/src/main/kotlin/com/dcd/server/persistence/domain/entity/DomainJpaEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/domain/entity/DomainJpaEntity.kt
@@ -9,7 +9,6 @@ import java.util.*
 @Table(name = "domain_entity")
 class DomainJpaEntity(
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(columnDefinition = "BINARY(16)")
     val id: UUID,
     val name: String,

--- a/src/main/kotlin/com/dcd/server/persistence/env/entity/common/Env.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/env/entity/common/Env.kt
@@ -1,15 +1,12 @@
 package com.dcd.server.persistence.env.entity.common
 
-import jakarta.persistence.Column
-import jakarta.persistence.Id
-import jakarta.persistence.MappedSuperclass
-import org.hibernate.annotations.GenericGenerator
+import jakarta.persistence.*
 import java.util.UUID
 
 @MappedSuperclass
 open class Env(
     @Id
-    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(columnDefinition = "BINARY(16)")
     val id: UUID,
     @Column(name = "env_key")

--- a/src/main/kotlin/com/dcd/server/persistence/env/entity/common/Env.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/env/entity/common/Env.kt
@@ -6,7 +6,6 @@ import java.util.UUID
 @MappedSuperclass
 open class Env(
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(columnDefinition = "BINARY(16)")
     val id: UUID,
     @Column(name = "env_key")

--- a/src/main/kotlin/com/dcd/server/persistence/user/entity/UserJpaEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/user/entity/UserJpaEntity.kt
@@ -9,7 +9,6 @@ import java.util.*
 @Table(name = "user_entity")
 class UserJpaEntity(
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(columnDefinition = "BINARY(16)")
     val id: UUID = UUID.randomUUID(),
     val email: String,

--- a/src/main/kotlin/com/dcd/server/persistence/user/entity/UserJpaEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/user/entity/UserJpaEntity.kt
@@ -3,14 +3,13 @@ package com.dcd.server.persistence.user.entity
 import com.dcd.server.core.domain.auth.model.Role
 import com.dcd.server.core.domain.user.model.enums.Status
 import jakarta.persistence.*
-import org.hibernate.annotations.GenericGenerator
 import java.util.*
 
 @Entity
 @Table(name = "user_entity")
 class UserJpaEntity(
     @Id
-    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(columnDefinition = "BINARY(16)")
     val id: UUID = UUID.randomUUID(),
     val email: String,

--- a/src/main/kotlin/com/dcd/server/persistence/workspace/entity/WorkspaceJpaEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/workspace/entity/WorkspaceJpaEntity.kt
@@ -3,14 +3,13 @@ package com.dcd.server.persistence.workspace.entity
 import com.dcd.server.persistence.env.entity.GlobalEnvEntity
 import com.dcd.server.persistence.user.entity.UserJpaEntity
 import jakarta.persistence.*
-import org.hibernate.annotations.GenericGenerator
 import java.util.UUID
 
 @Entity
 @Table(name = "workspace_entity")
 class WorkspaceJpaEntity(
     @Id
-    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(columnDefinition = "BINARY(16)")
     val id: UUID = UUID.randomUUID(),
     val title: String,

--- a/src/main/kotlin/com/dcd/server/persistence/workspace/entity/WorkspaceJpaEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/workspace/entity/WorkspaceJpaEntity.kt
@@ -9,7 +9,6 @@ import java.util.UUID
 @Table(name = "workspace_entity")
 class WorkspaceJpaEntity(
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(columnDefinition = "BINARY(16)")
     val id: UUID = UUID.randomUUID(),
     val title: String,


### PR DESCRIPTION
## 개요
* UUID 기본키 생성 전략을 개선합니다.
## 작업내용
* 엔티티의 UUID 타입 ID 사용시 GeneratedValue를 사용하도록 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 여러 엔티티의 기본 키 UUID 생성 방식에서 Hibernate 전용 어노테이션을 제거하여 표준 JPA 방식으로 변경하였습니다.  
  * UUID 생성 전략 관련 내부 코드가 간소화되었으며, 사용자에게는 변경 사항이 직접적으로 보이지 않습니다.  
  * 내부 동작의 표준화와 코드 정리가 이루어졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->