### PR TITLE
🔀 :: [#664] - 도메인 정보 조회 API 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/domain/dto/extension/DomainDtoExtension.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/domain/dto/extension/DomainDtoExtension.kt
@@ -1,6 +1,8 @@
 package com.dcd.server.core.domain.domain.dto.extension
 
+import com.dcd.server.core.domain.application.dto.extenstion.toProfileDto
 import com.dcd.server.core.domain.domain.dto.request.CreateDomainReqDto
+import com.dcd.server.core.domain.domain.dto.response.DomainResDto
 import com.dcd.server.core.domain.domain.model.Domain
 import com.dcd.server.core.domain.workspace.model.Workspace
 import java.util.UUID
@@ -12,4 +14,12 @@ fun CreateDomainReqDto.toEntity(workspace: Workspace): Domain =
         description = this.description,
         application = null,
         workspace = workspace,
+    )
+
+fun Domain.toResDto(): DomainResDto =
+    DomainResDto(
+        id = this.id,
+        name = this.name,
+        description = this.description,
+        application = this.application?.toProfileDto()
     )

--- a/src/main/kotlin/com/dcd/server/core/domain/domain/dto/response/DomainResDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/domain/dto/response/DomainResDto.kt
@@ -1,0 +1,10 @@
+package com.dcd.server.core.domain.domain.dto.response
+
+import com.dcd.server.core.domain.application.dto.response.ApplicationProfileResDto
+
+data class DomainResDto(
+    val id: String,
+    val name: String,
+    val description: String,
+    val application: ApplicationProfileResDto?,
+)

--- a/src/main/kotlin/com/dcd/server/core/domain/domain/spi/QueryDomainPort.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/domain/spi/QueryDomainPort.kt
@@ -1,9 +1,11 @@
 package com.dcd.server.core.domain.domain.spi
 
 import com.dcd.server.core.domain.domain.model.Domain
+import com.dcd.server.core.domain.workspace.model.Workspace
 
 interface QueryDomainPort {
     fun findAll(): List<Domain>
     fun findById(id: String): Domain?
+    fun findByWorkspace(workspace: Workspace): List<Domain>
     fun existsByName(name: String): Boolean
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/domain/usecase/GetDomainUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/domain/usecase/GetDomainUseCase.kt
@@ -1,0 +1,26 @@
+package com.dcd.server.core.domain.domain.usecase
+
+import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.common.data.WorkspaceInfo
+import com.dcd.server.core.common.data.dto.response.ListResDto
+import com.dcd.server.core.domain.domain.dto.extension.toResDto
+import com.dcd.server.core.domain.domain.dto.response.DomainResDto
+import com.dcd.server.core.domain.domain.spi.QueryDomainPort
+import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
+
+@UseCase(readOnly = true)
+class GetDomainUseCase(
+    private val queryDomainPort: QueryDomainPort,
+    private val workspaceInfo: WorkspaceInfo,
+) {
+    fun execute(): ListResDto<DomainResDto> {
+        val workspace = (workspaceInfo.workspace
+            ?: throw WorkspaceNotFoundException())
+
+        val domainListResDto =
+            queryDomainPort.findByWorkspace(workspace)
+                .map { it.toResDto() }
+                .let { ListResDto(it) }
+        return domainListResDto
+    }
+}

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
@@ -83,6 +83,7 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.DELETE, "/workspace/{workspaceId}/env").authenticated()
 
                 //domain
+                it.requestMatchers(HttpMethod.GET, "/{workspaceId}/domain").authenticated()
                 it.requestMatchers(HttpMethod.POST, "/{workspaceId}/domain").authenticated()
                 it.requestMatchers(HttpMethod.DELETE, "/{workspaceId}/domain/{domainId}").authenticated()
                 it.requestMatchers(HttpMethod.POST, "/{workspaceId}/domain/{domainId}/connect").authenticated()

--- a/src/main/kotlin/com/dcd/server/persistence/domain/DomainPersistenceAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/domain/DomainPersistenceAdapter.kt
@@ -2,9 +2,11 @@ package com.dcd.server.persistence.domain
 
 import com.dcd.server.core.domain.domain.model.Domain
 import com.dcd.server.core.domain.domain.spi.DomainPort
+import com.dcd.server.core.domain.workspace.model.Workspace
 import com.dcd.server.persistence.domain.adapter.toDomain
 import com.dcd.server.persistence.domain.adapter.toEntity
 import com.dcd.server.persistence.domain.repository.DomainRepository
