### PR TITLE
🔀 :: [#709] - 볼륨 삭제 API 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
@@ -23,6 +23,7 @@ enum class ErrorCode(
     ALREADY_CONNECTED_DOMAIN("이미 연결된 도메인", 400),
     NOT_CONNECTED_DOMAIN("도메인이 애플리케이션에 연결되어 있지 않음", 400),
     ALREADY_EXISTS_VOLUME("이미 존재하는 볼륨", 400),
+    ALREADY_EXISTS_VOLUME_MOUNT("볼륨 마운트가 존재합니다.", 400),
 
     UNAUTHORIZED("권한이 없음", 401),
     EXPIRED_TOKEN("토큰이 만료됨", 401),
@@ -45,6 +46,7 @@ enum class ErrorCode(
     WORKSPACE_NOT_FOUND("해당 워크스페이스를 찾을 수 없음", 404),
     AUTH_CODE_NOT_FOUND("인증 코드를 찾을 수 없습니다. 코드를 다시 전송 해주세요.", 404),
     DOMAIN_NOT_FOUND("해당 도메인을 찾을 수 없음", 404),
+    VOLUME_NOT_FOUND("해당 볼륨을 찾을 수 없음", 404),
 
     CONFLICT("해당 요청은 서버의 상태와 충돌됩니다.", 409),
     CAN_NOT_DEPLOY_APPLICATION("애플리케이션을 배포할 수 없습니다. 애플리케이션을 정지시킨 후 실행해주세요.", 409),
@@ -61,4 +63,5 @@ enum class ErrorCode(
     INTERNAL_ERROR("서버 내부 에러", 500),
     INVALID_PARSING_OBJECT_FIELD("파싱할 필드가 올바르게 설정되어있지 않는 객체임", 500),
     FAILURE_VOLUME_CREATION("컨테이너 볼륨 생성에 실패했습니다.", 500),
+    FAILURE_VOLUME_DELETE("컨테이너 볼륨 삭제에 실패했습니다.", 500),
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/exception/AlreadyExistsVolumeMountException.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/exception/AlreadyExistsVolumeMountException.kt
@@ -1,0 +1,6 @@
+package com.dcd.server.core.domain.volume.exception
+
+import com.dcd.server.core.common.error.BasicException
+import com.dcd.server.core.common.error.ErrorCode
+
+class AlreadyExistsVolumeMountException : BasicException(ErrorCode.ALREADY_EXISTS_VOLUME_MOUNT)

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/exception/VolumeCreationFailureException.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/exception/VolumeCreationFailureException.kt
@@ -3,4 +3,4 @@ package com.dcd.server.core.domain.volume.exception
 import com.dcd.server.core.common.error.BasicException
 import com.dcd.server.core.common.error.ErrorCode
 
-class VolumeCreationFailedException : BasicException(ErrorCode.FAILURE_VOLUME_CREATION)
+class VolumeCreationFailureException : BasicException(ErrorCode.FAILURE_VOLUME_CREATION)

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/exception/VolumeDeleteFailureException.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/exception/VolumeDeleteFailureException.kt
@@ -1,0 +1,6 @@
+package com.dcd.server.core.domain.volume.exception
+
+import com.dcd.server.core.common.error.BasicException
+import com.dcd.server.core.common.error.ErrorCode
+
+class VolumeDeleteFailureException : BasicException(ErrorCode.FAILURE_VOLUME_DELETE)

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/exception/VolumeNotFoundException.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/exception/VolumeNotFoundException.kt
@@ -1,0 +1,6 @@
+package com.dcd.server.core.domain.volume.exception
+
+import com.dcd.server.core.common.error.BasicException
+import com.dcd.server.core.common.error.ErrorCode
+
+class VolumeNotFoundException : BasicException(ErrorCode.VOLUME_NOT_FOUND)

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/service/DeleteVolumeService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/service/DeleteVolumeService.kt
@@ -1,0 +1,7 @@
+package com.dcd.server.core.domain.volume.service
+
+import com.dcd.server.core.domain.volume.model.Volume
+
+interface DeleteVolumeService {
+    fun deleteVolume(volume: Volume)
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/service/impl/CreateDockerVolumeServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/service/impl/CreateDockerVolumeServiceImpl.kt
@@ -1,7 +1,7 @@
 package com.dcd.server.core.domain.volume.service.impl
 
 import com.dcd.server.core.common.command.CommandPort
-import com.dcd.server.core.domain.volume.exception.VolumeCreationFailedException
+import com.dcd.server.core.domain.volume.exception.VolumeCreationFailureException
 import com.dcd.server.core.domain.volume.model.Volume
 import com.dcd.server.core.domain.volume.service.CreateVolumeService
 import org.springframework.stereotype.Service
@@ -14,6 +14,6 @@ class CreateDockerVolumeServiceImpl(
         val exitValue = commandPort.executeShellCommand("docker volume create ${volume.volumeName}")
 
         if (exitValue != 0)
-            throw VolumeCreationFailedException()
+            throw VolumeCreationFailureException()
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/service/impl/DeleteDockerVolumeServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/service/impl/DeleteDockerVolumeServiceImpl.kt
@@ -1,0 +1,19 @@
+package com.dcd.server.core.domain.volume.service.impl
+
+import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.domain.volume.exception.VolumeDeleteFailureException
+import com.dcd.server.core.domain.volume.model.Volume
+import com.dcd.server.core.domain.volume.service.DeleteVolumeService
+import org.springframework.stereotype.Service
+
+@Service
+class DeleteDockerVolumeServiceImpl(
+    private val commandPort: CommandPort
+) : DeleteVolumeService {
+    override fun deleteVolume(volume: Volume) {
+        val exitValue = commandPort.executeShellCommand("docker volume rm ${volume.volumeName}")
+
+        if (exitValue != 0)
+            throw VolumeDeleteFailureException()
+    }
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/usecase/DeleteVolumeUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/usecase/DeleteVolumeUseCase.kt
@@ -1,0 +1,29 @@
+package com.dcd.server.core.domain.volume.usecase
+
+import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.domain.volume.exception.AlreadyExistsVolumeMountException
+import com.dcd.server.core.domain.volume.exception.VolumeNotFoundException
+import com.dcd.server.core.domain.volume.service.DeleteVolumeService
+import com.dcd.server.core.domain.volume.spi.CommandVolumePort
+import com.dcd.server.core.domain.volume.spi.QueryVolumePort
+import java.util.UUID
+
+@UseCase
+class DeleteVolumeUseCase(
+    private val queryVolumePort: QueryVolumePort,
+    private val commandVolumePort: CommandVolumePort,
+    private val deleteVolumeService: DeleteVolumeService
+) {
+    fun execute(volumeId: UUID) {
+        val volume = (queryVolumePort.findById(volumeId)
+            ?: throw VolumeNotFoundException())
+
+        val volumeMountList = queryVolumePort.findAllMountByVolume(volume)
+        if (volumeMountList.isNotEmpty())
+            throw AlreadyExistsVolumeMountException()
+
+        deleteVolumeService.deleteVolume(volume)
+
+        commandVolumePort.delete(volume)
+    }
+}

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
@@ -100,6 +100,7 @@ class SecurityConfig(
 
                 //volume
                 it.requestMatchers(HttpMethod.POST, "/{workspaceId}/volume").authenticated()
+                it.requestMatchers(HttpMethod.DELETE, "/{workspaceId}/volume/{volumeId}").authenticated()
 
                 //when url not set
                 it.anyRequest().denyAll()

--- a/src/main/kotlin/com/dcd/server/presentation/domain/volume/VolumeWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/volume/VolumeWebAdapter.kt
@@ -2,18 +2,22 @@ package com.dcd.server.presentation.domain.volume
 
 import com.dcd.server.core.common.annotation.WorkspaceOwnerVerification
 import com.dcd.server.core.domain.volume.usecase.CreateVolumeUseCase
+import com.dcd.server.core.domain.volume.usecase.DeleteVolumeUseCase
 import com.dcd.server.presentation.common.annotation.WebAdapter
 import com.dcd.server.presentation.domain.volume.data.extension.toDto
 import com.dcd.server.presentation.domain.volume.data.request.CreateVolumeRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import java.util.UUID
 
 @WebAdapter("/{workspaceId}/volume")
 class VolumeWebAdapter(
-    private val createVolumeUseCase: CreateVolumeUseCase
+    private val createVolumeUseCase: CreateVolumeUseCase,
+    private val deleteVolumeUseCase: DeleteVolumeUseCase
 ) {
     @PostMapping
     @WorkspaceOwnerVerification("#workspaceId")
@@ -22,5 +26,14 @@ class VolumeWebAdapter(
         @Validated @RequestBody createVolumeRequest: CreateVolumeRequest
     ): ResponseEntity<Void> =
         createVolumeUseCase.execute(createVolumeRequest.toDto())
+            .run { ResponseEntity.ok().build() }
+
+    @DeleteMapping("/{volumeId}")
+    @WorkspaceOwnerVerification("#workspaceId")
+    fun deleteVolume(
+        @PathVariable workspaceId: String,
+        @PathVariable volumeId: UUID,
+    ): ResponseEntity<Void> =
+        deleteVolumeUseCase.execute(volumeId)
             .run { ResponseEntity.ok().build() }
 }

--- a/src/main/kotlin/com/dcd/server/presentation/domain/volume/data/request/CreateVolumeRequest.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/volume/data/request/CreateVolumeRequest.kt
@@ -1,9 +1,11 @@
 package com.dcd.server.presentation.domain.volume.data.request
 
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
 
 data class CreateVolumeRequest(
     @field:NotBlank
+    @field:Pattern(regexp = "^[a-zA-Z0-9][a-zA-Z0-9_.\\s-]{0,62}$")
     val name: String,
     @field:NotBlank
     val description: String

--- a/src/test/kotlin/com/dcd/server/core/domain/volume/usecase/DeleteVolumeUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/volume/usecase/DeleteVolumeUseCaseTest.kt
@@ -1,0 +1,102 @@
+package com.dcd.server.core.domain.volume.usecase
+
+import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.common.data.WorkspaceInfo
+import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import com.dcd.server.core.domain.volume.exception.AlreadyExistsVolumeMountException
+import com.dcd.server.core.domain.volume.exception.VolumeNotFoundException
+import com.dcd.server.core.domain.volume.model.Volume
+import com.dcd.server.core.domain.volume.model.VolumeMount
+import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
+import com.dcd.server.persistence.user.repository.UserRepository
+import com.dcd.server.persistence.volume.adapter.toDomain
+import com.dcd.server.persistence.volume.adapter.toEntity
+import com.dcd.server.persistence.volume.repository.VolumeMountRepository
+import com.dcd.server.persistence.volume.repository.VolumeRepository
+import com.dcd.server.persistence.workspace.repository.WorkspaceRepository
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class DeleteVolumeUseCaseTest(
+    private val deleteVolumeUseCase: DeleteVolumeUseCase,
+    @MockkBean(relaxed = true)
+    private val commandPort: CommandPort,
+    private val volumeRepository: VolumeRepository,
+    private val volumeMountRepository: VolumeMountRepository,
+    private val workspaceRepository: WorkspaceRepository,
+    private val userRepository: UserRepository,
+    private val queryWorkspacePort: QueryWorkspacePort,
+    private val queryApplicationPort: QueryApplicationPort,
+    private val workspaceInfo: WorkspaceInfo
+) : BehaviorSpec({
+    val targetVolumeId = UUID.randomUUID()
+
+    beforeSpec {
+        val targetWorkspace = queryWorkspacePort.findById("d57b42f5-5cc4-440b-8dce-b4fc2e372eff")!!
+        workspaceInfo.workspace = targetWorkspace
+
+        val volume = Volume(
+            id = targetVolumeId,
+            name = "testVolume",
+            description = "testDescription",
+            workspace = targetWorkspace
+        )
+        volumeRepository.save(volume.toEntity())
+    }
+
+    given("타켓 볼륨 아이디가 주어지고") {
+
+        `when`("유스케이스를 실행할때") {
+            deleteVolumeUseCase.execute(targetVolumeId)
+
+            then("해당 볼륨이 삭제되어야함") {
+                volumeRepository.findByIdOrNull(targetVolumeId) shouldBe null
+            }
+        }
+    }
+
+    given("볼륨이 존재하지 않고") {
+        volumeRepository.deleteAll()
+
+        `when`("유스케이스를 실행하면") {
+
+            then("에러가 발생해야함") {
+                shouldThrow<VolumeNotFoundException> {
+                    deleteVolumeUseCase.execute(targetVolumeId)
+                }
+            }
+        }
+    }
+
+    given("마운트된 볼륨이 존재하고") {
+        val application = queryApplicationPort.findById("2fb0f315-8272-422f-8e9f-c4f765c022b2")!!
+        val volume = volumeRepository.findByIdOrNull(targetVolumeId)!!.toDomain()
+        val volumeMount = VolumeMount(
+            id = UUID.randomUUID(),
+            application = application,
+            volume = volume,
+            mountPath = "/test/volume",
+            readOnly = false
+        )
+        volumeMountRepository.save(volumeMount.toEntity())
+
+        `when`("유스케이스를 실행하면") {
+
+            then("에러가 발생해야함") {
+                shouldThrow<AlreadyExistsVolumeMountException> {
+                    deleteVolumeUseCase.execute(targetVolumeId)
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/dcd/server/presentation/domain/volume/VolumeWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/volume/VolumeWebAdapterTest.kt
@@ -2,6 +2,7 @@ package com.dcd.server.presentation.domain.volume
 
 import com.dcd.server.core.domain.volume.dto.request.CreateVolumeReqDto
 import com.dcd.server.core.domain.volume.usecase.CreateVolumeUseCase
+import com.dcd.server.core.domain.volume.usecase.DeleteVolumeUseCase
 import com.dcd.server.presentation.domain.volume.data.request.CreateVolumeRequest
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -12,8 +13,9 @@ import java.util.UUID
 
 class VolumeWebAdapterTest : BehaviorSpec({
     val createVolumeUseCase = mockk<CreateVolumeUseCase>(relaxUnitFun = true)
+    val deleteVolumeUseCase = mockk<DeleteVolumeUseCase>(relaxUnitFun = true)
 
-    val volumeWebAdapter = VolumeWebAdapter(createVolumeUseCase)
+    val volumeWebAdapter = VolumeWebAdapter(createVolumeUseCase, deleteVolumeUseCase)
 
     given("워크스페이스 아이디와 볼륨 생성 요청이 주어지고") {
         val testWorkspaceId = UUID.randomUUID().toString()
@@ -28,6 +30,23 @@ class VolumeWebAdapterTest : BehaviorSpec({
 
             then("볼륨 생성 유스케이스를 실행해야함") {
                 verify { createVolumeUseCase.execute(any() as CreateVolumeReqDto) }
+            }
+        }
+    }
+
+    given("워크스페이스 아이디와 삭제할 볼륨 아이디가 주어지고") {
+        val testWorkspaceId = UUID.randomUUID().toString()
+        val testVolumeId = UUID.randomUUID()
+
+        `when`("볼륨 삭제 메서드를 실행하면") {
+            val result = volumeWebAdapter.deleteVolume(testWorkspaceId, testVolumeId)
+
+            then("상태코드 OK가 응답되어야함") {
+                result.statusCode shouldBe HttpStatus.OK
+            }
+
+            then("볼륨 삭제 유스케이스를 실행해야함") {
+                verify { deleteVolumeUseCase.execute(testVolumeId) }
             }
         }
     }


### PR DESCRIPTION
## 개요
* 볼륨을 삭제하는 API를 추가합니다.
## 작업내용
* 볼륨 생성 실패 예외 네이밍 수정
* 볼륨 삭제에 필요한 예외 추가
* 컨테이너 볼륨 삭제 서비스 추가
* 볼륨 삭제 유스케이스 추가
* 볼륨 삭제 엔드포인트 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 워크스페이스 내 볼륨 삭제 기능(DELETE API) 추가 및 도커 볼륨 삭제 서비스 도입
  - 삭제 전 볼륨 존재/마운트 검증 로직 적용
  - 신규 오류 코드(볼륨 마운트 존재, 볼륨 미존재, 볼륨 삭제 실패) 및 관련 예외 추가
  - 요청 유효성: 볼륨 이름 정규식 검증 추가
- **Chores**
  - 볼륨 삭제 엔드포인트에 인증 요구사항 추가
- **Refactor**
  - 볼륨 관련 예외 명칭/구조 정비
- **Tests**
  - 볼륨 삭제 성공/미존재/마운트 존재 시나리오 및 웹 어댑터 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->