### PR TITLE
🔀 :: [#666] - 도메인 관련 유스케이스에서 워크스페이스 정보를 검증하는 로직 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,4 @@ src/main/resources/application-test.yml
 
 getImageVersion.sh
 
-sql/
+/sql/

--- a/src/main/kotlin/com/dcd/server/core/domain/domain/usecase/ConnectDomainUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/domain/usecase/ConnectDomainUseCase.kt
@@ -25,6 +25,9 @@ class ConnectDomainUseCase(
         val domain = (queryDomainPort.findById(domainId)
             ?: throw DomainNotFoundException())
 
+        if (domain.workspace != workspaceInfo.workspace)
+            throw DomainNotFoundException()
+
         if (domain.application != null)
             throw AlreadyConnectedDomainException()
 

--- a/src/main/kotlin/com/dcd/server/core/domain/domain/usecase/DeleteDomainUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/domain/usecase/DeleteDomainUseCase.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.core.domain.domain.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.common.data.WorkspaceInfo
 import com.dcd.server.core.domain.domain.exception.AlreadyConnectedDomainException
 import com.dcd.server.core.domain.domain.exception.DomainNotFoundException
 import com.dcd.server.core.domain.domain.spi.CommandDomainPort
@@ -9,11 +10,15 @@ import com.dcd.server.core.domain.domain.spi.QueryDomainPort
 @UseCase
 class DeleteDomainUseCase(
     private val queryDomainPort: QueryDomainPort,
-    private val commandDomainPort: CommandDomainPort
+    private val commandDomainPort: CommandDomainPort,
+    private val workspaceInfo: WorkspaceInfo
 ) {
     fun execute(id: String) {
         val domain = (queryDomainPort.findById(id)
             ?: throw DomainNotFoundException())
+
+        if (domain.workspace != workspaceInfo.workspace)
+            throw DomainNotFoundException()
 
         if (domain.application != null)
             throw AlreadyConnectedDomainException()

--- a/src/main/kotlin/com/dcd/server/core/domain/domain/usecase/DisconnectDomainUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/domain/usecase/DisconnectDomainUseCase.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.core.domain.domain.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.common.data.WorkspaceInfo
 import com.dcd.server.core.domain.domain.exception.DomainNotFoundException
 import com.dcd.server.core.domain.domain.service.RebootNginxService
 import com.dcd.server.core.domain.domain.service.RemoveHttpConfigService
@@ -12,11 +13,15 @@ class DisconnectDomainUseCase(
     private val queryDomainPort: QueryDomainPort,
     private val commandDomainPort: CommandDomainPort,
     private val removeHttpConfigService: RemoveHttpConfigService,
-    private val rebootNginxService: RebootNginxService
+    private val rebootNginxService: RebootNginxService,
+    private val workspaceInfo: WorkspaceInfo
 ) {
     fun execute(domainId: String) {
         val domain = (queryDomainPort.findById(domainId)
             ?: throw DomainNotFoundException())
+
+        if (workspaceInfo.workspace != domain.workspace)
+            throw DomainNotFoundException()
 
         val updatedDomain = domain.copy(application = null)
         commandDomainPort.save(updatedDomain)

--- a/src/test/kotlin/com/dcd/server/core/domain/domain/usecase/ConnectDomainUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/domain/usecase/ConnectDomainUseCaseTest.kt
@@ -94,6 +94,23 @@ class ConnectDomainUseCaseTest(
             }
         }
 
+        `when`("타겟 도메인이 해당 워크스페이스랑 다른 워크스페이스에 위치할때") {
+            val existingWorkspace = workspaceInfo.workspace!!
+            val otherWorkspace = WorkspaceGenerator.generateWorkspace(user = existingWorkspace.owner)
+            commandWorkspacePort.save(otherWorkspace)
+            workspaceInfo.workspace = otherWorkspace
+
+            val request = ConnectDomainReqDto(applicationId)
+
+            then("에러가 발생해야함") {
+                shouldThrow<DomainNotFoundException> {
+                    connectDomainUseCase.execute(domainId, request)
+                }
+            }
+
+            workspaceInfo.workspace = existingWorkspace
+        }
+
         `when`("타겟 애플리케이션이 해당 워크스페이스랑 다른 워크스페이스에 위치할때") {
             val otherWorkspace = WorkspaceGenerator.generateWorkspace(user = workspaceInfo.workspace!!.owner)
             commandWorkspacePort.save(otherWorkspace)

--- a/src/test/kotlin/com/dcd/server/core/domain/domain/usecase/DeleteDomainUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/domain/usecase/DeleteDomainUseCaseTest.kt
@@ -1,10 +1,12 @@
 package com.dcd.server.core.domain.domain.usecase
 
+import com.dcd.server.core.common.data.WorkspaceInfo
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.domain.exception.AlreadyConnectedDomainException
 import com.dcd.server.core.domain.domain.exception.DomainNotFoundException
 import com.dcd.server.core.domain.domain.spi.CommandDomainPort
 import com.dcd.server.core.domain.domain.spi.QueryDomainPort
+import com.dcd.server.core.domain.workspace.spi.CommandWorkspacePort
 import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
@@ -24,12 +26,15 @@ class DeleteDomainUseCaseTest(
     private val commandDomainPort: CommandDomainPort,
     private val queryDomainPort: QueryDomainPort,
     private val queryWorkspacePort: QueryWorkspacePort,
-    private val commandApplicationPort: CommandApplicationPort
+    private val commandWorkspacePort: CommandWorkspacePort,
+    private val commandApplicationPort: CommandApplicationPort,
+    private val workspaceInfo: WorkspaceInfo
 ) : BehaviorSpec({
     val domainId = UUID.randomUUID().toString()
 
     given("삭제할 도메인이 주어지고") {
         val workspace = queryWorkspacePort.findById("d57b42f5-5cc4-440b-8dce-b4fc2e372eff")!!
+        workspaceInfo.workspace = workspace
         val domain = DomainGenerator.generateDomain(id = domainId, workspace = workspace)
         commandDomainPort.save(domain)
 
@@ -39,6 +44,20 @@ class DeleteDomainUseCaseTest(
             then("도메인을 조회할 수 없게 되야함") {
                 queryDomainPort.findById(domainId) shouldBe null
             }
+        }
+
+        `when`("현재 워크스페이스 정보가 도메인의 워크스페이스가 아닐때") {
+            val otherWorkspace = workspace.copy(owner = workspace.owner)
+            commandWorkspacePort.save(otherWorkspace)
+            workspaceInfo.workspace = workspace
+
+            then("에러가 발생해야함") {
+                shouldThrow<DomainNotFoundException> {
+                    deleteDomainUseCase.execute(domainId)
+                }
+            }
+
+            workspaceInfo.workspace = workspace
         }
 
         `when`("이미 연결되어있는 도메인일때") {

--- a/src/test/kotlin/com/dcd/server/core/domain/domain/usecase/DisconnectDomainUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/domain/usecase/DisconnectDomainUseCaseTest.kt
@@ -6,6 +6,7 @@ import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.domain.exception.DomainNotFoundException
 import com.dcd.server.core.domain.domain.spi.CommandDomainPort
 import com.dcd.server.core.domain.domain.spi.QueryDomainPort
+import com.dcd.server.core.domain.workspace.spi.CommandWorkspacePort
 import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.assertions.throwables.shouldThrow
@@ -16,6 +17,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
 import util.domain.DomainGenerator
+import util.workspace.WorkspaceGenerator
 import java.util.*
 
 @Transactional
@@ -25,6 +27,7 @@ class DisconnectDomainUseCaseTest(
     private val disconnectDomainUseCase: DisconnectDomainUseCase,
     private val commandDomainPort: CommandDomainPort,
     private val queryDomainPort: QueryDomainPort,
+    private val commandWorkspacePort: CommandWorkspacePort,
     private val queryWorkspacePort: QueryWorkspacePort,
     private val queryApplicationPort: QueryApplicationPort,
     private val workspaceInfo: WorkspaceInfo,
@@ -69,6 +72,18 @@ class DisconnectDomainUseCaseTest(
             }
 
             commandDomainPort.save(domain)
+        }
+
+        `when`("워크스페이스 정보가 도메인의 워크스페이스가 아닐때") {
+            val otherWorkspace = workspaceInfo.workspace!!.copy(id = UUID.randomUUID().toString())
+            commandWorkspacePort.save(otherWorkspace)
+            workspaceInfo.workspace = otherWorkspace
+
+            then("에러가 발생해야함") {
+                shouldThrow<DomainNotFoundException> {
+                    disconnectDomainUseCase.execute(domainId)
+                }
+            }
         }
     }
 })


### PR DESCRIPTION
## 개요
* 도메인 관련 유스케이스에서 워크스페이스 정보를 검증하는 로직을 추가합니다.
## 작업내용
* gitignore sql 디렉토리 명시 수정
* 연결해제 유스케이스에 워크스페이스 검증 로직 추가
* 연결 유스케이스에 워크스페이스 검증 로직 추가
* 도메인 삭제 유스케이스에 워크스페이스 검증 로직 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [ ] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?