### PR TITLE
🔀 :: [#723] - 도메인 연결시 설정파일이 생성되어도 트래픽이 전달되지 않는 현상 수정

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
@@ -118,7 +118,7 @@ object FileContent {
             proxy_set_header X-Real-IP ${'$'}remote_addr;
             proxy_set_header X-Forwarded-For ${'$'}proxy_add_x_forwarded_for;
             
-            proxy_pass http://host.docker.internal:${application.externalPort};
+            proxy_pass http://${application.containerName}:${application.externalPort};
           }
         }
         """.trimIndent()


### PR DESCRIPTION
## 개요
* 도메인을 연결후 성공적으로 연결되었고, 파일이 반영되었지만, nginx가 리버스 프록싱을 못하는 현상을 수정합니다.
## 작업내용
* http 설정시 애플리케이션의 containerName을 통한 경로로 프록싱하도록 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - Docker 환경에서 프록시 라우팅 불안정으로 인한 간헐적 연결 실패를 해소했습니다. 요청 전달의 안정성과 응답 시간 일관성이 개선되고, 재시도/타임아웃 발생률이 감소했습니다.
- 작업(Chores)
  - 컨테이너화된 배포에 맞춰 HTTP 프록시 구성을 정비했습니다. 로컬·CI·운영 환경 간 동작 일관성이 향상되고, 네트워크 해상도 의존성이 줄어 설정 관리가 단순해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->