### PR TITLE
🔀 :: [#678] - 애플리케이션 환경변수에 워크스페이스 연관관계 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/PutApplicationEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/PutApplicationEnvUseCase.kt
@@ -22,6 +22,9 @@ class PutApplicationEnvUseCase(
 ) {
     @Lock("#id")
     fun execute(id: String, putApplicationEnvReqDto: PutApplicationEnvReqDto) {
+        val workspace = workspaceInfo.workspace
+            ?: throw WorkspaceNotFoundException()
+
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
 
@@ -29,7 +32,8 @@ class PutApplicationEnvUseCase(
             id = UUID.randomUUID(),
             name = putApplicationEnvReqDto.name,
             description = putApplicationEnvReqDto.description,
-            details = listOf()
+            details = listOf(),
+            workspace = workspace
         )
 
         val applicationEnvDetailList = putApplicationEnvReqDto.envList.map { putEnv ->
@@ -56,6 +60,7 @@ class PutApplicationEnvUseCase(
     fun execute(labels: List<String>, putApplicationEnvReqDto: PutApplicationEnvReqDto) {
         val workspace = workspaceInfo.workspace
             ?: throw WorkspaceNotFoundException()
+
         val applicationList = queryApplicationPort.findAllByWorkspace(workspace, labels)
 
         applicationList.forEach { application ->
@@ -64,7 +69,8 @@ class PutApplicationEnvUseCase(
                 id = UUID.randomUUID(),
                 name = putApplicationEnvReqDto.name,
                 description = putApplicationEnvReqDto.description,
-                details = listOf()
+                details = listOf(),
+                workspace = workspace
             )
 
             val applicationEnvDetailList = putApplicationEnvReqDto.envList.map { putEnv ->

--- a/src/main/kotlin/com/dcd/server/core/domain/env/model/ApplicationEnv.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/env/model/ApplicationEnv.kt
@@ -1,10 +1,12 @@
 package com.dcd.server.core.domain.env.model
 
+import com.dcd.server.core.domain.workspace.model.Workspace
 import java.util.*
 
 data class ApplicationEnv(
     val id: UUID = UUID.randomUUID(),
     val name: String,
     val description: String,
-    val details: List<ApplicationEnvDetail>
+    val details: List<ApplicationEnvDetail>,
+    val workspace: Workspace
 )

--- a/src/main/kotlin/com/dcd/server/persistence/env/adapter/EnvAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/env/adapter/EnvAdapter.kt
@@ -15,7 +15,8 @@ fun ApplicationEnv.toEntity(): ApplicationEnvEntity =
         id = this.id,
         name = this.name,
         description = this.description,
-        details = listOf()
+        details = listOf(),
+        workspace = this.workspace.toEntity()
     )
 
 fun ApplicationEnvEntity.toDomain(): ApplicationEnv =
@@ -23,7 +24,8 @@ fun ApplicationEnvEntity.toDomain(): ApplicationEnv =
         id = this.id,
         name = this.name,
         description = this.description,
-        details = this.details.map { it.toDomain() }
+        details = this.details.map { it.toDomain() },
+        workspace = this.workspace.toDomain()
     )
 
 fun ApplicationEnvDetailEntity.toDomain(): ApplicationEnvDetail =

--- a/src/main/kotlin/com/dcd/server/persistence/env/entity/ApplicationEnvEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/env/entity/ApplicationEnvEntity.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.persistence.env.entity
 
 import com.dcd.server.persistence.env.entity.common.Env
+import com.dcd.server.persistence.workspace.entity.WorkspaceJpaEntity
 import jakarta.persistence.*
 import java.util.*
 import kotlin.collections.List
@@ -11,5 +12,8 @@ class ApplicationEnvEntity(
     name: String,
     description: String,
     @OneToMany(mappedBy = "applicationEnv", cascade = [CascadeType.REMOVE])
-    val details: List<ApplicationEnvDetailEntity>
+    val details: List<ApplicationEnvDetailEntity>,
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "workspace_id")
+    val workspace: WorkspaceJpaEntity,
 ) : Env(id, name, description)

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/DeleteApplicationEnvUseCaseTest.kt
@@ -41,6 +41,7 @@ class DeleteApplicationEnvUseCaseTest(
             name = "testEnv",
             description = "testEnvDescription",
             details = listOf(ApplicationEnvDetail(id = targetApplicationDetailId, key = "testKey", value = "testValue")),
+            workspace = application.workspace
         )
         commandApplicationEnvPort.save(applicationEnv, application)
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/PutApplicationEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/PutApplicationEnvUseCaseTest.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.core.domain.application.usecase
 
+import com.dcd.server.core.common.data.WorkspaceInfo
 import com.dcd.server.core.common.spi.EncryptPort
 import com.dcd.server.core.domain.application.dto.request.PutApplicationEnvReqDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
@@ -22,9 +23,14 @@ class PutApplicationEnvUseCaseTest(
     private val putApplicationEnvUseCase: PutApplicationEnvUseCase,
     private val queryApplicationPort: QueryApplicationPort,
     private val queryApplicationEnvPort: QueryApplicationEnvPort,
-    private val encryptPort: EncryptPort
+    private val encryptPort: EncryptPort,
+    private val workspaceInfo: WorkspaceInfo
 ) : BehaviorSpec({
     val targetApplicationId = "2fb0f315-8272-422f-8e9f-c4f765c022b2"
+    beforeTest {
+        val application = queryApplicationPort.findById(targetApplicationId)!!
+        workspaceInfo.workspace = application.workspace
+    }
 
     given("애플리케이션 아이디와 request가 주어지고") {
         val request = PutApplicationEnvReqDto(

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -16,12 +16,13 @@ create table role_entity (roles varchar(255) check (roles in ('ROLE_ADMIN','ROLE
 create table user_entity (email varchar(255), id binary(16) not null, name varchar(255), password varchar(255), status varchar(255) check (status in ('PENDING','CREATED')), primary key (id));
 create table workspace_entity (description varchar(255), id binary(16) not null, owner_id binary(16), title varchar(255), primary key (id));
 create table domain_entity (id binary(16), name varchar(255), description varchar(255), application_id binary(16), workspace_id binary(16), primary key(id));
-create table application_env_entity (id BINARY(16) not null, description varchar(255), name varchar(255), primary key (id));
+create table application_env_entity (id BINARY(16) not null, description varchar(255), name varchar(255), workspace_id binary(16), primary key (id));
 create table application_env_detail_entity (id BINARY(16) not null, encryption bit not null, env_key varchar(255), env_value varchar(255), env_id BINARY(16), primary key (id));
 create table application_env_matcher_entity (id BINARY(16) not null, application_id BINARY(16), env_id BINARY(16), primary key (id));
 alter table if exists application_env_detail_entity add constraint FKtjqi6ag33hu1vxeg5kgc58ga6 foreign key (env_id) references application_env_entity (id);
 alter table if exists application_env_matcher_entity add constraint FK4ivou7scuc0dg5af4g7epjdj0 foreign key (application_id) references application_entity (id);
 alter table if exists application_env_matcher_entity add constraint FKqfkw6tgy65k4x6syrh6p858ic foreign key (env_id) references application_env_entity (id);
+alter table if exists application_env_entity add constraint FKm22cqdjjl434jyqenpa4nf78p foreign key (workspace_id) references workspace_entity (id);
 alter table if exists application_entity add constraint FKn9drxkrx2h6wlorxfy00mr45h foreign key (workspace_id) references workspace_entity;
 alter table if exists application_label_entity add constraint FKq6iovxq5tdx2i1lwrx34kg0b9 foreign key (application_id) references application_entity;
 alter table if exists role_entity add constraint FKrot6fehcor0f3sux5s6kgl0a4 foreign key (user_id) references user_entity;


### PR DESCRIPTION
## 개요
* 애플리케이션 환경변수가 워크스페이스 내부에 속하도록 연관관계를 추가합니다.
## 작업내용
* 애플리케이션 환경변수 엔티티에 workspace 필드 추가
* 애플리케이션 환경변수 도메인 모델에 workspace 필드 추가
* EnvAdapter에서 workspace를 초기화하는 부분 추가
* 환경변수 삽입시 workspace를 가져오는 로직 추가
* 테스트 관련 설정 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?