### PR TITLE
🔀 :: [#662] - 도메인 연결 해제 API 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
@@ -20,6 +20,7 @@ enum class ErrorCode(
     ALREADY_EXISTS_WORKSPACE("이미 존재하는 워크스페이스", 400),
     ALREADY_EXISTS_DOMAIN("이미 존재하는 도메인", 400),
     ALREADY_CONNECTED_DOMAIN("이미 연결된 도메인", 400),
+    NOT_CONNECTED_DOMAIN("도메인이 애플리케이션에 연결되어 있지 않음", 400),
 
     UNAUTHORIZED("권한이 없음", 401),
     EXPIRED_TOKEN("토큰이 만료됨", 401),

--- a/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
@@ -16,6 +16,7 @@ enum class ErrorCode(
     INVALID_CMD("올바르지 않은 커맨드 형식", 400),
     INVALID_DOMAIN_FORMAT("도매인 포맷이 올바르지 않음", 400),
     FAILURE_HTTP_CONFIG("Http 설정 생성에 실패함", 400),
+    FAILURE_HTTP_REMOVE("Http 설정 삭제에 실패함", 400),
     ALREADY_EXISTS_APPLICATION("이미 존재하는 이름의 애플리케이션", 400),
     ALREADY_EXISTS_WORKSPACE("이미 존재하는 워크스페이스", 400),
     ALREADY_EXISTS_DOMAIN("이미 존재하는 도메인", 400),

--- a/src/main/kotlin/com/dcd/server/core/domain/domain/exception/DomainNotConnectedException.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/domain/exception/DomainNotConnectedException.kt
@@ -1,0 +1,8 @@
+package com.dcd.server.core.domain.domain.exception
+
+import com.dcd.server.core.common.error.BasicException
+import com.dcd.server.core.common.error.ErrorCode
+
+class DomainNotConnectedException : BasicException(ErrorCode.NOT_CONNECTED_DOMAIN) {
+
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/domain/exception/HttpConfigFailureException.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/domain/exception/HttpConfigFailureException.kt
@@ -1,4 +1,4 @@
-package com.dcd.server.core.domain.application.exception
+package com.dcd.server.core.domain.domain.exception
 
 import com.dcd.server.core.common.error.BasicException
 import com.dcd.server.core.common.error.ErrorCode

--- a/src/main/kotlin/com/dcd/server/core/domain/domain/exception/HttpConfigRemoveFailureException.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/domain/exception/HttpConfigRemoveFailureException.kt
@@ -1,0 +1,7 @@
+package com.dcd.server.core.domain.domain.exception
+
+import com.dcd.server.core.common.error.BasicException
+import com.dcd.server.core.common.error.ErrorCode
+
+class HttpConfigRemoveFailureException : BasicException(ErrorCode.FAILURE_HTTP_REMOVE) {
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/domain/service/RemoveHttpConfigService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/domain/service/RemoveHttpConfigService.kt
@@ -1,0 +1,7 @@
+package com.dcd.server.core.domain.domain.service
+
+import com.dcd.server.core.domain.domain.model.Domain
+
+interface RemoveHttpConfigService {
+    fun removeHttpConfig(domain: Domain)
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/domain/service/impl/GenerateHttpConfigServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/domain/service/impl/GenerateHttpConfigServiceImpl.kt
@@ -2,7 +2,7 @@ package com.dcd.server.core.domain.domain.service.impl
 
 import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.common.file.FileContent
-import com.dcd.server.core.domain.application.exception.HttpConfigFailureException
+import com.dcd.server.core.domain.domain.exception.HttpConfigFailureException
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.domain.model.Domain
 import com.dcd.server.core.domain.domain.service.GenerateHttpConfigService

--- a/src/main/kotlin/com/dcd/server/core/domain/domain/service/impl/RemoveHttpConfigServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/domain/service/impl/RemoveHttpConfigServiceImpl.kt
@@ -1,0 +1,27 @@
+package com.dcd.server.core.domain.domain.service.impl
+
+import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.domain.domain.exception.DomainNotConnectedException
+import com.dcd.server.core.domain.domain.exception.HttpConfigRemoveFailureException
+import com.dcd.server.core.domain.domain.model.Domain
+import com.dcd.server.core.domain.domain.service.RemoveHttpConfigService
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+
+@Service
+class RemoveHttpConfigServiceImpl(
+    private val commandPort: CommandPort,
+    @Value("\${domain.config-path:.}")
+    private val domainConfigPath: String
+) : RemoveHttpConfigService {
+    override fun removeHttpConfig(domain: Domain) {
+        if (domain.application == null)
+            throw DomainNotConnectedException()
+
+        val httpConfigDirectory = "${domainConfigPath}/nginx/conf/${domain.id}"
+        val exitValue = commandPort.executeShellCommand("rm -r $httpConfigDirectory")
+
+        if (exitValue != 0)
+            throw HttpConfigRemoveFailureException()
+    }
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/domain/usecase/DisconnectDomainUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/domain/usecase/DisconnectDomainUseCase.kt
@@ -1,0 +1,27 @@
+package com.dcd.server.core.domain.domain.usecase
+
+import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.domain.domain.exception.DomainNotFoundException
+import com.dcd.server.core.domain.domain.service.RebootNginxService
+import com.dcd.server.core.domain.domain.service.RemoveHttpConfigService
+import com.dcd.server.core.domain.domain.spi.CommandDomainPort
+import com.dcd.server.core.domain.domain.spi.QueryDomainPort
+
+@UseCase
+class DisconnectDomainUseCase(
+    private val queryDomainPort: QueryDomainPort,
+    private val commandDomainPort: CommandDomainPort,
+    private val removeHttpConfigService: RemoveHttpConfigService,
+    private val rebootNginxService: RebootNginxService
+) {
+    fun execute(domainId: String) {
+        val domain = (queryDomainPort.findById(domainId)
+            ?: throw DomainNotFoundException())
+
+        val updatedDomain = domain.copy(application = null)
+        commandDomainPort.save(updatedDomain)
+
+        removeHttpConfigService.removeHttpConfig(domain)
+        rebootNginxService.rebootNginx()
+    }
+}

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
@@ -86,6 +86,7 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.POST, "/{workspaceId}/domain").authenticated()
                 it.requestMatchers(HttpMethod.DELETE, "/{workspaceId}/domain/{domainId}").authenticated()
                 it.requestMatchers(HttpMethod.POST, "/{workspaceId}/domain/{domainId}/connect").authenticated()
+                it.requestMatchers(HttpMethod.POST, "/{workspaceId}/domain/{domainId}/disconnect").authenticated()
 
                 //user
                 it.requestMatchers(HttpMethod.GET, "/user/profile").authenticated()

--- a/src/main/kotlin/com/dcd/server/presentation/domain/domain/DomainWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/domain/DomainWebAdapter.kt
@@ -4,6 +4,7 @@ import com.dcd.server.core.common.annotation.WorkspaceOwnerVerification
 import com.dcd.server.core.domain.domain.usecase.ConnectDomainUseCase
 import com.dcd.server.core.domain.domain.usecase.CreateDomainUseCase
 import com.dcd.server.core.domain.domain.usecase.DeleteDomainUseCase
+import com.dcd.server.core.domain.domain.usecase.DisconnectDomainUseCase
 import com.dcd.server.presentation.domain.domain.data.extension.toDto
 import com.dcd.server.presentation.domain.domain.data.extension.toResponse
 import com.dcd.server.presentation.domain.domain.data.request.ConnectDomainRequest
@@ -23,7 +24,8 @@ import org.springframework.web.bind.annotation.RestController
 class DomainWebAdapter(
     private val createDomainUseCase: CreateDomainUseCase,
     private val deleteDomainUseCase: DeleteDomainUseCase,
-    private val connectDomainUseCase: ConnectDomainUseCase
+    private val connectDomainUseCase: ConnectDomainUseCase,
+    private val disconnectDomainUseCase: DisconnectDomainUseCase
 ) {
     @PostMapping
     @WorkspaceOwnerVerification("#workspaceId")
@@ -51,5 +53,14 @@ class DomainWebAdapter(
         @Validated @RequestBody connectDomainRequest: ConnectDomainRequest
     ): ResponseEntity<Void> =
         connectDomainUseCase.execute(domainId, connectDomainRequest.toDto())
+            .run { ResponseEntity.ok().build() }
+
+    @PostMapping("/{domainId}/disconnect")
+    @WorkspaceOwnerVerification("#workspaceId")
+    fun disconnectDomain(
+        @PathVariable workspaceId: String,
+        @PathVariable domainId: String
+    ): ResponseEntity<Void> =
+        disconnectDomainUseCase.execute(domainId)
             .run { ResponseEntity.ok().build() }
 }

--- a/src/test/kotlin/com/dcd/server/core/domain/domain/usecase/DisconnectDomainUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/domain/usecase/DisconnectDomainUseCaseTest.kt
@@ -1,0 +1,74 @@
+package com.dcd.server.core.domain.domain.usecase
+
+import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.common.data.WorkspaceInfo
+import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import com.dcd.server.core.domain.domain.exception.DomainNotFoundException
+import com.dcd.server.core.domain.domain.spi.CommandDomainPort
+import com.dcd.server.core.domain.domain.spi.QueryDomainPort
+import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.verify
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+import util.domain.DomainGenerator
+import java.util.*
+
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class DisconnectDomainUseCaseTest(
+    private val disconnectDomainUseCase: DisconnectDomainUseCase,
+    private val commandDomainPort: CommandDomainPort,
+    private val queryDomainPort: QueryDomainPort,
+    private val queryWorkspacePort: QueryWorkspacePort,
+    private val queryApplicationPort: QueryApplicationPort,
+    private val workspaceInfo: WorkspaceInfo,
+    @MockkBean(relaxed = true)
+    private val commandPort: CommandPort,
+) : BehaviorSpec({
+    val domainId = UUID.randomUUID().toString()
+    val applicationId = "2fb0f315-8272-422f-8e9f-c4f765c022b2"
+    beforeContainer {
+        val workspace = queryWorkspacePort.findById("d57b42f5-5cc4-440b-8dce-b4fc2e372eff")!!
+        workspaceInfo.workspace = workspace
+    }
+
+    given("연결해제할 도메인이 주어지고") {
+        val application = queryApplicationPort.findById(applicationId)!!
+        val domain = DomainGenerator.generateDomain(id = domainId, workspace = workspaceInfo.workspace!!, application = application)
+        commandDomainPort.save(domain)
+
+        `when`("도메인에 애플리케이션을 연결 해제할때") {
+            disconnectDomainUseCase.execute(domainId)
+
+            then("Nginx 설정 파일을 삭제해야함") {
+                val httpConfigDirectory = "./nginx/conf/${domain.id}"
+                verify { commandPort.executeShellCommand("rm -r $httpConfigDirectory") }
+            }
+            then("도메인에 해당 애플리케이션이 null로 변경되어야함") {
+                val domain = queryDomainPort.findById(domainId)!!
+                domain.application shouldBe null
+            }
+            then("nginx 재실행이 명령되어야함") {
+                verify { commandPort.executeShellCommand("docker restart dcd-nginx") }
+            }
+        }
+
+        `when`("해당 도메인이 존재하지 않을때") {
+            commandDomainPort.delete(domain)
+
+            then("에러가 발생해야함") {
+                shouldThrow<DomainNotFoundException> {
+                    disconnectDomainUseCase.execute(domainId)
+                }
+            }
+
+            commandDomainPort.save(domain)
+        }
+    }
+})

--- a/src/test/kotlin/com/dcd/server/presentation/domain/domain/DomainWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/domain/DomainWebAdapterTest.kt
@@ -5,6 +5,7 @@ import com.dcd.server.core.domain.domain.dto.response.CreateDomainResDto
 import com.dcd.server.core.domain.domain.usecase.ConnectDomainUseCase
 import com.dcd.server.core.domain.domain.usecase.CreateDomainUseCase
 import com.dcd.server.core.domain.domain.usecase.DeleteDomainUseCase
+import com.dcd.server.core.domain.domain.usecase.DisconnectDomainUseCase
 import com.dcd.server.presentation.domain.domain.data.request.ConnectDomainRequest
 import com.dcd.server.presentation.domain.domain.data.request.CreateDomainRequest
 import io.kotest.core.spec.style.BehaviorSpec
@@ -19,11 +20,13 @@ class DomainWebAdapterTest : BehaviorSpec({
     val createDomainUseCase = mockk<CreateDomainUseCase>()
     val deleteDomainUseCase = mockk<DeleteDomainUseCase>(relaxUnitFun = true)
     val connectDomainUseCase = mockk<ConnectDomainUseCase>(relaxUnitFun = true)
+    val disconnectDomainUseCase = mockk<DisconnectDomainUseCase>(relaxUnitFun = true)
 
     val domainWebAdapter = DomainWebAdapter(
         createDomainUseCase = createDomainUseCase,
         deleteDomainUseCase = deleteDomainUseCase,
         connectDomainUseCase = connectDomainUseCase,
+        disconnectDomainUseCase = disconnectDomainUseCase,
     )
 
     given("CreateDomainRequest가 주어지고") {
@@ -47,7 +50,7 @@ class DomainWebAdapterTest : BehaviorSpec({
         val domainId = UUID.randomUUID().toString()
 
         `when`("도메인 삭제 메서드를 실행할때") {
-            val result = domainWebAdapter.deleteDomain(UUID.randomUUID().toString(), domainId)
+            val result = domainWebAdapter.deleteDomain(workspaceId, domainId)
 
             then("200으로 응답되어야함") {
                 result.statusCode shouldBe HttpStatus.OK
@@ -57,7 +60,16 @@ class DomainWebAdapterTest : BehaviorSpec({
 
         `when`("도메인 연결 메서드를 실행할때") {
             val request = ConnectDomainRequest(UUID.randomUUID().toString())
-            val result = domainWebAdapter.connectDomain(UUID.randomUUID().toString(), domainId, request)
+            val result = domainWebAdapter.connectDomain(workspaceId, domainId, request)
+
+            then("200으로 응답되어야함") {
+                result.statusCode shouldBe HttpStatus.OK
+                result.body shouldBe null
+            }
+        }
+
+        `when`("도메인 연결 해제 메서드를 실행할때") {
+            val result = domainWebAdapter.disconnectDomain(workspaceId, domainId)
 
             then("200으로 응답되어야함") {
                 result.statusCode shouldBe HttpStatus.OK


### PR DESCRIPTION
## 개요
* 도메인의 연결을 해제하는 API를 추가합니다.
## 작업내용
* 도메인이 연결되지 않은 예외 추가
* Http 설정 제거 실패 예외 추가
* Http 설정 제거 서비스 추가
* 도메인 연결 해제 유스케이스 추가
* 도메인 연결 해제 엔드포인트 추가
* 도메인 연결 해제 유스케이스 테스트 추가
* 도메인 연결 해제 웹어뎁터 테스트 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 도메인 연결 해제(Disconnect) API 엔드포인트가 추가되었습니다.
  * 도메인 연결 해제 시 관련 HTTP 설정이 삭제되고, Nginx가 자동으로 재시작됩니다.

* **버그 수정**
  * 없음

* **테스트**
  * 도메인 연결 해제 기능에 대한 단위 및 통합 테스트가 추가되었습니다.

* **문서화**
  * 없음

* **기타**
  * 도메인 연결 해제 및 HTTP 설정 삭제 관련 오류 코드가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->