+import com.dcd.server.persistence.workspace.adapter.toEntity
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 import java.util.*
@@ -32,6 +34,10 @@ class DomainPersistenceAdapter(
     override fun findById(id: String): Domain? =
         domainRepository.findByIdOrNull(UUID.fromString(id))
             ?.toDomain()
+
+    override fun findByWorkspace(workspace: Workspace): List<Domain> =
+        domainRepository.findAllByWorkspace(workspace.toEntity())
+            .map { it.toDomain() }
 
     override fun existsByName(name: String): Boolean =
         domainRepository.existsByName(name)

--- a/src/main/kotlin/com/dcd/server/persistence/domain/repository/DomainRepository.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/domain/repository/DomainRepository.kt
@@ -1,9 +1,11 @@
 package com.dcd.server.persistence.domain.repository
 
 import com.dcd.server.persistence.domain.entity.DomainJpaEntity
+import com.dcd.server.persistence.workspace.entity.WorkspaceJpaEntity
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.UUID
 
 interface DomainRepository : JpaRepository<DomainJpaEntity, UUID> {
     fun existsByName(name: String): Boolean
+    fun findAllByWorkspace(workspace: WorkspaceJpaEntity): List<DomainJpaEntity>
 }

--- a/src/main/kotlin/com/dcd/server/presentation/domain/domain/DomainWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/domain/DomainWebAdapter.kt
@@ -1,23 +1,18 @@
 package com.dcd.server.presentation.domain.domain
 
 import com.dcd.server.core.common.annotation.WorkspaceOwnerVerification
-import com.dcd.server.core.domain.domain.usecase.ConnectDomainUseCase
-import com.dcd.server.core.domain.domain.usecase.CreateDomainUseCase
-import com.dcd.server.core.domain.domain.usecase.DeleteDomainUseCase
-import com.dcd.server.core.domain.domain.usecase.DisconnectDomainUseCase
+import com.dcd.server.core.domain.domain.usecase.*
+import com.dcd.server.presentation.common.data.extension.toResponse
+import com.dcd.server.presentation.common.data.response.ListResponse
 import com.dcd.server.presentation.domain.domain.data.extension.toDto
 import com.dcd.server.presentation.domain.domain.data.extension.toResponse
 import com.dcd.server.presentation.domain.domain.data.request.ConnectDomainRequest
 import com.dcd.server.presentation.domain.domain.data.request.CreateDomainRequest
 import com.dcd.server.presentation.domain.domain.data.response.CreateDomainResponse
+import com.dcd.server.presentation.domain.domain.data.response.DomainResponse
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
-import org.springframework.web.bind.annotation.DeleteMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/{workspaceId}/domain")
@@ -25,8 +20,15 @@ class DomainWebAdapter(
     private val createDomainUseCase: CreateDomainUseCase,
     private val deleteDomainUseCase: DeleteDomainUseCase,
     private val connectDomainUseCase: ConnectDomainUseCase,
-    private val disconnectDomainUseCase: DisconnectDomainUseCase
+    private val disconnectDomainUseCase: DisconnectDomainUseCase,
+    private val getDomainUseCase: GetDomainUseCase
 ) {
+    @GetMapping
+    @WorkspaceOwnerVerification("#workspaceId")
+    fun getDomainList(@PathVariable workspaceId: String): ResponseEntity<ListResponse<DomainResponse>> =
+        getDomainUseCase.execute()
+            .let { ResponseEntity.ok(it.toResponse { resDto -> resDto.toResponse() }) }
+
     @PostMapping
     @WorkspaceOwnerVerification("#workspaceId")
     fun createDomain(

--- a/src/main/kotlin/com/dcd/server/presentation/domain/domain/data/extension/DomainResponseDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/domain/data/extension/DomainResponseDataExtension.kt
@@ -1,9 +1,20 @@
 package com.dcd.server.presentation.domain.domain.data.extension
 
 import com.dcd.server.core.domain.domain.dto.response.CreateDomainResDto
+import com.dcd.server.core.domain.domain.dto.response.DomainResDto
+import com.dcd.server.presentation.domain.application.data.exetension.toResponse
 import com.dcd.server.presentation.domain.domain.data.response.CreateDomainResponse
+import com.dcd.server.presentation.domain.domain.data.response.DomainResponse
 
 fun CreateDomainResDto.toResponse(): CreateDomainResponse =
     CreateDomainResponse(
         domainId = domainId
+    )
+
+fun DomainResDto.toResponse(): DomainResponse =
+    DomainResponse(
+        id = id,
+        name = name,
+        description = description,
+        application = application?.toResponse(),
     )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/domain/data/response/DomainResponse.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/domain/data/response/DomainResponse.kt
@@ -1,0 +1,10 @@
+package com.dcd.server.presentation.domain.domain.data.response
+
+import com.dcd.server.presentation.domain.application.data.response.ApplicationProfileResponse
+
+data class DomainResponse(
+    val id: String,
+    val name: String,
+    val description: String,
+    val application: ApplicationProfileResponse?,
+)

--- a/src/test/kotlin/com/dcd/server/core/domain/domain/usecase/GetDomainUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/domain/usecase/GetDomainUseCaseTest.kt
@@ -1,0 +1,54 @@
+package com.dcd.server.core.domain.domain.usecase
+
+import com.dcd.server.core.common.data.WorkspaceInfo
+import com.dcd.server.core.domain.domain.dto.extension.toResDto
+import com.dcd.server.core.domain.domain.spi.CommandDomainPort
+import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
+import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+import util.domain.DomainGenerator
+import java.util.*
+
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class GetDomainUseCaseTest(
+    private val getDomainUseCase: GetDomainUseCase,
+    private val commandDomainPort: CommandDomainPort,
+    private val queryWorkspacePort: QueryWorkspacePort,
+    private val workspaceInfo: WorkspaceInfo
+) : BehaviorSpec({
+    val domainId = UUID.randomUUID().toString()
+
+    given("도메인이 주어지고") {
+        val workspace = queryWorkspacePort.findById("d57b42f5-5cc4-440b-8dce-b4fc2e372eff")!!
+        workspaceInfo.workspace = workspace
+        val domain = DomainGenerator.generateDomain(id = domainId, workspace = workspace)
+        commandDomainPort.save(domain)
+
+        `when`("조회할때") {
+            val result = getDomainUseCase.execute()
+
+            then("주어진 도메인의 정보가 응답되야함") {
+                result.list.size shouldBe 1
+
+                result.list[0] shouldBe domain.toResDto()
+            }
+        }
+
+        `when`("워크스페이스 정보가 초기화되지 않았을때") {
+            workspaceInfo.workspace = null
+
+            then("에러가 발생해야함") {
+                shouldThrow<WorkspaceNotFoundException> {
+                    getDomainUseCase.execute()
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/dcd/server/presentation/domain/domain/DomainWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/domain/DomainWebAdapterTest.kt
@@ -1,17 +1,18 @@
 package com.dcd.server.presentation.domain.domain
 
+import com.dcd.server.core.common.data.dto.response.ListResDto
 import com.dcd.server.core.domain.domain.dto.request.CreateDomainReqDto
 import com.dcd.server.core.domain.domain.dto.response.CreateDomainResDto
-import com.dcd.server.core.domain.domain.usecase.ConnectDomainUseCase
-import com.dcd.server.core.domain.domain.usecase.CreateDomainUseCase
-import com.dcd.server.core.domain.domain.usecase.DeleteDomainUseCase
-import com.dcd.server.core.domain.domain.usecase.DisconnectDomainUseCase
+import com.dcd.server.core.domain.domain.dto.response.DomainResDto
+import com.dcd.server.core.domain.domain.usecase.*
 import com.dcd.server.presentation.domain.domain.data.request.ConnectDomainRequest
 import com.dcd.server.presentation.domain.domain.data.request.CreateDomainRequest
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.springframework.http.HttpStatus
 import java.util.UUID
 
@@ -21,12 +22,14 @@ class DomainWebAdapterTest : BehaviorSpec({
     val deleteDomainUseCase = mockk<DeleteDomainUseCase>(relaxUnitFun = true)
     val connectDomainUseCase = mockk<ConnectDomainUseCase>(relaxUnitFun = true)
     val disconnectDomainUseCase = mockk<DisconnectDomainUseCase>(relaxUnitFun = true)
+    val getDomainUseCase = mockk<GetDomainUseCase>()
 
     val domainWebAdapter = DomainWebAdapter(
         createDomainUseCase = createDomainUseCase,
         deleteDomainUseCase = deleteDomainUseCase,
         connectDomainUseCase = connectDomainUseCase,
         disconnectDomainUseCase = disconnectDomainUseCase,
+        getDomainUseCase = getDomainUseCase
     )
 
     given("CreateDomainRequest가 주어지고") {
@@ -74,6 +77,32 @@ class DomainWebAdapterTest : BehaviorSpec({
             then("200으로 응답되어야함") {
                 result.statusCode shouldBe HttpStatus.OK
                 result.body shouldBe null
+            }
+        }
+    }
+
+    given("아무것도 주어지지 않고") {
+
+        `when`("도메인을 조회할때") {
+            val domainResDto = DomainResDto(id = UUID.randomUUID().toString(), name = "testDomain", description = "test", application = null)
+            every { getDomainUseCase.execute() } returns ListResDto(listOf(domainResDto))
+
+            val result = domainWebAdapter.getDomainList(workspaceId)
+
+            then("유스케이스에서 반환된 값의 정보를 가지고 있어야함") {
+                val list = result.body?.list
+                list shouldNotBe null
+                list!!.size shouldBe 1
+
+                val domainResponse = list[0]
+                domainResponse.id shouldBe domainResDto.id
+                domainResponse.name shouldBe domainResDto.name
+                domainResponse.description shouldBe domainResDto.description
+                domainResponse.application shouldBe domainResDto.application
+            }
+
+            then("응답 상태는 OK여야함") {
+                result.statusCode shouldBe HttpStatus.OK
             }
         }
     }


### PR DESCRIPTION
## 개요
* 도메인 정보를 조회하는 API를 추가합니다.
## 작업내용
* 워크스페이스를 기준으로 도메인을 조회하는 메서드 추가
* 도메인 응답 dto 추가
* 도메인 조회 유스케이스 추가
* 도메인 응답 객체 추가
* 도메인 조회 엔드포인트 추가
* 도메인 조회 유스케이스 테스트 추가
* 도메인 조회 웹어뎁터 테스트 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?