### PR TITLE
🔀 :: [#737] - 애플리케이션 정보 응답에 초기화 스크립트 관련 필드 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/extenstion/ApplicationDtoExtension.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/extenstion/ApplicationDtoExtension.kt
@@ -4,6 +4,7 @@ import com.dcd.server.core.domain.application.dto.request.CreateApplicationReqDt
 import com.dcd.server.core.domain.application.dto.response.ApplicationProfileResDto
 import com.dcd.server.core.domain.application.dto.response.ApplicationResDto
 import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.ApplicationInitialScript
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.env.model.ApplicationEnv
 import com.dcd.server.core.domain.workspace.dto.response.WorkspaceApplicationResDto
@@ -23,7 +24,7 @@ fun CreateApplicationReqDto.toEntity(workspace: Workspace, externalPort: Int): A
         labels = this.labels
     )
 
-fun Application.toDto(envList: List<ApplicationEnv>): ApplicationResDto =
+fun Application.toDto(envList: List<ApplicationEnv>, initialScriptList: List<ApplicationInitialScript>): ApplicationResDto =
     ApplicationResDto(
         id = this.id,
         name = this.name,
@@ -41,6 +42,7 @@ fun Application.toDto(envList: List<ApplicationEnv>): ApplicationResDto =
         version = this.version,
         status = this.status,
         failureReason = this.failureReason,
+        initialScripts = initialScriptList.map { it.script },
         labels = this.labels
     )
 

--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/response/ApplicationResDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/response/ApplicationResDto.kt
@@ -15,5 +15,6 @@ data class ApplicationResDto(
     val version: String,
     val status: ApplicationStatus,
     val failureReason: String?,
+    val initialScripts: List<String>,
     val labels: List<String>
 )

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCase.kt
@@ -5,6 +5,7 @@ import com.dcd.server.core.common.data.WorkspaceInfo
 import com.dcd.server.core.common.data.dto.response.ListResDto
 import com.dcd.server.core.domain.application.dto.extenstion.toDto
 import com.dcd.server.core.domain.application.dto.response.ApplicationResDto
+import com.dcd.server.core.domain.application.spi.QueryApplicationInitialScriptPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.env.spi.QueryApplicationEnvPort
 import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
