### PR TITLE
🔀 :: [#734] - 애플리케ㅣ션 배포시 초기화 스크립트 적용

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
@@ -1,10 +1,27 @@
 package com.dcd.server.core.common.file
 
 import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import java.lang.StringBuilder
 
 object FileContent {
-    fun getSpringBootDockerFileContent(version: String, port: Int, env: Map<String, String>): String =
+    fun getApplicationDockerFileContent(
+        applicationType: ApplicationType,
+        version: String,
+        port: Int,
+        env: Map<String, String>,
+        initialScripts: List<String>
+    ): String =
+        when(applicationType) {
+            ApplicationType.SPRING_BOOT -> getSpringBootDockerFileContent(version, port, env, initialScripts)
+            ApplicationType.NEST_JS -> getNestJsDockerFileContent(version, port, env, initialScripts)
+            ApplicationType.MYSQL -> getMYSQLDockerFileContent(version, port, env, initialScripts)
+            ApplicationType.MARIA_DB -> getMARIADBDockerFileContent(version, port, env, initialScripts)
+            ApplicationType.H2_DB -> getH2DBDockerFileContent(version, port, env, initialScripts)
+            ApplicationType.REDIS -> getRedisDockerFileContent(version, port, env, initialScripts)
+        }
+
+    private fun getSpringBootDockerFileContent(version: String, port: Int, env: Map<String, String>, initialScripts: List<String>): String =
         """
         FROM openjdk:${version}-jdk
         COPY build/libs/*.jar build/libs/
@@ -16,7 +33,7 @@ object FileContent {
         CMD ["java", "-jar", "build/libs/app.jar"]
         """.trimIndent()
 
-    fun getNestJsDockerFileContent(version: String, port: Int, env: Map<String, String>): String =
+    private fun getNestJsDockerFileContent(version: String, port: Int, env: Map<String, String>, initialScripts: List<String>): String =
         """
         FROM node:${version}
         COPY . .
@@ -28,7 +45,7 @@ object FileContent {
         CMD ["npm", "start"]
         """.trimIndent()
 
-    fun getMYSQLDockerFileContent(version: String, port: Int, env: Map<String, String>): String =
+    private fun getMYSQLDockerFileContent(version: String, port: Int, env: Map<String, String>, initialScripts: List<String>): String =
         """
         FROM mysql:${version}
         EXPOSE $port
@@ -36,7 +53,7 @@ object FileContent {
         ${getInitialScriptsString(initialScripts)}
         """.trimIndent()
 
-    fun getMARIADBDockerFileContent(version: String, port: Int, env: Map<String, String>): String =
+    private fun getMARIADBDockerFileContent(version: String, port: Int, env: Map<String, String>, initialScripts: List<String>): String =
         """
         FROM mariadb:${version}
         EXPOSE $port
@@ -44,7 +61,7 @@ object FileContent {
         ${getInitialScriptsString(initialScripts)}
         """.trimIndent()
 
-    fun getRedisDockerFileContent(version: String, port: Int, env: Map<String, String>): String =
+    private fun getRedisDockerFileContent(version: String, port: Int, env: Map<String, String>, initialScripts: List<String>): String =
         """
         FROM redis:${version}
         EXPOSE $port
@@ -52,7 +69,7 @@ object FileContent {
         ${getInitialScriptsString(initialScripts)}
        """.trimIndent()
 
-    fun getH2DBDockerFileContent(version: String, port: Int, env: Map<String, String>): String =
+    private fun getH2DBDockerFileContent(version: String, port: Int, env: Map<String, String>, initialScripts: List<String>): String =
         """
         FROM oscarfonts/h2:${version}
         EXPOSE $port

--- a/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
@@ -12,6 +12,7 @@ object FileContent {
         RUN mv build/libs/*.jar build/libs/app.jar
         EXPOSE $port
         ${getEnvString(env)}
+        ${getInitialScriptsString(initialScripts)}
         CMD ["java", "-jar", "build/libs/app.jar"]
         """.trimIndent()
 
@@ -23,6 +24,7 @@ object FileContent {
         RUN npm run build
         EXPOSE $port
         ${getEnvString(env)}
+        ${getInitialScriptsString(initialScripts)}
         CMD ["npm", "start"]
         """.trimIndent()
 
@@ -31,6 +33,7 @@ object FileContent {
         FROM mysql:${version}
         EXPOSE $port
         ${getEnvString(env)}
+        ${getInitialScriptsString(initialScripts)}
         """.trimIndent()
 
     fun getMARIADBDockerFileContent(version: String, port: Int, env: Map<String, String>): String =
@@ -38,6 +41,7 @@ object FileContent {
         FROM mariadb:${version}
         EXPOSE $port
         ${getEnvString(env)}
+        ${getInitialScriptsString(initialScripts)}
         """.trimIndent()
 
     fun getRedisDockerFileContent(version: String, port: Int, env: Map<String, String>): String =
@@ -45,6 +49,7 @@ object FileContent {
         FROM redis:${version}
         EXPOSE $port
         ${getEnvString(env)}
+        ${getInitialScriptsString(initialScripts)}
        """.trimIndent()
 
     fun getH2DBDockerFileContent(version: String, port: Int, env: Map<String, String>): String =
@@ -52,6 +57,7 @@ object FileContent {
         FROM oscarfonts/h2:${version}
         EXPOSE $port
         ${getEnvString(env)}
+        ${getInitialScriptsString(initialScripts)}
         """.trimIndent()
 
     fun getImageVersionShellScriptContent(imageName: String, minVersion: String): String {
@@ -141,4 +147,11 @@ object FileContent {
         return envString.toString()
     }
 
+    private fun getInitialScriptsString(initialScripts: List<String>): String {
+        val initialScriptString = StringBuilder()
+        for (initialScript in initialScripts) {
+            initialScriptString.append("RUN $initialScript")
+        }
+        return initialScriptString.toString()
+    }
 }

--- a/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
@@ -167,7 +167,7 @@ object FileContent {
     private fun getInitialScriptsString(initialScripts: List<String>): String {
         val initialScriptString = StringBuilder()
         for (initialScript in initialScripts) {
-            initialScriptString.append("RUN $initialScript")
+            initialScriptString.append("RUN $initialScript\n")
         }
         return initialScriptString.toString()
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateDockerFileServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateDockerFileServiceImpl.kt
@@ -7,9 +7,9 @@ import com.dcd.server.core.domain.application.event.ChangeApplicationStatusEvent
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
-import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.CreateDockerFileService
 import com.dcd.server.core.domain.application.spi.CheckExitValuePort
+import com.dcd.server.core.domain.application.spi.QueryApplicationInitialScriptPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.application.util.FailureCase
 import com.dcd.server.core.domain.env.spi.QueryApplicationEnvPort
@@ -26,6 +26,7 @@ import java.io.IOException
 class CreateDockerFileServiceImpl(
     private val queryApplicationPort: QueryApplicationPort,
     private val queryApplicationEnvPort: QueryApplicationEnvPort,
+    private val queryApplicationInitialScriptPort: QueryApplicationInitialScriptPort,
     private val commandPort: CommandPort,
     private val checkExitValuePort: CheckExitValuePort,
     private val eventPublisher: ApplicationEventPublisher,
@@ -57,6 +58,11 @@ class CreateDockerFileServiceImpl(
                         it.key to it.value
                 }
 
+        val initialScripts =
+            queryApplicationInitialScriptPort
+                .findAllByApplication(application)
+                .map { it.script }
+
         commandPort.executeShellCommand("mkdir -p $directoryName")
             .also {exitValue ->
                 if (exitValue != 0)
@@ -65,25 +71,15 @@ class CreateDockerFileServiceImpl(
             }
 
         val file = File("./${application.name}/Dockerfile")
-        val fileContent = when (application.applicationType) {
-            ApplicationType.SPRING_BOOT ->
-                FileContent.getSpringBootDockerFileContent(version, application.port, applicationEnv)
+        val fileContent =
+            FileContent.getApplicationDockerFileContent(
+                application.applicationType,
+                version,
+                application.port,
+                applicationEnv,
+                initialScripts
+            )
 
-            ApplicationType.MYSQL ->
-                FileContent.getMYSQLDockerFileContent(version, application.port, applicationEnv)
-
-            ApplicationType.MARIA_DB ->
-                FileContent.getMARIADBDockerFileContent(version, application.port, applicationEnv)
-
-            ApplicationType.REDIS ->
-                FileContent.getRedisDockerFileContent(version, application.port, applicationEnv)
-
-            ApplicationType.NEST_JS ->
-                FileContent.getNestJsDockerFileContent(version, application.port, applicationEnv)
-
-            ApplicationType.H2_DB ->
-                FileContent.getH2DBDockerFileContent(version, application.port, applicationEnv)
-        }
         try {
             if (!file.exists())
                 file.createNewFile()

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/CreateDockerFileServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/CreateDockerFileServiceImplTest.kt
@@ -7,6 +7,7 @@ import com.dcd.server.core.domain.application.service.impl.CreateDockerFileServi
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.infrastructure.global.command.adapter.CommandAdapter
 import com.dcd.server.core.domain.application.spi.CheckExitValuePort
+import com.dcd.server.core.domain.application.spi.QueryApplicationInitialScriptPort
 import com.dcd.server.core.domain.env.spi.QueryApplicationEnvPort
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -21,16 +22,18 @@ import java.io.File
 class CreateDockerFileServiceImplTest : BehaviorSpec({
     val queryApplicationPort = mockk<QueryApplicationPort>()
     val queryApplicationEnvPort = mockk<QueryApplicationEnvPort>()
+    val queryApplicationInitialScriptPort = mockk<QueryApplicationInitialScriptPort>()
     val commandPort = spyk(CommandAdapter())
     val eventPublisher = mockk<ApplicationEventPublisher>(relaxed = true)
     val checkExitValuePort = mockk<CheckExitValuePort>(relaxUnitFun = true)
     val encryptPort = mockk<EncryptPort>()
-    val createDockerFileService = CreateDockerFileServiceImpl(queryApplicationPort, queryApplicationEnvPort, commandPort, checkExitValuePort, eventPublisher, encryptPort)
+    val createDockerFileService = CreateDockerFileServiceImpl(queryApplicationPort, queryApplicationEnvPort, queryApplicationInitialScriptPort, commandPort, checkExitValuePort, eventPublisher, encryptPort)
 
     given("스프링 애플리케이션이 주어지고") {
         val application =
             ApplicationGenerator.generateApplication(applicationType = ApplicationType.SPRING_BOOT)
         every { queryApplicationEnvPort.findByApplication(application) } returns emptyList()
+        every { queryApplicationInitialScriptPort.findAllByApplication(application) } returns emptyList()
 
         `when`("서비스를 실행할때") {
             createDockerFileService.createFileToApplication(application, application.version)
@@ -48,7 +51,7 @@ class CreateDockerFileServiceImplTest : BehaviorSpec({
                 }
                 actualFileContent.deleteAt(actualFileContent.length - 1)
 
-                actualFileContent.toString() shouldBe FileContent.getSpringBootDockerFileContent(application.version, application.port, emptyMap())
+                actualFileContent.toString() shouldBe FileContent.getApplicationDockerFileContent(application.applicationType, application.version, application.port, emptyMap(), listOf())
             }
         }
 
@@ -59,6 +62,7 @@ class CreateDockerFileServiceImplTest : BehaviorSpec({
         val application =
             ApplicationGenerator.generateApplication(applicationType = ApplicationType.REDIS)
         every { queryApplicationEnvPort.findByApplication(application) } returns emptyList()
+        every { queryApplicationInitialScriptPort.findAllByApplication(application) } returns emptyList()
 
         `when`("서비스를 실행할때") {
             createDockerFileService.createFileToApplication(application, application.version)
@@ -75,7 +79,7 @@ class CreateDockerFileServiceImplTest : BehaviorSpec({
                     actualFileContent.append(it + "\n")
                 }
 
-                actualFileContent.toString() shouldBe FileContent.getRedisDockerFileContent(application.version, application.port, emptyMap())
+                actualFileContent.toString() shouldBe FileContent.getApplicationDockerFileContent(application.applicationType, application.version, application.port, emptyMap(), listOf())
             }
         }
 
@@ -86,6 +90,7 @@ class CreateDockerFileServiceImplTest : BehaviorSpec({
         val application =
             ApplicationGenerator.generateApplication(applicationType = ApplicationType.MYSQL)
         every { queryApplicationEnvPort.findByApplication(application) } returns emptyList()
+        every { queryApplicationInitialScriptPort.findAllByApplication(application) } returns emptyList()
 
         `when`("서비스를 실행할때") {
             createDockerFileService.createFileToApplication(application, application.version)
@@ -102,7 +107,7 @@ class CreateDockerFileServiceImplTest : BehaviorSpec({
                     actualFileContent.append(it + "\n")
                 }
 
-                actualFileContent.toString() shouldBe FileContent.getMYSQLDockerFileContent(application.version, application.port, emptyMap())
+                actualFileContent.toString() shouldBe FileContent.getApplicationDockerFileContent(application.applicationType, application.version, application.port, emptyMap(), listOf())
             }
         }
 
@@ -113,6 +118,7 @@ class CreateDockerFileServiceImplTest : BehaviorSpec({
         val application =
             ApplicationGenerator.generateApplication(applicationType = ApplicationType.MARIA_DB)
         every { queryApplicationEnvPort.findByApplication(application) } returns emptyList()
+        every { queryApplicationInitialScriptPort.findAllByApplication(application) } returns emptyList()
 
         `when`("서비스를 실행할때") {
             createDockerFileService.createFileToApplication(application, application.version)
@@ -129,7 +135,7 @@ class CreateDockerFileServiceImplTest : BehaviorSpec({
                     actualFileContent.append(it + "\n")
                 }
 
-                actualFileContent.toString() shouldBe FileContent.getMARIADBDockerFileContent(application.version, application.port, emptyMap())
+                actualFileContent.toString() shouldBe FileContent.getApplicationDockerFileContent(application.applicationType, application.version, application.port, emptyMap(), listOf())
             }
         }
 


### PR DESCRIPTION
## 개요
* 애플리케이션 배포시에 초기화 스크립트를 수행하는 로직을 추가합니다.
## 작업내용
* 초기화 스크립트 도커파일 내용을 생성하는 메서드 추가
* 도커파일 생성을 하나의 메서드에서 처리하도록 수정
* 도커파일 생성 서비스에서 when 분기대신 getApplicationDockerFileContent 메서드를 사용하도록 수정
* 도커파일 생성 서비스에 초기화 스크립트 관련 테스트 케이스 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Docker 파일 생성 시 여러 초기 스크립트(RUN 명령) 추가 실행 지원

* **리팩토링**
  * 애플리케이션 유형별 Dockerfile 생성 로직을 통합해 호출 방식 단순화

* **테스트**
  * 초기 스크립트 흐름을 반영하도록 단위 테스트 및 목 설정 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->