### PR TITLE
🔀 :: [#725] - H2 지원

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
@@ -47,6 +47,13 @@ object FileContent {
         ${getEnvString(env)}
        """.trimIndent()
 
+    fun getH2DBDockerFileContent(version: String, port: Int, env: Map<String, String>): String =
+        """
+        FROM oscarfonts/h2:${version}
+        EXPOSE $port
+        ${getEnvString(env)}
+        """.trimIndent()
+
     fun getImageVersionShellScriptContent(imageName: String, minVersion: String): String =
         """
         #!/bin/bash

--- a/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
@@ -54,12 +54,14 @@ object FileContent {
         ${getEnvString(env)}
         """.trimIndent()
 
-    fun getImageVersionShellScriptContent(imageName: String, minVersion: String): String =
-        """
+    fun getImageVersionShellScriptContent(imageName: String, minVersion: String): String {
+        val imagePrefix = if (imageName.contains("/")) "" else "library/"
+
+        return """
         #!/bin/bash
     
         # 이미지, 페이지 사이즈, 최소 버전(threshold) 설정
-        IMAGE_NAME="library/$imageName"
+        IMAGE_NAME="${imagePrefix}$imageName"
         PAGE_SIZE=100
         MIN_VERSION="$minVersion"
     
@@ -107,6 +109,7 @@ object FileContent {
             echo "${'$'}sorted_numeric_tags"
         fi
         """.trimIndent()
+    }
 
     fun getApplicationHttpConfig(application: Application, domain: String): String =
         """

--- a/src/main/kotlin/com/dcd/server/core/domain/application/model/enums/ApplicationType.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/model/enums/ApplicationType.kt
@@ -5,5 +5,6 @@ enum class ApplicationType {
     NEST_JS,
     MYSQL,
     MARIA_DB,
-    REDIS
+    REDIS,
+    H2_DB
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateDockerFileServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateDockerFileServiceImpl.kt
@@ -80,6 +80,9 @@ class CreateDockerFileServiceImpl(
 
             ApplicationType.NEST_JS ->
                 FileContent.getNestJsDockerFileContent(version, application.port, applicationEnv)
+
+            ApplicationType.H2_DB ->
+                FileContent.getH2DBDockerFileContent(version, application.port, applicationEnv)
         }
         try {
             if (!file.exists())

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetApplicationVersionServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetApplicationVersionServiceImpl.kt
@@ -17,6 +17,7 @@ class GetApplicationVersionServiceImpl(
             ApplicationType.MARIA_DB -> "mariadb" to "10"
             ApplicationType.MYSQL -> "mysql" to "8"
             ApplicationType.REDIS -> "redis" to "6"
+            ApplicationType.H2_DB -> "oscarfonts/h2" to "0"
         }
         val getVersionScript = FileContent.getImageVersionShellScriptContent(baseImageName, minVersion)
         return commandPort.executeShellCommandWithResult(getVersionScript)


### PR DESCRIPTION
## 개요
* h2 데이터베이스를 애플리케이션 타입으로 추가합니다.
## 작업내용
* h2 db 애플리케이션 타입 추가
* h2 db 도커 파일 추가
* CreateDockerFileServiceImpl에 h2_db 타입 분기 추가
* 애플리케이션 버전 조회시 h2_db 분기 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 새로운 기능
  - H2 DB 지원 추가: 애플리케이션 유형에서 H2 DB를 선택할 수 있습니다.
  - H2 전용 Dockerfile 템플릿이 자동 생성되어 컨테이너 이미지 빌드 준비가 쉬워졌습니다.
  - Dockerfile에 포트와 환경 변수 설정이 반영되어 실행 환경 구성이 단순화되었습니다.
  - 이미지 버전 확인 로직에 H2 이미지가 포함되어 최소 지원 버전에 대한 검증이 수행됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->