### PR TITLE
🔀 :: [#731] - 초기화 스크립트 엔티티 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/model/ApplicationInitialScript.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/model/ApplicationInitialScript.kt
@@ -1,0 +1,10 @@
+package com.dcd.server.core.domain.application.model
+
+import java.util.UUID
+
+class ApplicationInitialScript(
+    val id: UUID,
+    val script: String,
+    val application: Application
+) {
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/spi/ApplicationInitialScriptPort.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/spi/ApplicationInitialScriptPort.kt
@@ -1,0 +1,4 @@
+package com.dcd.server.core.domain.application.spi
+
+interface ApplicationInitialScriptPort : CommandApplicationInitialScriptPort, QueryApplicationInitialScriptPort {
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/spi/CommandApplicationInitialScriptPort.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/spi/CommandApplicationInitialScriptPort.kt
@@ -1,0 +1,12 @@
+package com.dcd.server.core.domain.application.spi
+
+import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.ApplicationInitialScript
+
+interface CommandApplicationInitialScriptPort {
+    fun save(applicationInitialScript: ApplicationInitialScript)
+    fun saveAll(applicationInitialScriptList: List<ApplicationInitialScript>)
+    fun delete(applicationInitialScript: ApplicationInitialScript)
+    fun deleteAll(applicationInitialScriptList: List<ApplicationInitialScript>)
+    fun deleteByApplication(application: Application)
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/spi/QueryApplicationInitialScriptPort.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/spi/QueryApplicationInitialScriptPort.kt
@@ -1,0 +1,10 @@
+package com.dcd.server.core.domain.application.spi
+
+import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.ApplicationInitialScript
+import java.util.UUID
+
+interface QueryApplicationInitialScriptPort {
+    fun findById(id: UUID): ApplicationInitialScript?
+    fun findAllByApplication(application: Application): List<ApplicationInitialScript>
+}

--- a/src/main/kotlin/com/dcd/server/persistence/application/ApplicationInitialScriptPersistenceAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/application/ApplicationInitialScriptPersistenceAdapter.kt
@@ -1,0 +1,44 @@
+package com.dcd.server.persistence.application
+
+import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.ApplicationInitialScript
+import com.dcd.server.core.domain.application.spi.ApplicationInitialScriptPort
+import com.dcd.server.persistence.application.adapter.toDomain
+import com.dcd.server.persistence.application.adapter.toEntity
+import com.dcd.server.persistence.application.repository.ApplicationInitialScriptRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class ApplicationInitialScriptPersistenceAdapter(
+    private val applicationInitialScriptRepository: ApplicationInitialScriptRepository
+) : ApplicationInitialScriptPort{
+    override fun save(applicationInitialScript: ApplicationInitialScript) {
+        applicationInitialScriptRepository.save(applicationInitialScript.toEntity())
+    }
+
+    override fun saveAll(applicationInitialScriptList: List<ApplicationInitialScript>) {
+        applicationInitialScriptRepository.saveAll(applicationInitialScriptList.map { it.toEntity() })
+    }
+
+    override fun delete(applicationInitialScript: ApplicationInitialScript) {
+        applicationInitialScriptRepository.delete(applicationInitialScript.toEntity())
+    }
+
+    override fun deleteAll(applicationInitialScriptList: List<ApplicationInitialScript>) {
+        applicationInitialScriptRepository.deleteAll(applicationInitialScriptList.map { it.toEntity() })
+    }
+
+    override fun deleteByApplication(application: Application) {
+        applicationInitialScriptRepository.deleteAllByApplication(application.toEntity())
+    }
+
+    override fun findById(id: UUID): ApplicationInitialScript? =
+        applicationInitialScriptRepository.findByIdOrNull(id)
+            ?.toDomain()
+
+    override fun findAllByApplication(application: Application): List<ApplicationInitialScript> =
+        applicationInitialScriptRepository.findAllByApplication(application.toEntity())
+            .map { it.toDomain() }
+}

--- a/src/main/kotlin/com/dcd/server/persistence/application/adapter/ApplicationAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/application/adapter/ApplicationAdapter.kt
@@ -1,8 +1,9 @@
 package com.dcd.server.persistence.application.adapter
 
 import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.ApplicationInitialScript
+import com.dcd.server.persistence.application.entity.ApplicationInitialScriptJpaEntity
 import com.dcd.server.persistence.application.entity.ApplicationJpaEntity
-import com.dcd.server.persistence.env.adapter.toDomain
 import com.dcd.server.persistence.workspace.adapter.toDomain
 import com.dcd.server.persistence.workspace.adapter.toEntity
 import java.util.*
@@ -37,4 +38,18 @@ fun ApplicationJpaEntity.toDomain(): Application =
         status = this.status,
         failureReason = this.failureReason,
         labels = this.labels
+    )
+
+fun ApplicationInitialScript.toEntity(): ApplicationInitialScriptJpaEntity =
+    ApplicationInitialScriptJpaEntity(
+        id = this.id,
+        script = this.script,
+        application = this.application.toEntity()
+    )
+
+fun ApplicationInitialScriptJpaEntity.toDomain(): ApplicationInitialScript =
+    ApplicationInitialScript(
+        id = this.id,
+        script = this.script,
+        application = this.application.toDomain()
     )

--- a/src/main/kotlin/com/dcd/server/persistence/application/entity/ApplicationInitialScriptJpaEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/application/entity/ApplicationInitialScriptJpaEntity.kt
@@ -1,0 +1,23 @@
+package com.dcd.server.persistence.application.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.util.UUID
+
+@Entity
+@Table(name = "application_initial_script_entity")
+class ApplicationInitialScriptJpaEntity(
+    @Id
+    @Column(columnDefinition = "BINARY(16)")
+    val id: UUID,
+    val script: String,
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "application_id")
+    val application: ApplicationJpaEntity,
+) {
+}

--- a/src/main/kotlin/com/dcd/server/persistence/application/repository/ApplicationInitialScriptRepository.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/application/repository/ApplicationInitialScriptRepository.kt
@@ -1,0 +1,11 @@
+package com.dcd.server.persistence.application.repository
+
+import com.dcd.server.persistence.application.entity.ApplicationInitialScriptJpaEntity
+import com.dcd.server.persistence.application.entity.ApplicationJpaEntity
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface ApplicationInitialScriptRepository : JpaRepository<ApplicationInitialScriptJpaEntity, UUID> {
+    fun findAllByApplication(applicationJpaEntity: ApplicationJpaEntity): List<ApplicationInitialScriptJpaEntity>
+    fun deleteAllByApplication(applicationJpaEntity: ApplicationJpaEntity)
+}

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -3,6 +3,7 @@ SET MODE MySQL;
 -- 테이블 생성
 drop table if exists application_entity cascade;
 drop table if exists application_label_entity cascade;
+drop table if exists application_initial_script_entity cascade;
 drop table if exists role_entity cascade;
 drop table if exists user_entity cascade;
 drop table if exists workspace_entity cascade;
@@ -15,6 +16,7 @@ drop table if exists volume_entity cascade;
 drop table if exists volume_mount_entity cascade;
 create table application_entity (external_port integer not null, port integer not null, application_type varchar(255) check (application_type in ('SPRING_BOOT','NEST_JS','MYSQL','MARIA_DB','REDIS')), description varchar(255), failure_reason varchar(255), github_url varchar(255), id binary(16) not null, name varchar(255), status varchar(255) check (status in ('CREATED','PENDING','RUNNING','STOPPED','FAILURE')), version varchar(255), workspace_id binary(16), primary key (id));
 create table application_label_entity (application_id binary(16) not null, label varchar(255));
+create table application_initial_script_entity (id binary(16), script varchar(255), application_id binary(16) not null, primary key (id));
 create table role_entity (roles varchar(255) check (roles in ('ROLE_ADMIN','ROLE_DEVELOPER','ROLE_USER')), user_id binary(16) not null);
 create table user_entity (email varchar(255), id binary(16) not null, name varchar(255), password varchar(255), status varchar(255) check (status in ('PENDING','CREATED')), primary key (id));
 create table workspace_entity (description varchar(255), id binary(16) not null, owner_id binary(16), title varchar(255), primary key (id));
@@ -35,6 +37,7 @@ alter table if exists application_env_entity add constraint FKm22cqdjjl434jyqenp
 alter table if exists application_env_label_entity add constraint FKgd5b8upn11w2uh6voe20dm6df foreign key (application_env_id) references application_env_entity (id);
 alter table if exists application_entity add constraint FKn9drxkrx2h6wlorxfy00mr45h foreign key (workspace_id) references workspace_entity;
 alter table if exists application_label_entity add constraint FKq6iovxq5tdx2i1lwrx34kg0b9 foreign key (application_id) references application_entity;
+alter table if exists application_initial_script_entity add constraint FKq6iovxq5tdx2i1lwrx34kg0b0 foreign key (appliccation_id) references application_entity;
 alter table if exists role_entity add constraint FKrot6fehcor0f3sux5s6kgl0a4 foreign key (user_id) references user_entity;
 alter table if exists workspace_entity add constraint FKlfxk1bhw5knckt8vv28xvx5g2 foreign key (owner_id) references user_entity;
 alter table if exists domain_entity add constraint FKh7b0t3y0a7x5boh75j8lanww6 foreign key (application_id) references application_entity;

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -37,7 +37,7 @@ alter table if exists application_env_entity add constraint FKm22cqdjjl434jyqenp
 alter table if exists application_env_label_entity add constraint FKgd5b8upn11w2uh6voe20dm6df foreign key (application_env_id) references application_env_entity (id);
 alter table if exists application_entity add constraint FKn9drxkrx2h6wlorxfy00mr45h foreign key (workspace_id) references workspace_entity;
 alter table if exists application_label_entity add constraint FKq6iovxq5tdx2i1lwrx34kg0b9 foreign key (application_id) references application_entity;
-alter table if exists application_initial_script_entity add constraint FKq6iovxq5tdx2i1lwrx34kg0b0 foreign key (appliccation_id) references application_entity;
+alter table if exists application_initial_script_entity add constraint FKq6iovxq5tdx2i1lwrx34kg0b0 foreign key (application_id) references application_entity;
 alter table if exists role_entity add constraint FKrot6fehcor0f3sux5s6kgl0a4 foreign key (user_id) references user_entity;
 alter table if exists workspace_entity add constraint FKlfxk1bhw5knckt8vv28xvx5g2 foreign key (owner_id) references user_entity;
 alter table if exists domain_entity add constraint FKh7b0t3y0a7x5boh75j8lanww6 foreign key (application_id) references application_entity;


### PR DESCRIPTION
## 개요
* 초기화 스크립트에 관련된 엔티티를 추가합니다.
## 작업내용
* ApplicationInitialScriptJpaEntity 추가
* ApplicationInitialScript 도메인 추가
* 초기화 스크립트 영속성관련 port및 adapter 추가
* 테스트 sql에 초기화 스크립트 테이블 관련 DDL 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 애플리케이션별 초기 스크립트 관리 기능 추가 — 초기 스크립트 저장, 일괄 저장, 조회(ID 또는 애플리케이션별), 삭제(단건/일괄/애플리케이션별) 가능해졌습니다.
* **테스트**
  * 테스트 데이터베이스 스키마에 초기 스크립트 테이블이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->