### PR TITLE
🔀 :: [#656] - 도메인 삭제 API 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
@@ -19,6 +19,7 @@ enum class ErrorCode(
     ALREADY_EXISTS_APPLICATION("이미 존재하는 이름의 애플리케이션", 400),
     ALREADY_EXISTS_WORKSPACE("이미 존재하는 워크스페이스", 400),
     ALREADY_EXISTS_DOMAIN("이미 존재하는 도메인", 400),
+    ALREADY_CONNECTED_DOMAIN("이미 연결된 도메인", 400),
 
     UNAUTHORIZED("권한이 없음", 401),
     EXPIRED_TOKEN("토큰이 만료됨", 401),
@@ -40,6 +41,7 @@ enum class ErrorCode(
     GLOBAL_ENV_NOT_FOUND("해당 환경변수를 찾을 수 없음", 404),
     WORKSPACE_NOT_FOUND("해당 워크스페이스를 찾을 수 없음", 404),
     AUTH_CODE_NOT_FOUND("인증 코드를 찾을 수 없습니다. 코드를 다시 전송 해주세요.", 404),
+    DOMAIN_NOT_FOUND("해당 도메인을 찾을 수 없음", 404),
 
     CONFLICT("해당 요청은 서버의 상태와 충돌됩니다.", 409),
     CAN_NOT_DEPLOY_APPLICATION("애플리케이션을 배포할 수 없습니다. 애플리케이션을 정지시킨 후 실행해주세요.", 409),

--- a/src/main/kotlin/com/dcd/server/core/domain/domain/exception/AlreadyConnectedDomainException.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/domain/exception/AlreadyConnectedDomainException.kt
@@ -1,0 +1,8 @@
+package com.dcd.server.core.domain.domain.exception
+
+import com.dcd.server.core.common.error.BasicException
+import com.dcd.server.core.common.error.ErrorCode
+
+class AlreadyConnectedDomainException : BasicException(ErrorCode.ALREADY_CONNECTED_DOMAIN) {
+
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/domain/exception/DomainNotFoundException.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/domain/exception/DomainNotFoundException.kt
@@ -1,0 +1,7 @@
+package com.dcd.server.core.domain.domain.exception
+
+import com.dcd.server.core.common.error.BasicException
+import com.dcd.server.core.common.error.ErrorCode
+
+class DomainNotFoundException : BasicException(ErrorCode.DOMAIN_NOT_FOUND) {
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/domain/usecase/DeleteDomainUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/domain/usecase/DeleteDomainUseCase.kt
@@ -1,0 +1,23 @@
+package com.dcd.server.core.domain.domain.usecase
+
+import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.domain.domain.exception.AlreadyConnectedDomainException
+import com.dcd.server.core.domain.domain.exception.DomainNotFoundException
+import com.dcd.server.core.domain.domain.spi.CommandDomainPort
+import com.dcd.server.core.domain.domain.spi.QueryDomainPort
+
+@UseCase
+class DeleteDomainUseCase(
+    private val queryDomainPort: QueryDomainPort,
+    private val commandDomainPort: CommandDomainPort
+) {
+    fun execute(id: String) {
+        val domain = (queryDomainPort.findById(id)
+            ?: throw DomainNotFoundException())
+
+        if (domain.application != null)
+            throw AlreadyConnectedDomainException()
+
+        commandDomainPort.delete(domain)
+    }
+}

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
@@ -85,6 +85,7 @@ class SecurityConfig(
 
                 //domain
                 it.requestMatchers(HttpMethod.POST, "/{workspaceId}/domain").authenticated()
+                it.requestMatchers(HttpMethod.DELETE, "/{workspaceId}/domain/{domainId}").authenticated()
 
                 //user
                 it.requestMatchers(HttpMethod.GET, "/user/profile").authenticated()

--- a/src/main/kotlin/com/dcd/server/presentation/domain/domain/DomainWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/domain/DomainWebAdapter.kt
@@ -2,12 +2,14 @@ package com.dcd.server.presentation.domain.domain
 
 import com.dcd.server.core.common.annotation.WorkspaceOwnerVerification
 import com.dcd.server.core.domain.domain.usecase.CreateDomainUseCase
+import com.dcd.server.core.domain.domain.usecase.DeleteDomainUseCase
 import com.dcd.server.presentation.domain.domain.data.dto.toDto
 import com.dcd.server.presentation.domain.domain.data.dto.toResponse
 import com.dcd.server.presentation.domain.domain.data.request.CreateDomainRequest
 import com.dcd.server.presentation.domain.domain.data.response.CreateDomainResponse
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -17,7 +19,8 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/{workspaceId}/domain")
 class DomainWebAdapter(
-    private val createDomainUseCase: CreateDomainUseCase
+    private val createDomainUseCase: CreateDomainUseCase,
+    private val deleteDomainUseCase: DeleteDomainUseCase
 ) {
     @PostMapping
     @WorkspaceOwnerVerification("#workspaceId")
@@ -27,4 +30,13 @@ class DomainWebAdapter(
     ): ResponseEntity<CreateDomainResponse> =
         createDomainUseCase.execute(createDomainRequest.toDto())
             .let { ResponseEntity.ok(it.toResponse()) }
+
+    @DeleteMapping("/{domainId}")
+    @WorkspaceOwnerVerification("#workspaceId")
+    fun deleteDomain(
+        @PathVariable workspaceId: String,
+        @PathVariable domainId: String
+    ): ResponseEntity<Void> =
+        deleteDomainUseCase.execute(domainId)
+            .run { ResponseEntity.ok().build() }
 }

--- a/src/test/kotlin/com/dcd/server/core/domain/domain/usecase/DeleteDomainUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/domain/usecase/DeleteDomainUseCaseTest.kt
@@ -1,0 +1,52 @@
+package com.dcd.server.core.domain.domain.usecase
+
+import com.dcd.server.core.domain.domain.exception.DomainNotFoundException
+import com.dcd.server.core.domain.domain.spi.CommandDomainPort
+import com.dcd.server.core.domain.domain.spi.QueryDomainPort
+import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+import util.domain.DomainGenerator
+import java.util.*
+
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class DeleteDomainUseCaseTest(
+    private val deleteDomainUseCase: DeleteDomainUseCase,
+    private val commandDomainPort: CommandDomainPort,
+    private val queryDomainPort: QueryDomainPort,
+    private val queryWorkspacePort: QueryWorkspacePort
+) : BehaviorSpec({
+    val domainId = UUID.randomUUID().toString()
+
+    given("삭제할 도메인이 주어지고") {
+        val workspace = queryWorkspacePort.findById("d57b42f5-5cc4-440b-8dce-b4fc2e372eff")!!
+        val domain = DomainGenerator.generateDomain(id = domainId, workspace = workspace)
+        commandDomainPort.save(domain)
+
+        `when`("도메인을 삭제할때") {
+            deleteDomainUseCase.execute(domainId)
+
+            then("도메인을 조회할 수 없게 되야함") {
+                queryDomainPort.findById(domainId) shouldBe null
+            }
+        }
+    }
+
+    given("삭제할 도메인이 주어지지않고") {
+
+        `when`("도메인을 삭제할때") {
+
+            then("예외가 발생해야함") {
+                shouldThrow<DomainNotFoundException> {
+                    deleteDomainUseCase.execute(domainId)
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/dcd/server/presentation/domain/domain/DomainWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/domain/DomainWebAdapterTest.kt
@@ -3,19 +3,23 @@ package com.dcd.server.presentation.domain.domain
 import com.dcd.server.core.domain.domain.dto.request.CreateDomainReqDto
 import com.dcd.server.core.domain.domain.dto.response.CreateDomainResDto
 import com.dcd.server.core.domain.domain.usecase.CreateDomainUseCase
+import com.dcd.server.core.domain.domain.usecase.DeleteDomainUseCase
 import com.dcd.server.presentation.domain.domain.data.request.CreateDomainRequest
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import org.springframework.http.HttpStatus
 import java.util.UUID
 
 class DomainWebAdapterTest : BehaviorSpec({
     val workspaceId= UUID.randomUUID().toString()
     val createDomainUseCase = mockk<CreateDomainUseCase>()
+    val deleteDomainUseCase = mockk<DeleteDomainUseCase>(relaxUnitFun = true)
 
     val domainWebAdapter = DomainWebAdapter(
         createDomainUseCase = createDomainUseCase,
+        deleteDomainUseCase = deleteDomainUseCase,
     )
 
     given("CreateDomainRequest가 주어지고") {
@@ -31,6 +35,19 @@ class DomainWebAdapterTest : BehaviorSpec({
             val response = domainWebAdapter.createDomain(workspaceId, request)
             then("유스케이스에서 반환한 도메인 아이디를 본문에 담아야함") {
                 response.body?.domainId shouldBe domainId
+            }
+        }
+    }
+
+    given("도메인 아이디가 주어지고") {
+        val domainId = UUID.randomUUID().toString()
+
+        `when`("도메인 삭제 메서드를 실행할때") {
+            val result = domainWebAdapter.deleteDomain(UUID.randomUUID().toString(), domainId)
+
+            then("200으로 응답되어야함") {
+                result.statusCode shouldBe HttpStatus.OK
+                result.body shouldBe null
             }
         }
     }


### PR DESCRIPTION
## 개요
* 도메인을 삭제하는 API를 추가합니다.
## 작업내용
* 도메인 삭제관련 예외 추가
* 도메인 삭제 유슨케이스 추가
* 도메인 삭제 엔드포인트 추가
* 도메인 삭제 테스트 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 도메인 삭제 기능이 추가되었습니다. 이제 도메인을 삭제할 수 있습니다.

* **버그 수정**
  * 도메인 삭제 시 이미 연결된 도메인 또는 존재하지 않는 도메인에 대한 오류 처리가 개선되었습니다.

* **보안**
  * 도메인 삭제 요청(DELETE)에 인증이 필요하도록 보안 규칙이 강화되었습니다.

* **테스트**
  * 도메인 삭제 기능에 대한 테스트가 추가되어 안정성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->