@@ -13,7 +14,8 @@ import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
 class GetAllApplicationUseCase(
     private val queryApplicationPort: QueryApplicationPort,
     private val workspaceInfo: WorkspaceInfo,
-    private val queryApplicationEnvPort: QueryApplicationEnvPort
+    private val queryApplicationEnvPort: QueryApplicationEnvPort,
+    private val queryApplicationInitialScriptPort: QueryApplicationInitialScriptPort,
 ) {
     fun execute(labels: List<String>?): ListResDto<ApplicationResDto> {
         val workspace = workspaceInfo.workspace
@@ -24,7 +26,8 @@ class GetAllApplicationUseCase(
                 .findAllByWorkspace(workspace, labels)
                 .map {
                     val applicationEnvList = queryApplicationEnvPort.findByApplication(it)
-                    it.toDto(applicationEnvList)
+                    val initialScripts = queryApplicationInitialScriptPort.findAllByApplication(it)
+                    it.toDto(applicationEnvList, initialScripts)
                 }
         )
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCase.kt
@@ -4,18 +4,21 @@ import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.domain.application.dto.extenstion.toDto
 import com.dcd.server.core.domain.application.dto.response.ApplicationResDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
+import com.dcd.server.core.domain.application.spi.QueryApplicationInitialScriptPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.env.spi.QueryApplicationEnvPort
 
 @UseCase(readOnly = true)
 class GetOneApplicationUseCase(
     private val queryApplicationPort: QueryApplicationPort,
-    private val queryApplicationEnvPort: QueryApplicationEnvPort
+    private val queryApplicationEnvPort: QueryApplicationEnvPort,
+    private val queryApplicationInitialScriptPort: QueryApplicationInitialScriptPort
 ) {
     fun execute(id: String): ApplicationResDto {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
         val applicationEnvList = queryApplicationEnvPort.findByApplication(application)
-        return application.toDto(applicationEnvList)
+        val initialScripts = queryApplicationInitialScriptPort.findAllByApplication(application)
+        return application.toDto(applicationEnvList, initialScripts)
     }
 }

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
@@ -20,8 +20,6 @@ class ApplicationWebAdapter(
     private val runApplicationUseCase: RunApplicationUseCase,
     private val getAllApplicationUseCase: GetAllApplicationUseCase,
     private val getOneApplicationUseCase: GetOneApplicationUseCase,
-//    private val putApplicationEnvUseCase: PutApplicationEnvUseCase,
-//    private val deleteApplicationEnvUseCase: DeleteApplicationEnvUseCase,
     private val stopApplicationUseCase: StopApplicationUseCase,
     private val deleteApplicationUseCase: DeleteApplicationUseCase,
     private val updateApplicationUseCase: UpdateApplicationUseCase,

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationResponseDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationResponseDataExtension.kt
@@ -18,6 +18,7 @@ fun ApplicationResDto.toResponse(): ApplicationResponse =
         version = this.version,
         status = this.status,
         failureReason = this.failureReason,
+        initialScripts = this.initialScripts,
         labels = this.labels
     )
 

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/response/ApplicationResponse.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/response/ApplicationResponse.kt
@@ -15,5 +15,6 @@ data class ApplicationResponse(
     val version: String,
     val status: ApplicationStatus,
     val failureReason: String?,
+    val initialScripts: List<String>,
     val labels: List<String>
 )

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCaseTest.kt
@@ -41,7 +41,7 @@ class GetAllApplicationUseCaseTest(
 
         `when`("usecase를 실행할때") {
             val result = getAllApplicationUseCase.execute(null)
-            val target = ListResDto(applicationList.map { it.toDto(listOf()) })
+            val target = ListResDto(applicationList.map { it.toDto(listOf(), listOf()) })
             then("result는 target이랑 같아야함") {
                 result shouldBe target
             }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCaseTest.kt
@@ -36,7 +36,7 @@ class GetOneApplicationUseCaseTest(
             val result = getOneApplicationUseCase.execute(application.id)
 
             then("result는 application의 내용이랑 같아야함") {
-                result shouldBeEqualToComparingFields application.toDto(listOf())
+                result shouldBeEqualToComparingFields application.toDto(listOf(), listOf())
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -69,7 +69,8 @@ class ApplicationWebAdapterTest : BehaviorSpec({
             version = "latest",
             status = ApplicationStatus.STOPPED,
             labels = listOf(),
-            failureReason = null
+            failureReason = null,
+            initialScripts = emptyList(),
         )
         val list = listOf(applicationResponse)
         val responseDto = ListResDto(list)
@@ -98,7 +99,8 @@ class ApplicationWebAdapterTest : BehaviorSpec({
             version = "latest",
             status = ApplicationStatus.STOPPED,
             labels = listOf(),
-            failureReason = null
+            failureReason = null,
+            initialScripts = emptyList(),
         )
         `when`("getOneApplication 메서드를 실행할때") {
             every { getOneApplicationUseCase.execute(testId) } returns applicationResponse


### PR DESCRIPTION
## 개요
* 애플리케이션 정보 응답에 초기화 스크립트 관련 필드를 추가합니다.
## 작업내용
* 애플리케이션 응답 dto에 initialScripts 필드 추가
* 애플리케이션 응답 객체에 initialScripts 필드 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 애플리케이션 조회 시 초기 스크립트를 함께 제공하는 기능이 추가되었습니다. 모든 애플리케이션 목록 조회 및 개별 애플리케이션 조회 시 관련 초기 스크립트 정보가 응답에 포함됩니다.

* **개선 사항**
  * 애플리케이션 응답 데이터 구조가 확장되어 초기 스크립트 정보를 더욱 효율적으로 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->