### PR TITLE
🔀 :: [#696] - 환경변수 삭제시 애플리케이션 재배포 적용

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/env/spi/QueryApplicationEnvPort.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/env/spi/QueryApplicationEnvPort.kt
@@ -3,6 +3,7 @@ package com.dcd.server.core.domain.env.spi
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.env.model.ApplicationEnv
 import com.dcd.server.core.domain.env.model.ApplicationEnvDetail
+import com.dcd.server.core.domain.env.model.ApplicationEnvMatcher
 import com.dcd.server.core.domain.workspace.model.Workspace
 import java.util.UUID
 
@@ -16,4 +17,6 @@ interface QueryApplicationEnvPort {
     fun findAllByWorkspace(workspace: Workspace): List<ApplicationEnv>
 
     fun findAllByLabelsIn(workspace: Workspace, labels: List<String>): List<ApplicationEnv>
+
+    fun findAllMatcherByEnv(applicationEnv: ApplicationEnv): List<ApplicationEnvMatcher>
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/env/usecase/DeleteApplicationEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/env/usecase/DeleteApplicationEnvUseCase.kt
@@ -1,19 +1,28 @@
 package com.dcd.server.core.domain.env.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.domain.application.event.DeployApplicationEvent
 import com.dcd.server.core.domain.env.exception.ApplicationEnvNotFoundException
 import com.dcd.server.core.domain.env.spi.CommandApplicationEnvPort
 import com.dcd.server.core.domain.env.spi.QueryApplicationEnvPort
+import org.springframework.context.ApplicationEventPublisher
 import java.util.UUID
 
 @UseCase
 class DeleteApplicationEnvUseCase(
     private val queryApplicationEnvPort: QueryApplicationEnvPort,
-    private val commandApplicationEnvPort: CommandApplicationEnvPort
+    private val commandApplicationEnvPort: CommandApplicationEnvPort,
+    private val eventPublisher: ApplicationEventPublisher
 ) {
     fun execute(envId: UUID) {
         val applicationEnv = queryApplicationEnvPort.findById(envId)
             ?: throw ApplicationEnvNotFoundException()
         commandApplicationEnvPort.delete(applicationEnv)
+
+        val envMatcher = queryApplicationEnvPort.findAllMatcherByEnv(applicationEnv)
+        val applicationSet = envMatcher.map { it.application }.toSet()
+        if (applicationSet.isNotEmpty()) {
+            eventPublisher.publishEvent(DeployApplicationEvent(applicationSet.map { it.id }))
+        }
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/env/usecase/DeleteApplicationEnvUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/env/usecase/DeleteApplicationEnvUseCase.kt
@@ -27,12 +27,12 @@ class DeleteApplicationEnvUseCase(
         if (applicationEnv.workspace != workspace)
             throw ApplicationEnvNotFoundException()
 
-        commandApplicationEnvPort.delete(applicationEnv)
-
         val envMatcher = queryApplicationEnvPort.findAllMatcherByEnv(applicationEnv)
         val applicationSet = envMatcher.map { it.application }.toSet()
         if (applicationSet.isNotEmpty()) {
             eventPublisher.publishEvent(DeployApplicationEvent(applicationSet.map { it.id }))
         }
+
+        commandApplicationEnvPort.delete(applicationEnv)
     }
 }

--- a/src/main/kotlin/com/dcd/server/persistence/env/ApplicationEnvPersistenceAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/env/ApplicationEnvPersistenceAdapter.kt
@@ -45,6 +45,10 @@ class ApplicationEnvPersistenceAdapter(
         applicationEnvRepository.findAllByWorkspaceAndLabelsIn(workspace.toEntity(), labels)
             .map { it.toDomain() }
 
+    override fun findAllMatcherByEnv(applicationEnv: ApplicationEnv): List<ApplicationEnvMatcher> =
+        applicationEnvMatcherRepository.findAllByApplicationEnv(applicationEnv.toEntity())
+            .map { it.toDomain() }
+
     override fun save(applicationEnv: ApplicationEnv) {
         val envEntity = applicationEnv.toEntity()
         applicationEnvRepository.save(envEntity)

--- a/src/main/kotlin/com/dcd/server/persistence/env/repository/ApplicationEnvMatcherRepository.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/env/repository/ApplicationEnvMatcherRepository.kt
@@ -10,4 +10,5 @@ interface ApplicationEnvMatcherRepository : JpaRepository<ApplicationEnvMatcherE
     fun deleteByApplicationEnv(applicationEnv: ApplicationEnvEntity)
     fun deleteByApplicationEnvIn(applicationEnvList: List<ApplicationEnvEntity>)
     fun findByApplication(application: ApplicationJpaEntity): List<ApplicationEnvMatcherEntity>
+    fun findAllByApplicationEnv(applicationEnv: ApplicationEnvEntity): List<ApplicationEnvMatcherEntity>
 }

--- a/src/test/kotlin/com/dcd/server/core/domain/env/usecase/DeleteApplicationEnvUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/env/usecase/DeleteApplicationEnvUseCaseTest.kt
@@ -1,17 +1,23 @@
 package com.dcd.server.core.domain.env.usecase
 
+import com.dcd.server.core.common.data.WorkspaceInfo
 import com.dcd.server.core.domain.env.exception.ApplicationEnvNotFoundException
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.env.model.ApplicationEnv
 import com.dcd.server.core.domain.env.model.ApplicationEnvDetail
 import com.dcd.server.core.domain.env.spi.CommandApplicationEnvPort
 import com.dcd.server.core.domain.env.spi.QueryApplicationEnvPort
+import com.dcd.server.core.domain.user.spi.QueryUserPort
+import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
+import com.dcd.server.core.domain.workspace.spi.CommandWorkspacePort
+import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
+import util.workspace.WorkspaceGenerator
 import java.util.UUID
 
 @Transactional
@@ -21,7 +27,11 @@ class DeleteApplicationEnvUseCaseTest(
     private val deleteApplicationEnvUseCase: DeleteApplicationEnvUseCase,
     private val queryApplicationPort: QueryApplicationPort,
     private val commandApplicationEnvPort: CommandApplicationEnvPort,
-    private val queryApplicationEnvPort: QueryApplicationEnvPort
+    private val queryApplicationEnvPort: QueryApplicationEnvPort,
+    private val commandWorkspacePort: CommandWorkspacePort,
+    private val queryWorkspacePort: QueryWorkspacePort,
+    private val queryUserPort: QueryUserPort,
+    private val workspaceInfo: WorkspaceInfo
 ) : BehaviorSpec({
     val targetApplicationEnvId = UUID.randomUUID()
 
@@ -39,6 +49,11 @@ class DeleteApplicationEnvUseCaseTest(
     }
 
     given("삭제할 애플리케이션의 아이디가 주어지고") {
+        beforeTest {
+            val workspace = queryWorkspacePort.findById("d57b42f5-5cc4-440b-8dce-b4fc2e372eff")
+            workspaceInfo.workspace = workspace
+        }
+
         `when`("유스케이스를 실행할때") {
             deleteApplicationEnvUseCase.execute(targetApplicationEnvId)
 
@@ -53,6 +68,39 @@ class DeleteApplicationEnvUseCaseTest(
             then("에러가 발생해야함") {
                 shouldThrow<ApplicationEnvNotFoundException> {
                     deleteApplicationEnvUseCase.execute(notfoundEnvId)
+                }
+            }
+        }
+    }
+
+    given("워크스페이스 정보가 주어지지않고") {
+        beforeTest {
+            workspaceInfo.workspace = null
+        }
+
+        `when`("유스케이스를 실행할때") {
+
+            then("에러가 발생해야함") {
+                shouldThrow<WorkspaceNotFoundException> {
+                    deleteApplicationEnvUseCase.execute(targetApplicationEnvId)
+                }
+            }
+        }
+    }
+
+    given("환경변수가 속해있지 않은 워크스페이스 정보가 주어지고") {
+        beforeTest {
+            val user = queryUserPort.findById("1e1973eb-3fb9-47ac-9342-c16cd63ffc6f")!!
+            val workspace = WorkspaceGenerator.generateWorkspace(user = user)
+            commandWorkspacePort.save(workspace)
+            workspaceInfo.workspace = workspace
+        }
+
+        `when`("유스케이스를 실행할때") {
+
+            then("에러가 발생해야함") {
+                shouldThrow<ApplicationEnvNotFoundException> {
+                    deleteApplicationEnvUseCase.execute(targetApplicationEnvId)
                 }
             }
         }


### PR DESCRIPTION
## 개요
* 환경변수 삭제시 애플리케이션 재배포 이벤트 발행을 적용합니다.
## 작업내용
* 환경변수 매칭 엔티티를 조회하는 쿼리 메서드 추가
* 환경변수 매칭 관계 조회 메서드 추가
* 환경변수 삭제시 애플리케이션 배포 이벤트를 발행하는 로직 추가
* 환경변수 삭제시 워크스페이스 검증 로직 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [ ] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신기능**
  - 특정 환경에 연결된 매처(매칭 규칙)를 조회하는 기능을 추가해, 환경 관련 구성을 더 쉽게 확인할 수 있습니다.
  - 삭제 시 워크스페이스 기반 유효성 검사를 적용해, 현재 워크스페이스에 속하지 않은 환경은 삭제되지 않도록 보호합니다.
  - 환경 삭제 전 관련 애플리케이션에 대한 재배포 이벤트를 자동으로 발행해 일관된 상태를 유지합니다.

- **테스트**
  - 워크스페이스 미설정·불일치 시 예외 경로를 포함해 삭제 플로우 테스트를 확장했습니다.
  - 정상 삭제와 재배포 트리거 동작을 검증하는 시나리오를 보강했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->