### PR TITLE
🔀 :: [#732] - 애플리케이션 생성및 수정시 초기화 스크립트 스펙 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/request/CreateApplicationReqDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/request/CreateApplicationReqDto.kt
@@ -9,5 +9,6 @@ data class CreateApplicationReqDto(
     val applicationType: ApplicationType,
     val port: Int,
     val version: String,
+    val initialScripts: List<String>,
     val labels: List<String>
 )

--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/request/UpdateApplicationReqDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/request/UpdateApplicationReqDto.kt
@@ -5,8 +5,9 @@ import com.dcd.server.core.domain.application.model.enums.ApplicationType
 data class UpdateApplicationReqDto(
     val name: String,
     val description: String?,
-    val applicationType: ApplicationType,
     val githubUrl: String?,
+    val applicationType: ApplicationType,
+    val port: Int,
     val version: String,
-    val port: Int
+    val initialScripts: List<String>,
 )

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/InitialScriptService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/InitialScriptService.kt
@@ -1,0 +1,7 @@
+package com.dcd.server.core.domain.application.service
+
+import com.dcd.server.core.domain.application.model.Application
+
+interface InitialScriptService {
+    fun write(application: Application, initialScripts: List<String>)
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/InitialScriptServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/InitialScriptServiceImpl.kt
@@ -15,6 +15,8 @@ class InitialScriptServiceImpl(
         application: Application,
         initialScripts: List<String>,
     ) {
+        commandApplicationInitialScriptPort.deleteByApplication(application)
+
         val initialScriptList = initialScripts.map { script ->
             ApplicationInitialScript(
                 id = UUID.randomUUID(),

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/InitialScriptServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/InitialScriptServiceImpl.kt
@@ -1,0 +1,27 @@
+package com.dcd.server.core.domain.application.service.impl
+
+import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.ApplicationInitialScript
+import com.dcd.server.core.domain.application.service.InitialScriptService
+import com.dcd.server.core.domain.application.spi.CommandApplicationInitialScriptPort
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+@Service
+class InitialScriptServiceImpl(
+    private val commandApplicationInitialScriptPort: CommandApplicationInitialScriptPort
+) : InitialScriptService {
+    override fun write(
+        application: Application,
+        initialScripts: List<String>,
+    ) {
+        val initialScriptList = initialScripts.map { script ->
+            ApplicationInitialScript(
+                id = UUID.randomUUID(),
+                script = script,
+                application = application,
+            )
+        }
+        commandApplicationInitialScriptPort.saveAll(initialScriptList)
+    }
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCase.kt
@@ -27,7 +27,8 @@ class CreateApplicationUseCase(
     private val buildDockerImageService: BuildDockerImageService,
     private val createContainerService: CreateContainerService,
     private val deleteApplicationDirectoryService: DeleteApplicationDirectoryService,
-    private val envAutoMatchService: EnvAutoMatchService
+    private val envAutoMatchService: EnvAutoMatchService,
+    private val initialScriptService: InitialScriptService
 ) : CoroutineScope by CoroutineScope(Dispatchers.IO) {
     fun execute(createApplicationReqDto: CreateApplicationReqDto): CreateApplicationResDto {
         val workspace = workspaceInfo.workspace
@@ -44,6 +45,7 @@ class CreateApplicationUseCase(
         val version = application.version
 
         envAutoMatchService.match(workspace, application)
+        initialScriptService.write(application, createApplicationReqDto.initialScripts)
 
         launch {
             val applicationType = application.applicationType

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCase.kt
@@ -9,6 +9,7 @@ import com.dcd.server.core.domain.application.exception.ApplicationNotFoundExcep
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.service.DeleteContainerService
 import com.dcd.server.core.domain.application.service.DeleteImageService
+import com.dcd.server.core.domain.application.service.InitialScriptService
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import kotlinx.coroutines.CoroutineScope
@@ -22,7 +23,8 @@ class UpdateApplicationUseCase(
     private val commandApplicationPort: CommandApplicationPort,
     private val deleteContainerService: DeleteContainerService,
     private val deleteImageService: DeleteImageService,
-    private val eventPublisher: ApplicationEventPublisher
+    private val eventPublisher: ApplicationEventPublisher,
+    private val initialScriptService: InitialScriptService
 ) : CoroutineScope by CoroutineScope(Dispatchers.IO) {
     @Lock("#id")
     fun execute(id: String, updateApplicationReqDto: UpdateApplicationReqDto) {
@@ -50,5 +52,7 @@ class UpdateApplicationUseCase(
                 port = updateApplicationReqDto.port
             )
         commandApplicationPort.save(updatedApplication)
+
+        initialScriptService.write(updatedApplication, updateApplicationReqDto.initialScripts)
     }
 }

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationRequestDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationRequestDataExtension.kt
@@ -30,7 +30,8 @@ fun UpdateApplicationRequest.toDto(): UpdateApplicationReqDto =
         applicationType = this.applicationType,
         githubUrl = this.githubUrl,
         version = this.version,
-        port = this.port
+        port = this.port,
+        initialScripts = this.initialScripts,
     )
 
 fun ExecuteCommandRequest.toDto(): ExecuteCommandReqDto =

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationRequestDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationRequestDataExtension.kt
@@ -19,6 +19,7 @@ fun CreateApplicationRequest.toDto(): CreateApplicationReqDto =
         applicationType = this.applicationType,
         port = this.port,
         version = this.version,
+        initialScripts = this.initialScripts,
         labels = this.labels
     )
 

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/request/CreateApplicationRequest.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/request/CreateApplicationRequest.kt
@@ -13,6 +13,6 @@ data class CreateApplicationRequest(
     val applicationType: ApplicationType,
     val port: Int,
     val version: String,
-    val initialScripts: List<String>,
+    val initialScripts: List<String> = listOf(),
     val labels: List<String> = listOf()
 )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/request/CreateApplicationRequest.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/request/CreateApplicationRequest.kt
@@ -13,5 +13,6 @@ data class CreateApplicationRequest(
     val applicationType: ApplicationType,
     val port: Int,
     val version: String,
+    val initialScripts: List<String>,
     val labels: List<String> = listOf()
 )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/request/UpdateApplicationRequest.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/request/UpdateApplicationRequest.kt
@@ -13,5 +13,5 @@ data class UpdateApplicationRequest(
     val applicationType: ApplicationType,
     val port: Int,
     val version: String,
-    val initialScripts: List<String>,
+    val initialScripts: List<String> = listOf(),
 )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/request/UpdateApplicationRequest.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/request/UpdateApplicationRequest.kt
@@ -9,8 +9,9 @@ data class UpdateApplicationRequest(
     @field:Pattern(regexp = "^[a-zA-Z0-9 ]{1,26}$")
     val name: String,
     val description: String?,
-    val applicationType: ApplicationType,
     val githubUrl: String?,
+    val applicationType: ApplicationType,
+    val port: Int,
     val version: String,
-    val port: Int
+    val initialScripts: List<String>,
 )

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCaseTest.kt
@@ -5,6 +5,7 @@ import com.dcd.server.core.domain.application.dto.request.CreateApplicationReqDt
 import com.dcd.server.core.domain.application.exception.AlreadyExistsApplicationException
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
+import com.dcd.server.core.domain.application.spi.QueryApplicationInitialScriptPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.env.model.ApplicationEnv
 import com.dcd.server.core.domain.env.model.ApplicationEnvDetail
@@ -19,6 +20,7 @@ import io.kotest.core.spec.style.BehaviorSpec
 import util.workspace.WorkspaceGenerator
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import kotlinx.coroutines.cancel
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
@@ -33,6 +35,7 @@ class CreateApplicationUseCaseTest(
     private val queryUserPort: QueryUserPort,
     private val commandWorkspacePort: CommandWorkspacePort,
     private val queryApplicationPort: QueryApplicationPort,
+    private val queryApplicationInitialScriptPort: QueryApplicationInitialScriptPort,
     private val queryWorkspacePort: QueryWorkspacePort,
     private val commandApplicationPort: CommandApplicationPort,
     private val commandApplicationEnvPort: CommandApplicationEnvPort,
@@ -56,6 +59,7 @@ class CreateApplicationUseCaseTest(
             githubUrl = "testGithub",
             version = "17",
             port = 8080,
+            initialScripts = listOf(),
             labels = listOf()
         )
 
@@ -82,6 +86,7 @@ class CreateApplicationUseCaseTest(
             githubUrl = "testGithub",
             version = "17",
             port = 8080,
+            initialScripts = listOf(),
             labels = listOf()
         )
 
@@ -104,6 +109,7 @@ class CreateApplicationUseCaseTest(
             githubUrl = "testGithub",
             version = "17",
             port = 8080,
+            initialScripts = listOf(),
             labels = listOf()
         )
 
@@ -142,6 +148,7 @@ class CreateApplicationUseCaseTest(
             githubUrl = "testGithub",
             version = "17",
             port = 8080,
+            initialScripts = listOf(),
             labels = listOf("testLabel")
         )
 
@@ -161,6 +168,30 @@ class CreateApplicationUseCaseTest(
 
                 envMatcher.application.id.toString() shouldBe application.id
                 envMatcher.applicationEnv.id shouldBe applicationEnv.id
+            }
+        }
+    }
+
+    given("초기화 스크립트 내용을 가진 애플리케이션 생성 정보가 주어지고") {
+        val request = CreateApplicationReqDto(
+            name = "testCreateApplication",
+            description = "testDescription",
+            applicationType = ApplicationType.SPRING_BOOT,
+            githubUrl = "testGithub",
+            version = "17",
+            port = 8080,
+            initialScripts = listOf("echo test"),
+            labels = listOf()
+        )
+
+        `when`("usecase를 실행하면") {
+            val applicationId = createApplicationUseCase.execute(request).applicationId
+
+            then("생성된 애플리케이션에 초기화 스크립트가 존재해야함") {
+                val application = queryApplicationPort.findById(applicationId).also { it shouldNotBe null }!!
+                val initialScript = queryApplicationInitialScriptPort.findAllByApplication(application)
+                initialScript.size shouldBe 1
+                initialScript[0].script shouldBe request.initialScripts.first()
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCaseTest.kt
@@ -7,12 +7,14 @@ import com.dcd.server.core.domain.application.exception.ApplicationNotFoundExcep
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
+import com.dcd.server.core.domain.application.spi.QueryApplicationInitialScriptPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.user.spi.QueryUserPort
 import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.mockk.coVerify
@@ -29,13 +31,14 @@ class UpdateApplicationUseCaseTest(
     private val queryUserPort: QueryUserPort,
     private val queryWorkspacePort: QueryWorkspacePort,
     private val queryApplicationPort: QueryApplicationPort,
+    private val queryApplicationInitialScriptPort: QueryApplicationInitialScriptPort,
     private val commandApplicationPort: CommandApplicationPort,
     @MockkBean(relaxed = true)
     private val commandPort: CommandPort
 ) : BehaviorSpec({
     val targetUserId = "923a6407-a5f8-4e1e-bffd-0621910ddfc8"
 
-    val updateReqDto = UpdateApplicationReqDto(name = "updated application", description = "dldl", applicationType = ApplicationType.SPRING_BOOT, githubUrl = null, version = "11", port = 8080)
+    val updateReqDto = UpdateApplicationReqDto(name = "updated application", description = "dldl", applicationType = ApplicationType.SPRING_BOOT, githubUrl = null, version = "11", port = 8080, initialScripts = listOf("echo test"))
 
     given("애플리케이션 아이디가 주어지고") {
         val targetUser = queryUserPort.findById(targetUserId)!!
@@ -58,6 +61,13 @@ class UpdateApplicationUseCaseTest(
                 result?.version shouldBe updateReqDto.version
                 coVerify { commandPort.executeShellCommand("docker rm ${targetApplication.containerName}") }
                 coVerify { commandPort.executeShellCommand("docker rmi ${targetApplication.containerName}") }
+            }
+
+            then("변경된 초기화 스크립트를 가지고 있어야함") {
+                val result = queryApplicationPort.findById(applicationId).also { it shouldNotBe null }!!
+                val initialScripts = queryApplicationInitialScriptPort.findAllByApplication(result)
+                initialScripts shouldHaveSize 1
+                initialScripts[0].script shouldBe updateReqDto.initialScripts.first()
             }
         }
 

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -39,6 +39,7 @@ class ApplicationWebAdapterTest : BehaviorSpec({
             applicationType = ApplicationType.SPRING_BOOT,
             githubUrl = "testUrl",
             port = 8080,
+            initialScripts = emptyList(),
             version = "17",
         )
 

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -158,7 +158,7 @@ class ApplicationWebAdapterTest : BehaviorSpec({
 
     given("UpdateRequest가 주어지고") {
         val testId ="testId"
-        val request = UpdateApplicationRequest(name = "update", description = null, applicationType = ApplicationType.SPRING_BOOT, githubUrl = null, version = "11", port = 8080)
+        val request = UpdateApplicationRequest(name = "update", description = null, applicationType = ApplicationType.SPRING_BOOT, githubUrl = null, version = "11", port = 8080, initialScripts = emptyList())
 
         `when`("updateApplication 메서드를 실행할때") {
             val result = applicationWebAdapter.updateApplication(testWorkspaceId, testId, request)

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -36,8 +36,8 @@ alter table if exists application_env_matcher_entity add constraint FKqfkw6tgy65
 alter table if exists application_env_entity add constraint FKm22cqdjjl434jyqenpa4nf78p foreign key (workspace_id) references workspace_entity (id);
 alter table if exists application_env_label_entity add constraint FKgd5b8upn11w2uh6voe20dm6df foreign key (application_env_id) references application_env_entity (id);
 alter table if exists application_entity add constraint FKn9drxkrx2h6wlorxfy00mr45h foreign key (workspace_id) references workspace_entity;
-alter table if exists application_label_entity add constraint FKq6iovxq5tdx2i1lwrx34kg0b9 foreign key (application_id) references application_entity;
-alter table if exists application_initial_script_entity add constraint FKq6iovxq5tdx2i1lwrx34kg0b0 foreign key (application_id) references application_entity;
+alter table if exists application_label_entity add constraint FKq6iovxq5tdx2i1lwrx34kg0b9 foreign key (application_id) references application_entity (id);
+alter table if exists application_initial_script_entity add constraint FKq6iovxq5tdx2i1lwrx34kg0b0 foreign key (application_id) references application_entity (id);
 alter table if exists role_entity add constraint FKrot6fehcor0f3sux5s6kgl0a4 foreign key (user_id) references user_entity;
 alter table if exists workspace_entity add constraint FKlfxk1bhw5knckt8vv28xvx5g2 foreign key (owner_id) references user_entity;
 alter table if exists domain_entity add constraint FKh7b0t3y0a7x5boh75j8lanww6 foreign key (application_id) references application_entity;


### PR DESCRIPTION
## 개요
* 애플리케이션 생성및 수정시 초기화 스크립트 스펙을 추가합니다.
## 작업내용
* 애플리케이션에 초기화 스크립트 작성 서비스 추가
* 애플리케이션 생성및 수정 스펙에 초기화 스크립트 필드 추가
* 변경사항 관련 테스트 케이스 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [x] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 애플리케이션 생성 및 업데이트 시 초기 스크립트를 지정·저장 가능
  * 애플리케이션 업데이트 요청에서 포트 설정 지원

* **Bug Fixes / Data**
  * 관련 데이터베이스 외래키 제약 강화

* **Tests**
  * 초기 스크립트 저장 및 검증을 위한 테스트 시나리오 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->