### PR TITLE
🔀 :: [#717] - 볼륨 마운트 API 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateContainerServiceImpl.kt
@@ -5,6 +5,7 @@ import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.service.CreateContainerService
 import com.dcd.server.core.domain.application.spi.CheckExitValuePort
 import com.dcd.server.core.domain.application.util.FailureCase
+import com.dcd.server.core.domain.volume.spi.QueryVolumePort
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.springframework.stereotype.Service
@@ -12,13 +13,26 @@ import org.springframework.stereotype.Service
 @Service
 class CreateContainerServiceImpl(
     private val commandPort: CommandPort,
+    private val queryVolumePort: QueryVolumePort,
     private val checkExitValuePort: CheckExitValuePort
 ) : CreateContainerService {
     override suspend fun createContainer(application: Application, externalPort: Int) {
+        val volumeMountBuilder = StringBuilder()
+        queryVolumePort.findAllMountByApplication(application)
+            .forEach {
+                val volume = it.volume
+                volumeMountBuilder.append("-v ${volume.name}:${it.mountPath}")
+                if (it.readOnly)
+                    volumeMountBuilder.append(":ro")
+                volumeMountBuilder.append(" ")
+            }
+        val volumeMountFlags = volumeMountBuilder.toString()
+
         withContext(Dispatchers.IO) {
             val cmd =
                 "docker create --network ${application.workspace.networkName} " +
                         "--name ${application.containerName} " +
+                        volumeMountFlags +
                         "-p ${externalPort}:${application.port} ${application.containerName}:latest"
 
             commandPort.executeShellCommand(cmd)

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/dto/request/MountVolumeReqDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/dto/request/MountVolumeReqDto.kt
@@ -1,0 +1,6 @@
+package com.dcd.server.core.domain.volume.dto.request
+
+data class MountVolumeReqDto(
+    val mountPath: String,
+    val readOnly: Boolean,
+)

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/spi/CommandVolumePort.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/spi/CommandVolumePort.kt
@@ -1,9 +1,12 @@
 package com.dcd.server.core.domain.volume.spi
 
 import com.dcd.server.core.domain.volume.model.Volume
+import com.dcd.server.core.domain.volume.model.VolumeMount
 
 interface CommandVolumePort {
     fun save(volume: Volume)
 
     fun delete(volume: Volume)
+
+    fun saveMount(volumeMount: VolumeMount)
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/usecase/MountVolumeUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/usecase/MountVolumeUseCase.kt
@@ -1,0 +1,52 @@
+package com.dcd.server.core.domain.volume.usecase
+
+import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.common.data.WorkspaceInfo
+import com.dcd.server.core.domain.application.event.DeployApplicationEvent
+import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
+import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import com.dcd.server.core.domain.volume.dto.request.MountVolumeReqDto
+import com.dcd.server.core.domain.volume.exception.VolumeNotFoundException
+import com.dcd.server.core.domain.volume.model.VolumeMount
+import com.dcd.server.core.domain.volume.spi.CommandVolumePort
+import com.dcd.server.core.domain.volume.spi.QueryVolumePort
+import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
+import org.springframework.context.ApplicationEventPublisher
+import java.util.UUID
+
+@UseCase
+class MountVolumeUseCase(
+    private val queryVolumePort: QueryVolumePort,
+    private val queryApplicationPort: QueryApplicationPort,
+    private val commandVolumePort: CommandVolumePort,
+    private val workspaceInfo: WorkspaceInfo,
+    private val eventPublisher: ApplicationEventPublisher,
+) {
+    fun execute(volumeId: UUID, applicationId: String, mountVolumeReqDto: MountVolumeReqDto) {
+        val workspace = (workspaceInfo.workspace
+            ?: throw WorkspaceNotFoundException())
+
+        val volume = (queryVolumePort.findById(volumeId)
+            ?: throw VolumeNotFoundException())
+
+        if (volume.workspace != workspace)
+            throw VolumeNotFoundException()
+
+        val application = (queryApplicationPort.findById(applicationId)
+            ?: throw ApplicationNotFoundException())
+        if (application.workspace != workspace)
+            throw ApplicationNotFoundException()
+
+        val volumeMount = VolumeMount(
+            id = UUID.randomUUID(),
+            application = application,
+            volume = volume,
+            mountPath = mountVolumeReqDto.mountPath,
+            readOnly = mountVolumeReqDto.readOnly
+        )
+        commandVolumePort.saveMount(volumeMount)
+
+        //마운트 생성후 대상 애플리케이션 재배포
+        eventPublisher.publishEvent(DeployApplicationEvent(listOf(application.id)))
+    }
+}

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
@@ -104,6 +104,7 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.PUT, "/{workspaceId}/volume/{volumeId}").authenticated()
                 it.requestMatchers(HttpMethod.GET, "/{workspaceId}/volume").authenticated()
                 it.requestMatchers(HttpMethod.GET, "/{workspaceId}/volume/{volumeId}").authenticated()
+                it.requestMatchers(HttpMethod.POST, "/{workspaceId}/volume/{volumeId}/mount").authenticated()
 
                 //when url not set
                 it.anyRequest().denyAll()

--- a/src/main/kotlin/com/dcd/server/persistence/volume/VolumePersistenceAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/volume/VolumePersistenceAdapter.kt
@@ -28,6 +28,10 @@ class VolumePersistenceAdapter(
         volumeRepository.deleteById(volume.id)
     }
 
+    override fun saveMount(volumeMount: VolumeMount) {
+        volumeMountRepository.save(volumeMount.toEntity())
+    }
+
     override fun findById(id: UUID): Volume? =
         volumeRepository.findByIdOrNull(id)
             ?.toDomain()

--- a/src/main/kotlin/com/dcd/server/presentation/domain/volume/VolumeWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/volume/VolumeWebAdapter.kt
@@ -5,11 +5,13 @@ import com.dcd.server.core.domain.volume.usecase.CreateVolumeUseCase
 import com.dcd.server.core.domain.volume.usecase.DeleteVolumeUseCase
 import com.dcd.server.core.domain.volume.usecase.GetAllVolumeUseCase
 import com.dcd.server.core.domain.volume.usecase.GetOneVolumeUseCase
+import com.dcd.server.core.domain.volume.usecase.MountVolumeUseCase
 import com.dcd.server.core.domain.volume.usecase.UpdateVolumeUseCase
 import com.dcd.server.presentation.common.annotation.WebAdapter
 import com.dcd.server.presentation.domain.volume.data.extension.toDto
 import com.dcd.server.presentation.domain.volume.data.extension.toResponse
 import com.dcd.server.presentation.domain.volume.data.request.CreateVolumeRequest
+import com.dcd.server.presentation.domain.volume.data.request.MountVolumeRequest
 import com.dcd.server.presentation.domain.volume.data.request.UpdateVolumeRequest
 import com.dcd.server.presentation.domain.volume.data.response.VolumeDetailResponse
 import com.dcd.server.presentation.domain.volume.data.response.VolumeListResponse
@@ -21,6 +23,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
 import java.util.UUID
 
 @WebAdapter("/{workspaceId}/volume")
@@ -29,7 +32,8 @@ class VolumeWebAdapter(
     private val deleteVolumeUseCase: DeleteVolumeUseCase,
     private val updateVolumeUseCase: UpdateVolumeUseCase,
     private val getAllVolumeUseCase: GetAllVolumeUseCase,
-    private val getOneVolumeUseCase: GetOneVolumeUseCase
+    private val getOneVolumeUseCase: GetOneVolumeUseCase,
+    private val mountVolumeUseCase: MountVolumeUseCase
 ) {
     @PostMapping
     @WorkspaceOwnerVerification("#workspaceId")
@@ -73,4 +77,15 @@ class VolumeWebAdapter(
     ): ResponseEntity<VolumeDetailResponse> =
         getOneVolumeUseCase.execute(volumeId)
             .let { ResponseEntity.ok(it.toResponse()) }
+
+    @PostMapping("/{volumeId}/mount")
+    @WorkspaceOwnerVerification("#workspaceId")
+    fun mountVolume(
+        @PathVariable workspaceId: String,
+        @PathVariable volumeId: UUID,
+        @RequestParam applicationId: String,
+        @Validated @RequestBody mountVolumeRequest: MountVolumeRequest
+    ): ResponseEntity<Void> =
+        mountVolumeUseCase.execute(volumeId, applicationId, mountVolumeRequest.toDto())
+            .run { ResponseEntity.ok().build() }
 }

--- a/src/main/kotlin/com/dcd/server/presentation/domain/volume/data/extension/VolumeRequestExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/volume/data/extension/VolumeRequestExtension.kt
@@ -1,8 +1,10 @@
 package com.dcd.server.presentation.domain.volume.data.extension
 
 import com.dcd.server.core.domain.volume.dto.request.CreateVolumeReqDto
+import com.dcd.server.core.domain.volume.dto.request.MountVolumeReqDto
 import com.dcd.server.core.domain.volume.dto.request.UpdateVolumeReqDto
 import com.dcd.server.presentation.domain.volume.data.request.CreateVolumeRequest
+import com.dcd.server.presentation.domain.volume.data.request.MountVolumeRequest
 import com.dcd.server.presentation.domain.volume.data.request.UpdateVolumeRequest
 
 fun CreateVolumeRequest.toDto(): CreateVolumeReqDto =
@@ -15,4 +17,10 @@ fun UpdateVolumeRequest.toDto(): UpdateVolumeReqDto =
     UpdateVolumeReqDto(
         name = this.name,
         description = this.description
+    )
+
+fun MountVolumeRequest.toDto(): MountVolumeReqDto =
+    MountVolumeReqDto(
+        mountPath = this.mountPath,
+        readOnly = this.readOnly
     )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/volume/data/request/MountVolumeRequest.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/volume/data/request/MountVolumeRequest.kt
@@ -1,9 +1,11 @@
 package com.dcd.server.presentation.domain.volume.data.request
 
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
 
 data class MountVolumeRequest(
     @field:NotBlank
+    @field:Pattern(regexp = "^(?!(?:/(?:proc|sys|dev|etc)?$))/(?:(?:[A-Za-z0-9._-]+/)*[A-Za-z0-9._-]+)?$")
     val mountPath: String,
     val readOnly: Boolean,
 )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/volume/data/request/MountVolumeRequest.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/volume/data/request/MountVolumeRequest.kt
@@ -1,0 +1,9 @@
+package com.dcd.server.presentation.domain.volume.data.request
+
+import jakarta.validation.constraints.NotBlank
+
+data class MountVolumeRequest(
+    @field:NotBlank
+    val mountPath: String,
+    val readOnly: Boolean,
+)

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/CreateContainerServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/CreateContainerServiceImplTest.kt
@@ -4,7 +4,9 @@ import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.domain.application.service.impl.CreateContainerServiceImpl
 import com.dcd.server.core.domain.application.spi.CheckExitValuePort
 import com.dcd.server.core.domain.application.util.FailureCase
+import com.dcd.server.core.domain.volume.spi.QueryVolumePort
 import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
@@ -12,14 +14,16 @@ import util.application.ApplicationGenerator
 
 class CreateContainerServiceImplTest : BehaviorSpec({
     val commandPort = mockk<CommandPort>(relaxed = true)
+    val queryVolumePort = mockk<QueryVolumePort>(relaxed = true)
     val checkExitValuePort = mockk<CheckExitValuePort>(relaxUnitFun = true)
-    val createContainerService = CreateContainerServiceImpl(commandPort, checkExitValuePort)
+    val createContainerService = CreateContainerServiceImpl(commandPort, queryVolumePort, checkExitValuePort)
 
     given("애플리케이션이 주어지고") {
         val application = ApplicationGenerator.generateApplication()
 
         `when`("service를 실행할때") {
             createContainerService.createContainer(application, application.externalPort)
+            every { queryVolumePort.findAllMountByApplication(application) } returns listOf()
 
             then("컨테이너를 실행하는 명령을 실행해야함") {
                 verify {

--- a/src/test/kotlin/com/dcd/server/core/domain/volume/usecase/MountVolumeUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/volume/usecase/MountVolumeUseCaseTest.kt
@@ -1,0 +1,128 @@
+package com.dcd.server.core.domain.volume.usecase
+
+import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.common.data.WorkspaceInfo
+import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
+import com.dcd.server.core.domain.volume.dto.request.MountVolumeReqDto
+import com.dcd.server.core.domain.volume.exception.VolumeNotFoundException
+import com.dcd.server.core.domain.volume.model.Volume
+import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
+import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
+import com.dcd.server.persistence.volume.adapter.toEntity
+import com.dcd.server.persistence.volume.repository.VolumeMountRepository
+import com.dcd.server.persistence.volume.repository.VolumeRepository
+import com.dcd.server.persistence.workspace.adapter.toEntity
+import com.dcd.server.persistence.workspace.repository.WorkspaceRepository
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+import util.workspace.WorkspaceGenerator
+import java.util.UUID
+
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class MountVolumeUseCaseTest(
+    private val mountVolumeUseCase: MountVolumeUseCase,
+    @MockkBean(relaxed = true)
+    private val commandPort: CommandPort,
+    private val queryWorkspacePort: QueryWorkspacePort,
+    private val volumeRepository: VolumeRepository,
+    private val volumeMountRepository: VolumeMountRepository,
+    private val workspaceRepository: WorkspaceRepository,
+    private val workspaceInfo: WorkspaceInfo
+) : BehaviorSpec({
+    val targetVolumeId = UUID.randomUUID()
+    val targetApplicationId = "2fb0f315-8272-422f-8e9f-c4f765c022b2"
+
+    beforeSpec {
+        val targetWorkspace = queryWorkspacePort.findById("d57b42f5-5cc4-440b-8dce-b4fc2e372eff")!!
+        val volume = Volume(
+            id = targetVolumeId,
+            name = "test1Volume",
+            description = "testDescription",
+            workspace = targetWorkspace
+        ).toEntity()
+        volumeRepository.save(volume)
+    }
+
+    given("마운트 요청 객체가 주어지고") {
+        beforeContainer {
+            val targetWorkspace = queryWorkspacePort.findById("d57b42f5-5cc4-440b-8dce-b4fc2e372eff")!!
+            workspaceInfo.workspace = targetWorkspace
+        }
+
+        val request = MountVolumeReqDto("/test", false)
+
+        `when`("유스케이스를 실행하면") {
+            mountVolumeUseCase.execute(targetVolumeId, targetApplicationId, request)
+
+            then("볼륨 마운트가 생성되어야함") {
+                val volumeMountList = volumeMountRepository.findAll()
+                volumeMountList.size shouldBe 1
+
+                val first = volumeMountList.first()
+                first.mountPath shouldBe request.mountPath
+                first.readOnly shouldBe request.readOnly
+                first.application.id.toString() shouldBe targetApplicationId
+                first.volume.id shouldBe targetVolumeId
+            }
+        }
+
+        `when`("존재하지 않는 볼륨 아이디로 실행하면") {
+            val invalidVolumeId = UUID.randomUUID()
+
+            then("에러가 발생해야함") {
+                shouldThrow<VolumeNotFoundException> {
+                    mountVolumeUseCase.execute(invalidVolumeId, targetApplicationId, request)
+                }
+            }
+        }
+
+        `when`("존재하지 않는 애플리케이션 아이디로 실행하면") {
+            val invalidApplicationId = UUID.randomUUID().toString()
+
+            then("에러가 발생행해야함") {
+                shouldThrow<ApplicationNotFoundException> {
+                    mountVolumeUseCase.execute(targetVolumeId, invalidApplicationId, request)
+                }
+            }
+        }
+
+        `when`("세팅된 워크스페이스가 볼륨이 속한 워크스페이스가 아닐때") {
+            beforeTest {
+                val targetWorkspace = queryWorkspacePort.findById("d57b42f5-5cc4-440b-8dce-b4fc2e372eff")!!
+                val otherWorkspace = WorkspaceGenerator.generateWorkspace(user = targetWorkspace.owner)
+                workspaceRepository.save(otherWorkspace.toEntity())
+                workspaceInfo.workspace = otherWorkspace
+            }
+
+            then("에러가 발생해야함") {
+                shouldThrow<VolumeNotFoundException> {
+                    mountVolumeUseCase.execute(targetVolumeId, targetApplicationId, request)
+                }
+            }
+        }
+    }
+
+    given("올바르지 않은 워크스페이스가 세팅되고") {
+        beforeContainer {
+            workspaceInfo.workspace = null
+        }
+
+        val request = MountVolumeReqDto("/test", false)
+
+        `when`("유스케이스를 실행할때") {
+
+            then("에러가 발생해야함") {
+                shouldThrow<WorkspaceNotFoundException> {
+                    mountVolumeUseCase.execute(targetVolumeId, targetApplicationId, request)
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/dcd/server/presentation/domain/volume/VolumeWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/volume/VolumeWebAdapterTest.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.presentation.domain.volume
 
 import com.dcd.server.core.domain.volume.dto.request.CreateVolumeReqDto
+import com.dcd.server.core.domain.volume.dto.request.MountVolumeReqDto
 import com.dcd.server.core.domain.volume.dto.request.UpdateVolumeReqDto
 import com.dcd.server.core.domain.volume.dto.response.VolumeDetailResDto
 import com.dcd.server.core.domain.volume.dto.response.VolumeListResDto
@@ -13,6 +14,7 @@ import com.dcd.server.core.domain.volume.usecase.MountVolumeUseCase
 import com.dcd.server.core.domain.volume.usecase.UpdateVolumeUseCase
 import com.dcd.server.presentation.domain.volume.data.extension.toResponse
 import com.dcd.server.presentation.domain.volume.data.request.CreateVolumeRequest
+import com.dcd.server.presentation.domain.volume.data.request.MountVolumeRequest
 import com.dcd.server.presentation.domain.volume.data.request.UpdateVolumeRequest
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -122,6 +124,24 @@ class VolumeWebAdapterTest : BehaviorSpec({
 
             then("유스케이스의 응답이 레핑되서 반환되어야함") {
                 result.body shouldBe volumeListResDto.toResponse()
+            }
+            then("상태코드 OK가 응답되어야함") {
+                result.statusCode shouldBe HttpStatus.OK
+            }
+        }
+    }
+
+    given("워크스페이스 아이디, 볼륨 아이디, 애플리케이션 아이디, 볼륨 마운트 요청 객체가 주어지고") {
+        val testWorkspaceId = UUID.randomUUID().toString()
+        val testVolumeId = UUID.randomUUID()
+        val testApplicationId = UUID.randomUUID().toString()
+        val request = MountVolumeRequest("/test", false)
+
+        `when`("볼륨 마운트 메서드를 실행할때") {
+            val result = volumeWebAdapter.mountVolume(testWorkspaceId, testVolumeId, testApplicationId, request)
+
+            then("볼륨 마운트 유스케이스가 실행되어야함") {
+                verify { mountVolumeUseCase.execute(testVolumeId, testApplicationId, any() as MountVolumeReqDto) }
             }
             then("상태코드 OK가 응답되어야함") {
                 result.statusCode shouldBe HttpStatus.OK

--- a/src/test/kotlin/com/dcd/server/presentation/domain/volume/VolumeWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/volume/VolumeWebAdapterTest.kt
@@ -9,6 +9,7 @@ import com.dcd.server.core.domain.volume.usecase.CreateVolumeUseCase
 import com.dcd.server.core.domain.volume.usecase.DeleteVolumeUseCase
 import com.dcd.server.core.domain.volume.usecase.GetAllVolumeUseCase
 import com.dcd.server.core.domain.volume.usecase.GetOneVolumeUseCase
+import com.dcd.server.core.domain.volume.usecase.MountVolumeUseCase
 import com.dcd.server.core.domain.volume.usecase.UpdateVolumeUseCase
 import com.dcd.server.presentation.domain.volume.data.extension.toResponse
 import com.dcd.server.presentation.domain.volume.data.request.CreateVolumeRequest
@@ -27,13 +28,15 @@ class VolumeWebAdapterTest : BehaviorSpec({
     val updateVolumeUseCase = mockk<UpdateVolumeUseCase>(relaxUnitFun = true)
     val getAllVolumeUseCase = mockk<GetAllVolumeUseCase>(relaxUnitFun = true)
     val getOneVolumeUseCase = mockk<GetOneVolumeUseCase>(relaxUnitFun = true)
+    val mountVolumeUseCase = mockk<MountVolumeUseCase>(relaxUnitFun = true)
 
     val volumeWebAdapter = VolumeWebAdapter(
         createVolumeUseCase,
         deleteVolumeUseCase,
         updateVolumeUseCase,
         getAllVolumeUseCase,
-        getOneVolumeUseCase
+        getOneVolumeUseCase,
+        mountVolumeUseCase
     )
 
     given("워크스페이스 아이디와 볼륨 생성 요청이 주어지고") {


### PR DESCRIPTION
## 개요
* 볼륨을 마운트하는 API를 추가합니다.
## 작업내용
* 애플리케이션 컨테이너 생성시 마운트된 볼륨을 반영해서 생성하는 로직 추가
* 볼륨 마운트 정보 세이브 메서드 추가
* 볼륨 마운트 요청 dto 추가
* 볼륨 마운트 유스케이스 추가
* 볼륨 마운트 요청 객체 추가
* 볼륨 마운트 엔드포인트 추가
* 볼륨 마운트관련 테스트 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 애플리케이션에 볼륨을 마운트하는 신규 엔드포인트 추가(POST /{workspaceId}/volume/{volumeId}/mount). mountPath 및 readOnly 파라미터 지원.
  - 볼륨 마운트 적용 시 애플리케이션이 자동 재배포되어 변경사항이 즉시 반영됩니다.
  - 컨테이너 생성 시 마운트 설정이 자동으로 포함됩니다.

- 보안
  - 볼륨 마운트 엔드포인트에 인증 요구 추가.

- 문서
  - 새 엔드포인트 및 요청 파라미터 사용 안내 반영.

- 테스트
  - 마운트 동작과 오류 경로를 검증하는 테스트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->