### PR TITLE
🔀 :: [#705] - 볼륨 테이블 not null 제약 조건 추가

### DIFF
--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -23,7 +23,7 @@ create table application_env_entity (id BINARY(16) not null, description varchar
 create table application_env_detail_entity (id BINARY(16) not null, encryption bit not null, env_key varchar(255), env_value varchar(255), env_id BINARY(16), primary key (id));
 create table application_env_matcher_entity (id BINARY(16) not null, application_id BINARY(16), env_id BINARY(16), primary key (id));
 create table application_env_label_entity (application_env_id BINARY(16) not null, label varchar(255));
-create table volume_entity (id BINARY(16) not null, description varchar(255), name varchar(255), physical_path varchar(255) not null, workspace_id BINARY(16), primary key (id));
+create table volume_entity (id BINARY(16) not null, description varchar(255), name varchar(255), physical_path varchar(255) not null, workspace_id BINARY(16) not null, primary key (id));
 create table volume_mount_entity (id BINARY(16) not null, mount_path varchar(255) not null, application_id BINARY(16) not null, volume_id BINARY(16) not null, read_only bit(1) not null, primary key (id));
 alter table if exists volume_entity add constraint FKhp1ggnqtveky8po2cwsb45una foreign key (workspace_id) references workspace_entity (id) on delete cascade;
 alter table if exists volume_mount_entity add constraint FKr5bb2ev813ioxtylyobgdphel foreign key (application_id) references application_entity (id) on delete cascade;


### PR DESCRIPTION
## 개요
* 볼륨 관련 테이블에서 도메인상 필수인 컬럼들에 NOT NULL 제약 조건을 추가하여 데이터 무결성을 강화함.
## 작업내용
* 볼륨및 볼륨 마운트 테이블 생성 쿼리에 not null 지정
* 볼륨및 볼륨 마운트 테이블 연관관계에 cascade 옵션 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * 데이터 무결성 강화: 볼륨 경로, 워크스페이스/애플리케이션/볼륨 연관 ID, 마운트 경로 및 읽기 전용 플래그에 대해 NULL을 허용하지 않음.
  * 연쇄 삭제 적용: 워크스페이스·애플리케이션·볼륨 삭제 시 관련 마운트와 볼륨이 자동으로 함께 삭제되어 고아 데이터 방지.
  * 전반적 안정성 향상: 볼륨 관리와 리소스 수명주기 동기화가 더 예측 가능하고 일관되게 동작합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->