### PR TITLE
🔀 :: [#711] - 볼륨 수정 API 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
@@ -64,4 +64,5 @@ enum class ErrorCode(
     INVALID_PARSING_OBJECT_FIELD("파싱할 필드가 올바르게 설정되어있지 않는 객체임", 500),
     FAILURE_VOLUME_CREATION("컨테이너 볼륨 생성에 실패했습니다.", 500),
     FAILURE_VOLUME_DELETE("컨테이너 볼륨 삭제에 실패했습니다.", 500),
+    FAILURE_VOLUME_COPY("컨테이너 볼륨 복제에 실패했습니다.", 500),
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/dto/extension/VolumeDtoExtension.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/dto/extension/VolumeDtoExtension.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.core.domain.volume.dto.extension
 
 import com.dcd.server.core.domain.volume.dto.request.CreateVolumeReqDto
+import com.dcd.server.core.domain.volume.dto.request.UpdateVolumeReqDto
 import com.dcd.server.core.domain.volume.model.Volume
 import com.dcd.server.core.domain.workspace.model.Workspace
 import java.util.UUID
@@ -11,4 +12,12 @@ fun CreateVolumeReqDto.toEntity(workspace: Workspace): Volume =
         name = this.name,
         description = this.description,
         workspace = workspace,
+    )
+
+fun UpdateVolumeReqDto.toEntity(volume: Volume): Volume =
+    Volume(
+        id = volume.id,
+        name = this.name,
+        description = this.description,
+        workspace = volume.workspace,
     )

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/dto/request/UpdateVolumeReqDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/dto/request/UpdateVolumeReqDto.kt
@@ -1,0 +1,6 @@
+package com.dcd.server.core.domain.volume.dto.request
+
+data class UpdateVolumeReqDto(
+    val name: String,
+    val description: String
+)

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/exception/VolumeCopyFailureException.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/exception/VolumeCopyFailureException.kt
@@ -1,0 +1,6 @@
+package com.dcd.server.core.domain.volume.exception
+
+import com.dcd.server.core.common.error.BasicException
+import com.dcd.server.core.common.error.ErrorCode
+
+class VolumeCopyFailureException : BasicException(ErrorCode.FAILURE_VOLUME_COPY)

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/service/CopyVolumeService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/service/CopyVolumeService.kt
@@ -1,0 +1,7 @@
+package com.dcd.server.core.domain.volume.service
+
+import com.dcd.server.core.domain.volume.model.Volume
+
+interface CopyVolumeService {
+    fun copyVolumeContent(existingVolume: Volume, newVolume: Volume)
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/service/impl/CopyDockerVolumeServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/service/impl/CopyDockerVolumeServiceImpl.kt
@@ -1,0 +1,22 @@
+package com.dcd.server.core.domain.volume.service.impl
+
+import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.domain.volume.model.Volume
+import com.dcd.server.core.domain.volume.service.CopyVolumeService
+import org.springframework.stereotype.Service
+
+@Service
+class CopyDockerVolumeServiceImpl(
+    private val commandPort: CommandPort
+) : CopyVolumeService {
+    override fun copyVolumeContent(existingVolume: Volume, newVolume: Volume) {
+        val volumeCopyCmd =
+            """
+                docker run --rm -it \
+                    -v ${existingVolume.volumeName}:/from \
+                    -v ${newVolume.volumeName}:/to \
+                    alpine ash -c \"cp -a /from/. /to/\"
+            """.trimIndent()
+        commandPort.executeShellCommand(volumeCopyCmd)
+    }
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/usecase/UpdateVolumeUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/usecase/UpdateVolumeUseCase.kt
@@ -1,0 +1,39 @@
+package com.dcd.server.core.domain.volume.usecase
+
+import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.domain.volume.dto.extension.toEntity
+import com.dcd.server.core.domain.volume.dto.request.UpdateVolumeReqDto
+import com.dcd.server.core.domain.volume.exception.AlreadyExistsVolumeMountException
+import com.dcd.server.core.domain.volume.exception.VolumeNotFoundException
+import com.dcd.server.core.domain.volume.service.CopyVolumeService
+import com.dcd.server.core.domain.volume.service.CreateVolumeService
+import com.dcd.server.core.domain.volume.service.DeleteVolumeService
+import com.dcd.server.core.domain.volume.spi.CommandVolumePort
+import com.dcd.server.core.domain.volume.spi.QueryVolumePort
+import java.util.UUID
+
+@UseCase
+class UpdateVolumeUseCase(
+    private val queryVolumePort: QueryVolumePort,
+    private val commandVolumePort: CommandVolumePort,
+    private val createVolumeService: CreateVolumeService,
+    private val copyVolumeService: CopyVolumeService,
+    private val deleteVolumeService: DeleteVolumeService,
+) {
+    fun execute(volumeId: UUID, request: UpdateVolumeReqDto) {
+        val volume = (queryVolumePort.findById(volumeId)
+            ?: throw VolumeNotFoundException())
+
+        val volumeMountList = queryVolumePort.findAllMountByVolume(volume)
+        if (volumeMountList.isNotEmpty())
+            throw AlreadyExistsVolumeMountException()
+
+        val newVolume = request.toEntity(volume)
+        commandVolumePort.save(newVolume)
+
+        // 수정된 볼륨을 생성후 내용을 복사하고, 기존 볼륨 삭제
+        createVolumeService.create(newVolume)
+        copyVolumeService.copyVolumeContent(volume, newVolume)
+        deleteVolumeService.deleteVolume(volume)
+    }
+}

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
@@ -101,6 +101,7 @@ class SecurityConfig(
                 //volume
                 it.requestMatchers(HttpMethod.POST, "/{workspaceId}/volume").authenticated()
                 it.requestMatchers(HttpMethod.DELETE, "/{workspaceId}/volume/{volumeId}").authenticated()
+                it.requestMatchers(HttpMethod.PUT, "/{workspaceId}/volume/{volumeId}").authenticated()
 
                 //when url not set
                 it.anyRequest().denyAll()

--- a/src/main/kotlin/com/dcd/server/presentation/domain/volume/VolumeWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/volume/VolumeWebAdapter.kt
@@ -3,21 +3,25 @@ package com.dcd.server.presentation.domain.volume
 import com.dcd.server.core.common.annotation.WorkspaceOwnerVerification
 import com.dcd.server.core.domain.volume.usecase.CreateVolumeUseCase
 import com.dcd.server.core.domain.volume.usecase.DeleteVolumeUseCase
+import com.dcd.server.core.domain.volume.usecase.UpdateVolumeUseCase
 import com.dcd.server.presentation.common.annotation.WebAdapter
 import com.dcd.server.presentation.domain.volume.data.extension.toDto
 import com.dcd.server.presentation.domain.volume.data.request.CreateVolumeRequest
+import com.dcd.server.presentation.domain.volume.data.request.UpdateVolumeRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import java.util.UUID
 
 @WebAdapter("/{workspaceId}/volume")
 class VolumeWebAdapter(
     private val createVolumeUseCase: CreateVolumeUseCase,
-    private val deleteVolumeUseCase: DeleteVolumeUseCase
+    private val deleteVolumeUseCase: DeleteVolumeUseCase,
+    private val updateVolumeUseCase: UpdateVolumeUseCase
 ) {
     @PostMapping
     @WorkspaceOwnerVerification("#workspaceId")
@@ -35,5 +39,15 @@ class VolumeWebAdapter(
         @PathVariable volumeId: UUID,
     ): ResponseEntity<Void> =
         deleteVolumeUseCase.execute(volumeId)
+            .run { ResponseEntity.ok().build() }
+
+    @PutMapping("/{volumeId}")
+    @WorkspaceOwnerVerification("#workspaceId")
+    fun updateVolume(
+        @PathVariable workspaceId: String,
+        @PathVariable volumeId: UUID,
+        @Validated @RequestBody updateVolumeRequest: UpdateVolumeRequest
+    ): ResponseEntity<Void> =
+        updateVolumeUseCase.execute(volumeId, updateVolumeRequest.toDto())
             .run { ResponseEntity.ok().build() }
 }

--- a/src/main/kotlin/com/dcd/server/presentation/domain/volume/data/extension/VolumeRequestExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/volume/data/extension/VolumeRequestExtension.kt
@@ -1,10 +1,18 @@
 package com.dcd.server.presentation.domain.volume.data.extension
 
 import com.dcd.server.core.domain.volume.dto.request.CreateVolumeReqDto
+import com.dcd.server.core.domain.volume.dto.request.UpdateVolumeReqDto
 import com.dcd.server.presentation.domain.volume.data.request.CreateVolumeRequest
+import com.dcd.server.presentation.domain.volume.data.request.UpdateVolumeRequest
 
 fun CreateVolumeRequest.toDto(): CreateVolumeReqDto =
     CreateVolumeReqDto(
+        name = this.name,
+        description = this.description
+    )
+
+fun UpdateVolumeRequest.toDto(): UpdateVolumeReqDto =
+    UpdateVolumeReqDto(
         name = this.name,
         description = this.description
     )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/volume/data/request/UpdateVolumeRequest.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/volume/data/request/UpdateVolumeRequest.kt
@@ -1,0 +1,12 @@
+package com.dcd.server.presentation.domain.volume.data.request
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+
+data class UpdateVolumeRequest(
+    @field:NotBlank
+    @field:Pattern(regexp = "^[a-zA-Z0-9][a-zA-Z0-9_.\\s-]{0,62}$")
+    val name: String,
+    @field:NotBlank
+    val description: String
+)

--- a/src/test/kotlin/com/dcd/server/core/domain/volume/usecase/UpdateVolumeUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/volume/usecase/UpdateVolumeUseCaseTest.kt
@@ -1,0 +1,108 @@
+package com.dcd.server.core.domain.volume.usecase
+
+import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.common.data.WorkspaceInfo
+import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import com.dcd.server.core.domain.volume.dto.request.UpdateVolumeReqDto
+import com.dcd.server.core.domain.volume.exception.AlreadyExistsVolumeMountException
+import com.dcd.server.core.domain.volume.exception.VolumeNotFoundException
+import com.dcd.server.core.domain.volume.model.Volume
+import com.dcd.server.core.domain.volume.model.VolumeMount
+import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
+import com.dcd.server.persistence.volume.adapter.toDomain
+import com.dcd.server.persistence.volume.adapter.toEntity
+import com.dcd.server.persistence.volume.repository.VolumeMountRepository
+import com.dcd.server.persistence.volume.repository.VolumeRepository
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class UpdateVolumeUseCaseTest(
+    private val updateVolumeUseCase: UpdateVolumeUseCase,
+    @MockkBean(relaxed = true)
+    private val commandPort: CommandPort,
+    private val workspaceInfo: WorkspaceInfo,
+    private val volumeRepository: VolumeRepository,
+    private val volumeMountRepository: VolumeMountRepository,
+    private val queryWorkspacePort: QueryWorkspacePort,
+    private val queryApplicationPort: QueryApplicationPort,
+) : BehaviorSpec({
+    val targetVolumeId = UUID.randomUUID()
+
+    beforeSpec {
+        val targetWorkspace = queryWorkspacePort.findById("d57b42f5-5cc4-440b-8dce-b4fc2e372eff")!!
+        workspaceInfo.workspace = targetWorkspace
+
+        val volume = Volume(
+            id = targetVolumeId,
+            name = "testVolume",
+            description = "testDescription",
+            workspace = targetWorkspace
+        )
+        volumeRepository.save(volume.toEntity())
+    }
+
+    given("타겟 볼륨 아이디와 수정할 볼륨 요청 dto가 주어지고") {
+        val request = UpdateVolumeReqDto(name = "updateVolume", description = "updateDescription")
+
+        `when`("유스케이스를 실행할때") {
+            updateVolumeUseCase.execute(targetVolumeId, request)
+
+            then("볼륨 정보가 수정되어야함") {
+                val targetVolume = volumeRepository.findByIdOrNull(targetVolumeId)
+
+                targetVolume shouldNotBe null
+                targetVolume!!.name shouldBe request.name
+                targetVolume.description shouldBe request.description
+            }
+        }
+    }
+
+    given("볼륨이 존재하지 않고") {
+        volumeRepository.deleteAll()
+        val request = UpdateVolumeReqDto(name = "updateVolume", description = "updateDescription")
+
+        `when`("유스케이스를 실행할때") {
+
+            then("예외가 발생해야함") {
+                shouldThrow<VolumeNotFoundException> {
+                    updateVolumeUseCase.execute(targetVolumeId, request)
+                }
+            }
+        }
+    }
+
+    given("볼륨 마운트가 존재하고") {
+        val application = queryApplicationPort.findById("2fb0f315-8272-422f-8e9f-c4f765c022b2")!!
+        val volume = volumeRepository.findByIdOrNull(targetVolumeId)!!.toDomain()
+        val volumeMount = VolumeMount(
+            id = UUID.randomUUID(),
+            application = application,
+            volume = volume,
+            mountPath = "/test/volume",
+            readOnly = false
+        )
+        volumeMountRepository.save(volumeMount.toEntity())
+
+        val request = UpdateVolumeReqDto(name = "updateVolume", description = "updateDescription")
+
+        `when`("유스케이스를 실행하면") {
+
+            then("에러가 발생해야함") {
+                shouldThrow<AlreadyExistsVolumeMountException> {
+                    updateVolumeUseCase.execute(targetVolumeId, request)
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/dcd/server/presentation/domain/volume/VolumeWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/volume/VolumeWebAdapterTest.kt
@@ -1,9 +1,12 @@
 package com.dcd.server.presentation.domain.volume
 
 import com.dcd.server.core.domain.volume.dto.request.CreateVolumeReqDto
+import com.dcd.server.core.domain.volume.dto.request.UpdateVolumeReqDto
 import com.dcd.server.core.domain.volume.usecase.CreateVolumeUseCase
 import com.dcd.server.core.domain.volume.usecase.DeleteVolumeUseCase
+import com.dcd.server.core.domain.volume.usecase.UpdateVolumeUseCase
 import com.dcd.server.presentation.domain.volume.data.request.CreateVolumeRequest
+import com.dcd.server.presentation.domain.volume.data.request.UpdateVolumeRequest
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.mockk
@@ -14,8 +17,9 @@ import java.util.UUID
 class VolumeWebAdapterTest : BehaviorSpec({
     val createVolumeUseCase = mockk<CreateVolumeUseCase>(relaxUnitFun = true)
     val deleteVolumeUseCase = mockk<DeleteVolumeUseCase>(relaxUnitFun = true)
+    val updateVolumeUseCase = mockk<UpdateVolumeUseCase>(relaxUnitFun = true)
 
-    val volumeWebAdapter = VolumeWebAdapter(createVolumeUseCase, deleteVolumeUseCase)
+    val volumeWebAdapter = VolumeWebAdapter(createVolumeUseCase, deleteVolumeUseCase, updateVolumeUseCase)
 
     given("워크스페이스 아이디와 볼륨 생성 요청이 주어지고") {
         val testWorkspaceId = UUID.randomUUID().toString()
@@ -47,6 +51,24 @@ class VolumeWebAdapterTest : BehaviorSpec({
 
             then("볼륨 삭제 유스케이스를 실행해야함") {
                 verify { deleteVolumeUseCase.execute(testVolumeId) }
+            }
+        }
+    }
+
+    given("워크스페이스 아이디, 볼륨 아이디, 볼륨 수정 요청이 주어지고") {
+        val testWorkspaceId = UUID.randomUUID().toString()
+        val testVolumeId = UUID.randomUUID()
+        val request = UpdateVolumeRequest(name = "testVolume", description = "testDescription")
+
+        `when`("볼륨 수정 메서드를 실행하면") {
+            val result = volumeWebAdapter.updateVolume(testWorkspaceId, testVolumeId, request)
+
+            then("상태코드 OK가 응답되어야함") {
+                result.statusCode shouldBe HttpStatus.OK
+            }
+
+            then("볼륨 수정 유스케이스를 실행해야함") {
+                verify { updateVolumeUseCase.execute(testVolumeId, any() as UpdateVolumeReqDto) }
             }
         }
     }


### PR DESCRIPTION
## 개요
* 볼륨 수정 API를 추가합니다.
## 작업내용
* 볼륨 수정 요청 dto 추가
* 볼륨 내용 복사 서비스 추가
* 볼륨 내용 복사 실패 예외 추가
* 볼륨 수정 유스케이스 추가
* 볼륨 수정 요청 객체 추가
* 볼륨 수정 엔드포인트 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 볼륨 업데이트(이름/설명) API 추가: PUT /{workspaceId}/volume/{volumeId}
  * 업데이트 시 기존 데이터 자동 복사로 내용 유지
* Security
  * 새 PUT 볼륨 엔드포인트에 인증 요구
* Validation
  * 이름 패턴(1~63자, 영숫자 시작, _, ., 공백, - 허용) 및 설명 공백 불가 검증
* Error Handling
  * 볼륨 복제 실패 시 표준 오류 코드/메시지 제공
  * 마운트가 존재하면 업데이트 차단

<!-- end of auto-generated comment: release notes by coderabbit.ai -->