### PR TITLE
🔀 :: [#719] - 마운트 해제 API 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
@@ -47,6 +47,7 @@ enum class ErrorCode(
     AUTH_CODE_NOT_FOUND("인증 코드를 찾을 수 없습니다. 코드를 다시 전송 해주세요.", 404),
     DOMAIN_NOT_FOUND("해당 도메인을 찾을 수 없음", 404),
     VOLUME_NOT_FOUND("해당 볼륨을 찾을 수 없음", 404),
+    VOLUME_MOUNT_NOT_FOUND("해당 볼륨 마운트를 찾을 수 없음", 404),
 
     CONFLICT("해당 요청은 서버의 상태와 충돌됩니다.", 409),
     CAN_NOT_DEPLOY_APPLICATION("애플리케이션을 배포할 수 없습니다. 애플리케이션을 정지시킨 후 실행해주세요.", 409),

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/exception/VolumeMountNotFoundException.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/exception/VolumeMountNotFoundException.kt
@@ -1,0 +1,6 @@
+package com.dcd.server.core.domain.volume.exception
+
+import com.dcd.server.core.common.error.BasicException
+import com.dcd.server.core.common.error.ErrorCode
+
+class VolumeMountNotFoundException : BasicException(ErrorCode.VOLUME_MOUNT_NOT_FOUND)

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/model/VolumeMount.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/model/VolumeMount.kt
@@ -4,7 +4,6 @@ import com.dcd.server.core.domain.application.model.Application
 import java.util.UUID
 
 class VolumeMount(
-    val id: UUID,
     val application: Application,
     val volume: Volume,
     val mountPath: String,

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/spi/CommandVolumePort.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/spi/CommandVolumePort.kt
@@ -9,4 +9,6 @@ interface CommandVolumePort {
     fun delete(volume: Volume)
 
     fun saveMount(volumeMount: VolumeMount)
+
+    fun deleteMount(volumeMount: VolumeMount)
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/spi/QueryVolumePort.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/spi/QueryVolumePort.kt
@@ -16,4 +16,6 @@ interface QueryVolumePort {
     fun findAllMountByApplication(application: Application): List<VolumeMount>
 
     fun findAllMountByVolume(volume: Volume): List<VolumeMount>
+
+    fun findMountByApplicationAndVolume(application: Application, volume: Volume): VolumeMount?
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/usecase/MountVolumeUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/usecase/MountVolumeUseCase.kt
@@ -42,7 +42,6 @@ class MountVolumeUseCase(
             throw AlreadyExistsVolumeMountException()
 
         val volumeMount = VolumeMount(
-            id = UUID.randomUUID(),
             application = application,
             volume = volume,
             mountPath = mountVolumeReqDto.mountPath,

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/usecase/MountVolumeUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/usecase/MountVolumeUseCase.kt
@@ -6,6 +6,7 @@ import com.dcd.server.core.domain.application.event.DeployApplicationEvent
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.volume.dto.request.MountVolumeReqDto
+import com.dcd.server.core.domain.volume.exception.AlreadyExistsVolumeMountException
 import com.dcd.server.core.domain.volume.exception.VolumeNotFoundException
 import com.dcd.server.core.domain.volume.model.VolumeMount
 import com.dcd.server.core.domain.volume.spi.CommandVolumePort
@@ -36,6 +37,9 @@ class MountVolumeUseCase(
             ?: throw ApplicationNotFoundException())
         if (application.workspace != workspace)
             throw ApplicationNotFoundException()
+
+        if (queryVolumePort.findMountByApplicationAndVolume(application, volume) != null)
+            throw AlreadyExistsVolumeMountException()
 
         val volumeMount = VolumeMount(
             id = UUID.randomUUID(),

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/usecase/UnMountVolumeUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/usecase/UnMountVolumeUseCase.kt
@@ -1,0 +1,44 @@
+package com.dcd.server.core.domain.volume.usecase
+
+import com.dcd.server.core.common.annotation.UseCase
+import com.dcd.server.core.common.data.WorkspaceInfo
+import com.dcd.server.core.domain.application.event.DeployApplicationEvent
+import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
+import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import com.dcd.server.core.domain.volume.exception.VolumeMountNotFoundException
+import com.dcd.server.core.domain.volume.exception.VolumeNotFoundException
+import com.dcd.server.core.domain.volume.spi.CommandVolumePort
+import com.dcd.server.core.domain.volume.spi.QueryVolumePort
+import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
+import org.springframework.context.ApplicationEventPublisher
+import java.util.UUID
+
+@UseCase
+class UnMountVolumeUseCase(
+    private val queryVolumePort: QueryVolumePort,
+    private val queryApplicationPort: QueryApplicationPort,
+    private val commandVolumePort: CommandVolumePort,
+    private val workspaceInfo: WorkspaceInfo,
+    private val eventPublisher: ApplicationEventPublisher
+) {
+    fun execute(volumeId: UUID, applicationId: String) {
+        val workspace = (workspaceInfo.workspace
+            ?: throw WorkspaceNotFoundException())
+
+        val volume = (queryVolumePort.findById(volumeId)
+            ?: throw VolumeNotFoundException())
+        if (volume.workspace != workspace)
+            throw VolumeNotFoundException()
+
+        val application = (queryApplicationPort.findById(applicationId)
+            ?: throw ApplicationNotFoundException())
+        if (application.workspace != workspace)
+            throw ApplicationNotFoundException()
+
+        val volumeMount = queryVolumePort.findMountByApplicationAndVolume(application, volume)
+            ?: throw VolumeMountNotFoundException()
+        commandVolumePort.deleteMount(volumeMount)
+
+        eventPublisher.publishEvent(DeployApplicationEvent(listOf(application.id)))
+    }
+}

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/SecurityConfig.kt
@@ -105,6 +105,7 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.GET, "/{workspaceId}/volume").authenticated()
                 it.requestMatchers(HttpMethod.GET, "/{workspaceId}/volume/{volumeId}").authenticated()
                 it.requestMatchers(HttpMethod.POST, "/{workspaceId}/volume/{volumeId}/mount").authenticated()
+                it.requestMatchers(HttpMethod.DELETE, "/{workspaceId}/volume/{volumeId}/mount").authenticated()
 
                 //when url not set
                 it.anyRequest().denyAll()

--- a/src/main/kotlin/com/dcd/server/persistence/volume/VolumePersistenceAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/volume/VolumePersistenceAdapter.kt
@@ -32,6 +32,10 @@ class VolumePersistenceAdapter(
         volumeMountRepository.save(volumeMount.toEntity())
     }
 
+    override fun deleteMount(volumeMount: VolumeMount) {
+        volumeMountRepository.deleteById(volumeMount.id)
+    }
+
     override fun findById(id: UUID): Volume? =
         volumeRepository.findByIdOrNull(id)
             ?.toDomain()
@@ -53,4 +57,8 @@ class VolumePersistenceAdapter(
     override fun findAllMountByVolume(volume: Volume): List<VolumeMount> =
         volumeMountRepository.findAllByVolume(volume.toEntity())
             .map { it.toDomain() }
+
+    override fun findMountByApplicationAndVolume(application: Application, volume: Volume): VolumeMount? =
+        volumeMountRepository.findByVolumeAndApplication(volume.toEntity(), application.toEntity())
+            ?.toDomain()
 }

--- a/src/main/kotlin/com/dcd/server/persistence/volume/VolumePersistenceAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/volume/VolumePersistenceAdapter.kt
@@ -33,7 +33,7 @@ class VolumePersistenceAdapter(
     }
 
     override fun deleteMount(volumeMount: VolumeMount) {
-        volumeMountRepository.deleteById(volumeMount.id)
+        volumeMountRepository.delete(volumeMount.toEntity())
     }
 
     override fun findById(id: UUID): Volume? =

--- a/src/main/kotlin/com/dcd/server/persistence/volume/adapter/VolumeAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/volume/adapter/VolumeAdapter.kt
@@ -27,7 +27,6 @@ fun VolumeJpaEntity.toDomain(): Volume =
 
 fun VolumeMount.toEntity(): VolumeMountJpaEntity =
     VolumeMountJpaEntity(
-        id = this.id,
         application = this.application.toEntity(),
         volume = this.volume.toEntity(),
         mountPath = this.mountPath,
@@ -36,7 +35,6 @@ fun VolumeMount.toEntity(): VolumeMountJpaEntity =
 
 fun VolumeMountJpaEntity.toDomain(): VolumeMount =
     VolumeMount(
-        id = this.id,
         application = this.application.toDomain(),
         volume = this.volume.toDomain(),
         mountPath = this.mountPath,

--- a/src/main/kotlin/com/dcd/server/persistence/volume/entity/VolumeMountJpaEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/volume/entity/VolumeMountJpaEntity.kt
@@ -30,8 +30,10 @@ class VolumeMountJpaEntity(
     @EmbeddedId
     val id: VolumeMountId = VolumeMountId(application.id, volume.id)
     @Embeddable
-    class VolumeMountId(
+    data class VolumeMountId(
+        @Column(nullable = false)
         val applicationId: UUID,
+        @Column(nullable = false)
         val volumeId: UUID
     ) : Serializable
 }

--- a/src/main/kotlin/com/dcd/server/persistence/volume/entity/VolumeMountJpaEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/volume/entity/VolumeMountJpaEntity.kt
@@ -2,25 +2,36 @@ package com.dcd.server.persistence.volume.entity
 
 import com.dcd.server.persistence.application.entity.ApplicationJpaEntity
 import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import jakarta.persistence.EmbeddedId
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
+import jakarta.persistence.MapsId
 import jakarta.persistence.Table
+import java.io.Serializable
 import java.util.UUID
 
 @Entity
 @Table(name = "volume_mount_entity")
 class VolumeMountJpaEntity(
-    @Id
-    @Column(columnDefinition = "BINARY(16)")
-    val id: UUID = UUID.randomUUID(),
+    @MapsId("applicationId")
     @ManyToOne
     @JoinColumn(name = "application_id")
     val application: ApplicationJpaEntity,
+    @MapsId("volumeId")
     @ManyToOne
     @JoinColumn(name = "volume_id")
     val volume: VolumeJpaEntity,
     val mountPath: String,
     val readOnly: Boolean
-)
+) {
+    @EmbeddedId
+    val id: VolumeMountId = VolumeMountId(application.id, volume.id)
+    @Embeddable
+    class VolumeMountId(
+        val applicationId: UUID,
+        val volumeId: UUID
+    ) : Serializable
+}

--- a/src/main/kotlin/com/dcd/server/persistence/volume/repository/VolumeMountRepository.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/volume/repository/VolumeMountRepository.kt
@@ -6,7 +6,7 @@ import com.dcd.server.persistence.volume.entity.VolumeMountJpaEntity
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.UUID
 
-interface VolumeMountRepository : JpaRepository<VolumeMountJpaEntity, UUID> {
+interface VolumeMountRepository : JpaRepository<VolumeMountJpaEntity, VolumeMountJpaEntity.VolumeMountId> {
     fun findAllByVolume(volume: VolumeJpaEntity): List<VolumeMountJpaEntity>
     fun findAllByApplication(application: ApplicationJpaEntity): List<VolumeMountJpaEntity>
     fun findByVolumeAndApplication(volume: VolumeJpaEntity, application: ApplicationJpaEntity): VolumeMountJpaEntity?

--- a/src/main/kotlin/com/dcd/server/persistence/volume/repository/VolumeMountRepository.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/volume/repository/VolumeMountRepository.kt
@@ -9,4 +9,5 @@ import java.util.UUID
 interface VolumeMountRepository : JpaRepository<VolumeMountJpaEntity, UUID> {
     fun findAllByVolume(volume: VolumeJpaEntity): List<VolumeMountJpaEntity>
     fun findAllByApplication(application: ApplicationJpaEntity): List<VolumeMountJpaEntity>
+    fun findByVolumeAndApplication(volume: VolumeJpaEntity, application: ApplicationJpaEntity): VolumeMountJpaEntity?
 }

--- a/src/main/kotlin/com/dcd/server/presentation/domain/volume/VolumeWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/volume/VolumeWebAdapter.kt
@@ -6,6 +6,7 @@ import com.dcd.server.core.domain.volume.usecase.DeleteVolumeUseCase
 import com.dcd.server.core.domain.volume.usecase.GetAllVolumeUseCase
 import com.dcd.server.core.domain.volume.usecase.GetOneVolumeUseCase
 import com.dcd.server.core.domain.volume.usecase.MountVolumeUseCase
+import com.dcd.server.core.domain.volume.usecase.UnMountVolumeUseCase
 import com.dcd.server.core.domain.volume.usecase.UpdateVolumeUseCase
 import com.dcd.server.presentation.common.annotation.WebAdapter
 import com.dcd.server.presentation.domain.volume.data.extension.toDto
@@ -33,7 +34,8 @@ class VolumeWebAdapter(
     private val updateVolumeUseCase: UpdateVolumeUseCase,
     private val getAllVolumeUseCase: GetAllVolumeUseCase,
     private val getOneVolumeUseCase: GetOneVolumeUseCase,
-    private val mountVolumeUseCase: MountVolumeUseCase
+    private val mountVolumeUseCase: MountVolumeUseCase,
+    private val unMountVolumeUseCase: UnMountVolumeUseCase
 ) {
     @PostMapping
     @WorkspaceOwnerVerification("#workspaceId")
@@ -87,5 +89,15 @@ class VolumeWebAdapter(
         @Validated @RequestBody mountVolumeRequest: MountVolumeRequest
     ): ResponseEntity<Void> =
         mountVolumeUseCase.execute(volumeId, applicationId, mountVolumeRequest.toDto())
+            .run { ResponseEntity.ok().build() }
+
+    @DeleteMapping("/{volumeId}/mount")
+    @WorkspaceOwnerVerification("#workspaceId")
+    fun unMountVolume(
+        @PathVariable workspaceId: String,
+        @PathVariable volumeId: UUID,
+        @RequestParam applicationId: String,
+    ): ResponseEntity<Void> =
+        unMountVolumeUseCase.execute(volumeId, applicationId)
             .run { ResponseEntity.ok().build() }
 }

--- a/src/test/kotlin/com/dcd/server/core/domain/volume/usecase/DeleteVolumeUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/volume/usecase/DeleteVolumeUseCaseTest.kt
@@ -96,7 +96,6 @@ class DeleteVolumeUseCaseTest(
         val application = queryApplicationPort.findById("2fb0f315-8272-422f-8e9f-c4f765c022b2")!!
         val volume = volumeRepository.findByIdOrNull(targetVolumeId)!!.toDomain()
         val volumeMount = VolumeMount(
-            id = UUID.randomUUID(),
             application = application,
             volume = volume,
             mountPath = "/test/volume",

--- a/src/test/kotlin/com/dcd/server/core/domain/volume/usecase/MountVolumeUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/volume/usecase/MountVolumeUseCaseTest.kt
@@ -119,7 +119,6 @@ class MountVolumeUseCaseTest(
                 val application = queryApplicationPort.findById(targetApplicationId)!!
                 val volume = volumeRepository.findByIdOrNull(targetVolumeId)!!.toDomain()
                 val volumeMount = VolumeMount(
-                    id = UUID.randomUUID(),
                     application = application,
                     volume = volume,
                     mountPath = "/test/volume",

--- a/src/test/kotlin/com/dcd/server/core/domain/volume/usecase/UnMountVolumeUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/volume/usecase/UnMountVolumeUseCaseTest.kt
@@ -133,7 +133,7 @@ class UnMountVolumeUseCaseTest(
             workspaceInfo.workspace = null
         }
 
-        `when`("워크스페이스를 실행할때") {
+        `when`("유스케이스를 실행할때") {
 
             then("에러가 발생해야함") {
                 shouldThrow<WorkspaceNotFoundException> {

--- a/src/test/kotlin/com/dcd/server/core/domain/volume/usecase/UnMountVolumeUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/volume/usecase/UnMountVolumeUseCaseTest.kt
@@ -54,7 +54,6 @@ class UnMountVolumeUseCaseTest(
 
         val application = queryApplicationPort.findById(targetApplicationId)!!
         val volumeMount = VolumeMount(
-            id = UUID.randomUUID(),
             application = application,
             volume = volume,
             mountPath = "/test/volume",

--- a/src/test/kotlin/com/dcd/server/core/domain/volume/usecase/UnMountVolumeUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/volume/usecase/UnMountVolumeUseCaseTest.kt
@@ -1,0 +1,145 @@
+package com.dcd.server.core.domain.volume.usecase
+
+import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.common.data.WorkspaceInfo
+import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
+import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import com.dcd.server.core.domain.volume.exception.VolumeMountNotFoundException
+import com.dcd.server.core.domain.volume.exception.VolumeNotFoundException
+import com.dcd.server.core.domain.volume.model.Volume
+import com.dcd.server.core.domain.volume.model.VolumeMount
+import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
+import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
+import com.dcd.server.persistence.volume.adapter.toEntity
+import com.dcd.server.persistence.volume.repository.VolumeMountRepository
+import com.dcd.server.persistence.volume.repository.VolumeRepository
+import com.dcd.server.persistence.workspace.adapter.toEntity
+import com.dcd.server.persistence.workspace.repository.WorkspaceRepository
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+import util.workspace.WorkspaceGenerator
+import java.util.UUID
+
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class UnMountVolumeUseCaseTest(
+    private val unMountVolumeUseCase: UnMountVolumeUseCase,
+    @MockkBean(relaxed = true)
+    private val commandPort: CommandPort,
+    private val queryWorkspacePort: QueryWorkspacePort,
+    private val queryApplicationPort: QueryApplicationPort,
+    private val volumeRepository: VolumeRepository,
+    private val volumeMountRepository: VolumeMountRepository,
+    private val workspaceRepository: WorkspaceRepository,
+    private val workspaceInfo: WorkspaceInfo
+) : BehaviorSpec({
+    val targetVolumeId = UUID.randomUUID()
+    val targetApplicationId = "2fb0f315-8272-422f-8e9f-c4f765c022b2"
+
+    beforeSpec {
+        val targetWorkspace = queryWorkspacePort.findById("d57b42f5-5cc4-440b-8dce-b4fc2e372eff")!!
+        val volume = Volume(
+            id = targetVolumeId,
+            name = "test1Volume",
+            description = "testDescription",
+            workspace = targetWorkspace
+        )
+        volumeRepository.save(volume.toEntity())
+
+        val application = queryApplicationPort.findById(targetApplicationId)!!
+        val volumeMount = VolumeMount(
+            id = UUID.randomUUID(),
+            application = application,
+            volume = volume,
+            mountPath = "/test/volume",
+            readOnly = false
+        )
+        volumeMountRepository.save(volumeMount.toEntity())
+    }
+
+    given("볼륨과 같은 워크스페이스가 세팅되었고") {
+        beforeContainer {
+            val targetWorkspace = queryWorkspacePort.findById("d57b42f5-5cc4-440b-8dce-b4fc2e372eff")!!
+            workspaceInfo.workspace = targetWorkspace
+        }
+
+        `when`("유스케이스를 실행할때") {
+            unMountVolumeUseCase.execute(targetVolumeId, targetApplicationId)
+
+            then("볼륨 마운트 엔티티가 삭제되어야함") {
+                volumeMountRepository.findAll().isEmpty() shouldBe true
+            }
+        }
+
+        `when`("존재하지 않는 볼륨 아이디로 실행할때") {
+            val notFoundVolumeId = UUID.randomUUID()
+
+            then("에러가 발생해야함") {
+                shouldThrow<VolumeNotFoundException> {
+                    unMountVolumeUseCase.execute(notFoundVolumeId, targetApplicationId)
+                }
+            }
+        }
+
+        `when`("존재하지 않는 애플리케이션 아이디로 실행할때") {
+            val notFoundApplicationId = UUID.randomUUID().toString()
+
+            then("에러가 발생해야함") {
+                shouldThrow<ApplicationNotFoundException> {
+                    unMountVolumeUseCase.execute(targetVolumeId, notFoundApplicationId)
+                }
+            }
+        }
+
+        `when`("마운트된 볼륨이 아닐때") {
+            beforeContainer {
+                volumeMountRepository.deleteAll()
+            }
+
+            then("에러가 발생해야함") {
+                shouldThrow<VolumeMountNotFoundException> {
+                    unMountVolumeUseCase.execute(targetVolumeId, targetApplicationId)
+                }
+            }
+        }
+    }
+
+    given("세팅된 워크스페이스가 볼륨이 속한 워크스페이스가 아니고") {
+        beforeContainer {
+            val targetWorkspace = queryWorkspacePort.findById("d57b42f5-5cc4-440b-8dce-b4fc2e372eff")!!
+            val otherWorkspace = WorkspaceGenerator.generateWorkspace(user = targetWorkspace.owner)
+            workspaceRepository.save(otherWorkspace.toEntity())
+            workspaceInfo.workspace = otherWorkspace
+        }
+
+        `when`("유스케이스를 실행할때") {
+
+            then("에러가 발생해야함") {
+                shouldThrow<VolumeNotFoundException> {
+                    unMountVolumeUseCase.execute(targetVolumeId, targetApplicationId)
+                }
+            }
+        }
+    }
+
+    given("워크스페이스가 세팅되지 않고") {
+        beforeContainer {
+            workspaceInfo.workspace = null
+        }
+
+        `when`("워크스페이스를 실행할때") {
+
+            then("에러가 발생해야함") {
+                shouldThrow<WorkspaceNotFoundException> {
+                    unMountVolumeUseCase.execute(targetVolumeId, targetApplicationId)
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/dcd/server/core/domain/volume/usecase/UpdateVolumeUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/volume/usecase/UpdateVolumeUseCaseTest.kt
@@ -104,7 +104,6 @@ class UpdateVolumeUseCaseTest(
         val application = queryApplicationPort.findById("2fb0f315-8272-422f-8e9f-c4f765c022b2")!!
         val volume = volumeRepository.findByIdOrNull(targetVolumeId)!!.toDomain()
         val volumeMount = VolumeMount(
-            id = UUID.randomUUID(),
             application = application,
             volume = volume,
             mountPath = "/test/volume",

--- a/src/test/kotlin/com/dcd/server/presentation/domain/volume/VolumeWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/volume/VolumeWebAdapterTest.kt
@@ -11,6 +11,7 @@ import com.dcd.server.core.domain.volume.usecase.DeleteVolumeUseCase
 import com.dcd.server.core.domain.volume.usecase.GetAllVolumeUseCase
 import com.dcd.server.core.domain.volume.usecase.GetOneVolumeUseCase
 import com.dcd.server.core.domain.volume.usecase.MountVolumeUseCase
+import com.dcd.server.core.domain.volume.usecase.UnMountVolumeUseCase
 import com.dcd.server.core.domain.volume.usecase.UpdateVolumeUseCase
 import com.dcd.server.presentation.domain.volume.data.extension.toResponse
 import com.dcd.server.presentation.domain.volume.data.request.CreateVolumeRequest
@@ -31,6 +32,7 @@ class VolumeWebAdapterTest : BehaviorSpec({
     val getAllVolumeUseCase = mockk<GetAllVolumeUseCase>(relaxUnitFun = true)
     val getOneVolumeUseCase = mockk<GetOneVolumeUseCase>(relaxUnitFun = true)
     val mountVolumeUseCase = mockk<MountVolumeUseCase>(relaxUnitFun = true)
+    val unMountVolumeUseCase = mockk<UnMountVolumeUseCase>(relaxUnitFun = true)
 
     val volumeWebAdapter = VolumeWebAdapter(
         createVolumeUseCase,
@@ -38,7 +40,8 @@ class VolumeWebAdapterTest : BehaviorSpec({
         updateVolumeUseCase,
         getAllVolumeUseCase,
         getOneVolumeUseCase,
-        mountVolumeUseCase
+        mountVolumeUseCase,
+        unMountVolumeUseCase
     )
 
     given("워크스페이스 아이디와 볼륨 생성 요청이 주어지고") {
@@ -142,6 +145,23 @@ class VolumeWebAdapterTest : BehaviorSpec({
 
             then("볼륨 마운트 유스케이스가 실행되어야함") {
                 verify { mountVolumeUseCase.execute(testVolumeId, testApplicationId, any() as MountVolumeReqDto) }
+            }
+            then("상태코드 OK가 응답되어야함") {
+                result.statusCode shouldBe HttpStatus.OK
+            }
+        }
+    }
+
+    given("워크스페이스 아이디, 볼륨 아이디, 애플리케이션 아이디가 주어지고") {
+        val testWorkspaceId = UUID.randomUUID().toString()
+        val testVolumeId = UUID.randomUUID()
+        val testApplicationId = UUID.randomUUID().toString()
+
+        `when`("마운트 해제 메서드를 실행할때") {
+            val result = volumeWebAdapter.unMountVolume(testWorkspaceId, testVolumeId, testApplicationId)
+
+            then("볼륨 마운트 해제 유스케이스가 실행되어야함") {
+                verify { unMountVolumeUseCase.execute(testVolumeId, testApplicationId) }
             }
             then("상태코드 OK가 응답되어야함") {
                 result.statusCode shouldBe HttpStatus.OK

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -24,7 +24,7 @@ create table application_env_detail_entity (id BINARY(16) not null, encryption b
 create table application_env_matcher_entity (id BINARY(16) not null, application_id BINARY(16), env_id BINARY(16), primary key (id));
 create table application_env_label_entity (application_env_id BINARY(16) not null, label varchar(255));
 create table volume_entity (id BINARY(16) not null, description varchar(255), name varchar(255), workspace_id BINARY(16) not null, primary key (id));
-create table volume_mount_entity (id BINARY(16) not null, mount_path varchar(255) not null, application_id BINARY(16) not null, volume_id BINARY(16) not null, read_only bit(1) not null, primary key (id));
+create table volume_mount_entity (application_id binary(16) not null, volume_id binary(16) not null, mount_path varchar(255), read_only bit not null, primary key (application_id, volume_id));
 alter table if exists volume_entity add constraint FKhp1ggnqtveky8po2cwsb45una foreign key (workspace_id) references workspace_entity (id) on delete cascade;
 alter table if exists volume_mount_entity add constraint FKr5bb2ev813ioxtylyobgdphel foreign key (application_id) references application_entity (id) on delete cascade;
 alter table if exists volume_mount_entity add constraint FKq6dppr5p20mvgjditmpypicey foreign key (volume_id) references volume_entity (id) on delete cascade;

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -24,7 +24,7 @@ create table application_env_detail_entity (id BINARY(16) not null, encryption b
 create table application_env_matcher_entity (id BINARY(16) not null, application_id BINARY(16), env_id BINARY(16), primary key (id));
 create table application_env_label_entity (application_env_id BINARY(16) not null, label varchar(255));
 create table volume_entity (id BINARY(16) not null, description varchar(255), name varchar(255), workspace_id BINARY(16) not null, primary key (id));
-create table volume_mount_entity (application_id binary(16) not null, volume_id binary(16) not null, mount_path varchar(255), read_only bit not null, primary key (application_id, volume_id));
+create table volume_mount_entity (application_id binary(16) not null, volume_id binary(16) not null, mount_path varchar(255) not null, read_only bit not null, primary key (application_id, volume_id));
 alter table if exists volume_entity add constraint FKhp1ggnqtveky8po2cwsb45una foreign key (workspace_id) references workspace_entity (id) on delete cascade;
 alter table if exists volume_mount_entity add constraint FKr5bb2ev813ioxtylyobgdphel foreign key (application_id) references application_entity (id) on delete cascade;
 alter table if exists volume_mount_entity add constraint FKq6dppr5p20mvgjditmpypicey foreign key (volume_id) references volume_entity (id) on delete cascade;


### PR DESCRIPTION
## 개요
* 마운트 해제 API를 추가합니다.
## 작업내용
* 볼륨 마운트시 이미 마운트됐을때 에러를 발생시키는 로직 추가
* 마운트 삭제, 마운트 조회 메서드 추가
* VolumeMountNotFoundException 추가
* 볼륨 마운트 해제 유스케이스 추가
* 볼륨 마운트 해제 엔드포인트 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 볼륨 언마운트 기능 추가: DELETE /{workspaceId}/volume/{volumeId}/mount (applicationId 필요), 성공 시 200 반환.
  - 중복 마운트 방지 로직 추가(이미 마운트된 경우 오류 발생).
  - 언마운트 엔드포인트에 인증 요구 추가.
  - 신규 오류 코드: 볼륨 마운트 미존재(404) 및 관련 예외 추가.

- **Tests**
  - 마운트/언마운트 유스케이스 및 웹 어댑터 테스트 추가, 정상·오류·경계 시나리오 검증.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->