### PR TITLE
🔀 :: [#743] - 애플리케이션 실패 사유 리펙토링

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/command/CommandPort.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/command/CommandPort.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.core.common.command
 
+import com.dcd.server.core.common.command.dto.CommandResult
+
 interface CommandPort {
-    fun executeShellCommand(cmd: String): Int
-    fun executeShellCommandWithResult(cmd: String): List<String>
+    fun executeShellCommand(cmd: String): CommandResult
 }

--- a/src/main/kotlin/com/dcd/server/core/common/command/dto/CommandResult.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/command/dto/CommandResult.kt
@@ -1,0 +1,6 @@
+package com.dcd.server.core.common.command.dto
+
+data class CommandResult(
+    val exitValue: Int,
+    val result: List<String>
+)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/extenstion/ApplicationDtoExtension.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/extenstion/ApplicationDtoExtension.kt
@@ -41,7 +41,7 @@ fun Application.toDto(envList: List<ApplicationEnv>, initialScriptList: List<App
         externalPort = this.externalPort,
         version = this.version,
         status = this.status,
-        failureReason = this.failureReason,
+        failureReason = this.deploymentResult.failureCase?.reason,
         initialScripts = initialScriptList.map { it.script },
         labels = this.labels
     )

--- a/src/main/kotlin/com/dcd/server/core/domain/application/event/ChangeApplicationStatusEvent.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/event/ChangeApplicationStatusEvent.kt
@@ -7,5 +7,6 @@ import com.dcd.server.core.domain.application.util.FailureCase
 class ChangeApplicationStatusEvent(
     val status: ApplicationStatus,
     val application: Application,
-    val failureCase: FailureCase? = null
+    val failureCase: FailureCase? = null,
+    val failureReasonDetail: String? = null
 )

--- a/src/main/kotlin/com/dcd/server/core/domain/application/event/listener/ApplicationEventListener.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/event/listener/ApplicationEventListener.kt
@@ -52,34 +52,29 @@ class ApplicationEventListener(
 
         applicationList.forEach { application ->
             CoroutineScope(Dispatchers.IO).launch {
-                try {
-                    deleteContainerService.deleteContainer(application)
-                    deleteImageService.deleteImage(application)
+                deleteContainerService.deleteContainer(application)
+                deleteImageService.deleteImage(application)
 
-                    val version = application.version
-                    val externalPort = application.externalPort
+                val version = application.version
+                val externalPort = application.externalPort
 
-                    val applicationType = application.applicationType
-                    when (applicationType) {
-                        ApplicationType.SPRING_BOOT, ApplicationType.NEST_JS -> {
-                            cloneApplicationByUrlService.cloneByApplication(application)
-                        }
-
-                        else -> {}
+                val applicationType = application.applicationType
+                when (applicationType) {
+                    ApplicationType.SPRING_BOOT, ApplicationType.NEST_JS -> {
+                        cloneApplicationByUrlService.cloneByApplication(application)
                     }
 
-                    createDockerFileService.createFileToApplication(application, version)
-                    buildDockerImageService.buildImageByApplication(application)
-                    createContainerService.createContainer(application, externalPort)
-
-                    val updatedApplication = application.copy(status = ApplicationStatus.STOPPED)
-                    commandApplicationPort.save(updatedApplication)
-                } catch (e: Exception) {
-                    val updatedApplication = application.copy(status = ApplicationStatus.FAILURE, failureReason = e.message)
-                    commandApplicationPort.save(updatedApplication)
-                } finally {
-                    deleteApplicationDirectoryService.deleteApplicationDirectory(application)
+                    else -> {}
                 }
+
+                createDockerFileService.createFileToApplication(application, version)
+                buildDockerImageService.buildImageByApplication(application)
+                createContainerService.createContainer(application, externalPort)
+
+                val updatedApplication = application.copy(status = ApplicationStatus.STOPPED)
+                commandApplicationPort.save(updatedApplication)
+
+                deleteApplicationDirectoryService.deleteApplicationDirectory(application)
             }
 
         }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/event/listener/ApplicationEventListener.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/event/listener/ApplicationEventListener.kt
@@ -2,6 +2,7 @@ package com.dcd.server.core.domain.application.event.listener
 
 import com.dcd.server.core.domain.application.event.ChangeApplicationStatusEvent
 import com.dcd.server.core.domain.application.event.DeployApplicationEvent
+import com.dcd.server.core.domain.application.model.DeploymentResult
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.BuildDockerImageService
@@ -39,7 +40,7 @@ class ApplicationEventListener(
     fun process(event: ChangeApplicationStatusEvent) {
         val updatedApplication = event.application.copy(
             status = event.status,
-            failureReason = event.failureCase?.reason
+            deploymentResult = DeploymentResult.from(event.failureCase, event.failureReasonDetail)
         )
 
         commandApplicationPort.save(updatedApplication)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/model/Application.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/model/Application.kt
@@ -2,7 +2,6 @@ package com.dcd.server.core.domain.application.model
 
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
-import com.dcd.server.core.domain.env.model.ApplicationEnv
 import com.dcd.server.core.domain.workspace.model.Workspace
 import java.util.*
 
@@ -17,7 +16,7 @@ data class Application(
     val port: Int,
     val externalPort: Int,
     val status: ApplicationStatus,
-    val failureReason: String? = null,
+    val deploymentResult: DeploymentResult = DeploymentResult.SUCCESS,
     val labels: List<String>
 ) {
     val containerName = "${name.replace(" ", "_").lowercase()}-$id"

--- a/src/main/kotlin/com/dcd/server/core/domain/application/model/DeploymentResult.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/model/DeploymentResult.kt
@@ -8,4 +8,12 @@ sealed class DeploymentResult(
 ) {
     object SUCCESS : DeploymentResult(failureCase = null, failureReasonDetail = null)
     class ERROR(failureCase: FailureCase, detail: String?) : DeploymentResult(failureCase = failureCase, failureReasonDetail = detail)
+
+    companion object {
+        fun from(failureCase: FailureCase?, failureReasonDetail: String?): DeploymentResult =
+            when (failureCase) {
+                null -> SUCCESS
+                else -> ERROR(failureCase, failureReasonDetail)
+            }
+    }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/model/DeploymentResult.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/model/DeploymentResult.kt
@@ -1,0 +1,11 @@
+package com.dcd.server.core.domain.application.model
+
+import com.dcd.server.core.domain.application.util.FailureCase
+
+sealed class DeploymentResult(
+    val failureCase: FailureCase?,
+    val failureReasonDetail: String?,
+) {
+    object SUCCESS : DeploymentResult(failureCase = null, failureReasonDetail = null)
+    class ERROR(failureCase: FailureCase, detail: String?) : DeploymentResult(failureCase = failureCase, failureReasonDetail = detail)
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/scheduler/ApplicationStatusScheduler.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/scheduler/ApplicationStatusScheduler.kt
@@ -1,11 +1,13 @@
 package com.dcd.server.core.domain.application.scheduler
 
 import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.DeploymentResult
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.scheduler.enums.ContainerStatus
 import com.dcd.server.core.domain.application.service.GetContainerService
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import com.dcd.server.core.domain.application.util.FailureCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
@@ -56,8 +58,10 @@ class ApplicationStatusScheduler(
                 val updatedApplication =
                     if (exitCode == "0")
                         containerExitedApplication.copy(status = ApplicationStatus.STOPPED)
-                    else
-                        containerExitedApplication.copy(status = ApplicationStatus.FAILURE, failureReason = "컨테이너가 비정상적으로 종료됨")
+                    else {
+                        val deploymentResult = DeploymentResult.ERROR(FailureCase.RUN_CONTAINER_FAILURE, "Container terminated")
+                        containerExitedApplication.copy(status = ApplicationStatus.FAILURE, deploymentResult = deploymentResult)
+                    }
 
                 updatedApplicationList.add(updatedApplication)
             }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/BuildDockerImageServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/BuildDockerImageServiceImpl.kt
@@ -23,11 +23,11 @@ class BuildDockerImageServiceImpl(
             ?: throw ApplicationNotFoundException())
         val directoryName = "'${application.name}'"
         withContext(Dispatchers.IO) {
-            val exitValue = when (application.applicationType) {
+            val commandResult = when (application.applicationType) {
                 ApplicationType.SPRING_BOOT -> {
                     commandPort.executeShellCommand("cd ./$directoryName && ./gradlew clean build")
                         .run {
-                            if (this == 0)
+                            if (this.exitValue == 0)
                                 commandPort.executeShellCommand("cd ./$directoryName && docker build -t ${application.containerName}:latest .")
                             else this
                         }
@@ -37,16 +37,16 @@ class BuildDockerImageServiceImpl(
                     commandPort.executeShellCommand("cd ./$directoryName && docker build -t ${application.containerName}:latest .")
                 }
             }
-            if (exitValue != 0)
+            if (commandResult.exitValue != 0)
                 commandPort.executeShellCommand("rm -rf $directoryName")
-            checkExitValuePort.checkApplicationExitValue(exitValue, application, this, FailureCase.IMAGE_BUILD_FAILURE)
+            checkExitValuePort.checkApplicationExitValue(commandResult, application, this, FailureCase.IMAGE_BUILD_FAILURE)
         }
     }
 
     override suspend fun buildImageByApplication(application: Application) {
         val directoryName = "'${application.name}'"
         withContext(Dispatchers.IO) {
-            val exitValue = when(application.applicationType) {
+            val commandResult = when(application.applicationType) {
                 ApplicationType.SPRING_BOOT -> {
                     commandPort.executeShellCommand("cd ./$directoryName && ./gradlew clean build")
                     commandPort.executeShellCommand("cd ./$directoryName && docker build -t ${application.containerName}:latest .")
@@ -58,9 +58,9 @@ class BuildDockerImageServiceImpl(
                     commandPort.executeShellCommand("cd ./$directoryName && docker build -t ${application.containerName}:latest .")
                 }
             }
-            if (exitValue != 0)
+            if (commandResult.exitValue != 0)
                 commandPort.executeShellCommand("rm -rf $directoryName")
-            checkExitValuePort.checkApplicationExitValue(exitValue, application, this, FailureCase.IMAGE_BUILD_FAILURE)
+            checkExitValuePort.checkApplicationExitValue(commandResult, application, this, FailureCase.IMAGE_BUILD_FAILURE)
         }
     }
 

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CloneApplicationByUrlServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CloneApplicationByUrlServiceImpl.kt
@@ -22,8 +22,8 @@ class CloneApplicationByUrlServiceImpl(
             val application = (queryApplicationPort.findById(id)
                 ?: throw ApplicationNotFoundException())
             val githubUrl = application.githubUrl
-            val exitValue = commandPort.executeShellCommand("git clone $githubUrl '${application.name}'")
-            checkExitValuePort.checkApplicationExitValue(exitValue, application, this, FailureCase.CLONE_FAILURE)
+            val commandResult = commandPort.executeShellCommand("git clone $githubUrl '${application.name}'")
+            checkExitValuePort.checkApplicationExitValue(commandResult, application, this, FailureCase.CLONE_FAILURE)
         }
     }
 
@@ -31,8 +31,8 @@ class CloneApplicationByUrlServiceImpl(
         withContext(Dispatchers.IO) {
             val githubUrl = application.githubUrl
             commandPort.executeShellCommand("git clone $githubUrl '${application.name}'")
-                .also {exitValue ->
-                    checkExitValuePort.checkApplicationExitValue(exitValue, application, this, FailureCase.CLONE_FAILURE)
+                .also {commandResult ->
+                    checkExitValuePort.checkApplicationExitValue(commandResult, application, this, FailureCase.CLONE_FAILURE)
                 }
         }
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateContainerServiceImpl.kt
@@ -35,9 +35,9 @@ class CreateContainerServiceImpl(
                 "-p ${externalPort}:${application.port} ${application.containerName}:latest"
 
             commandPort.executeShellCommand(cmd)
-                .also {exitValue ->
-                    checkExitValuePort.checkApplicationExitValue(exitValue, application, this, FailureCase.CREATE_CONTAINER_FAILURE)
-                    if (exitValue != 0) {
+                .also { commandResult ->
+                    checkExitValuePort.checkApplicationExitValue(commandResult, application, this, FailureCase.CREATE_CONTAINER_FAILURE)
+                    if (commandResult.exitValue != 0) {
                         commandPort.executeShellCommand("rm -rf ${application.name}")
                         return@withContext
                     }
@@ -45,9 +45,9 @@ class CreateContainerServiceImpl(
 
             val dcdNetworkConnectCmd = "docker network connect dcd ${application.containerName}"
             commandPort.executeShellCommand(dcdNetworkConnectCmd)
-                .also {exitValue ->
-                    checkExitValuePort.checkApplicationExitValue(exitValue, application, this, FailureCase.CONNECT_NETWORK_FAILURE)
-                    if (exitValue != 0) {
+                .also {commandResult ->
+                    checkExitValuePort.checkApplicationExitValue(commandResult, application, this, FailureCase.CONNECT_NETWORK_FAILURE)
+                    if (commandResult.exitValue != 0) {
                         commandPort.executeShellCommand("rm -rf ${application.name}")
                         return@withContext
                     }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateDockerFileServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/CreateDockerFileServiceImpl.kt
@@ -64,10 +64,10 @@ class CreateDockerFileServiceImpl(
                 .map { it.script }
 
         commandPort.executeShellCommand("mkdir -p $directoryName")
-            .also {exitValue ->
-                if (exitValue != 0)
+            .also {commandResult ->
+                if (commandResult.exitValue != 0)
                     commandPort.executeShellCommand("rm -rf $directoryName")
-                checkExitValuePort.checkApplicationExitValue(exitValue, application, coroutineScope, FailureCase.CREATE_DIRECTORY_FAILURE)
+                checkExitValuePort.checkApplicationExitValue(commandResult, application, coroutineScope, FailureCase.CREATE_DIRECTORY_FAILURE)
             }
 
         val file = File("./${application.name}/Dockerfile")

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteApplicationDirectoryServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteApplicationDirectoryServiceImpl.kt
@@ -17,8 +17,8 @@ class DeleteApplicationDirectoryServiceImpl(
     override suspend fun deleteApplicationDirectory(application: Application) {
         withContext(Dispatchers.IO) {
             commandPort.executeShellCommand("rm -rf '${application.name}'")
-                .also {exitValue ->
-                    checkExitValuePort.checkApplicationExitValue(exitValue, application, this, FailureCase.DELETE_DIRECTORY_FAILURE)
+                .also { commandResult ->
+                    checkExitValuePort.checkApplicationExitValue(commandResult, application, this, FailureCase.DELETE_DIRECTORY_FAILURE)
                 }
         }
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteContainerServiceImpl.kt
@@ -17,9 +17,9 @@ class DeleteContainerServiceImpl(
     override suspend fun deleteContainer(application: Application) {
         withContext(Dispatchers.IO) {
             commandPort.executeShellCommand("docker rm ${application.containerName}")
-                .also {exitValue ->
-                    if (exitValue != 0 && exitValue != 1)
-                        checkExitValuePort.checkApplicationExitValue(exitValue, application, this, FailureCase.DELETE_CONTAINER_FAILURE)
+                .also {commandResult ->
+                    if (commandResult.exitValue != 0 && commandResult.exitValue != 1)
+                        checkExitValuePort.checkApplicationExitValue(commandResult, application, this, FailureCase.DELETE_CONTAINER_FAILURE)
                 }
         }
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteImageServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteImageServiceImpl.kt
@@ -17,9 +17,9 @@ class DeleteImageServiceImpl(
     override suspend fun deleteImage(application: Application) {
         withContext(Dispatchers.IO) {
             commandPort.executeShellCommand("docker rmi ${application.containerName}")
-                .also {exitValue ->
-                    if (exitValue != 0 && exitValue != 1)
-                        checkExitValuePort.checkApplicationExitValue(exitValue, application, this, FailureCase.DELETE_IMAGE_FAILURE)
+                .also {commandResult ->
+                    if (commandResult.exitValue != 0 && commandResult.exitValue != 1)
+                        checkExitValuePort.checkApplicationExitValue(commandResult, application, this, FailureCase.DELETE_IMAGE_FAILURE)
                 }
         }
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExecContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExecContainerServiceImpl.kt
@@ -18,10 +18,7 @@ class ExecContainerServiceImpl(
     private val commandPort: CommandPort
 ) : ExecContainerService {
     override fun execCmd(application: Application, cmd: String): List<String> =
-        commandPort
-            .executeShellCommandWithResult(
-                "docker exec ${application.containerName} sh -c 'cd / && $cmd'"
-            )
+        commandPort.executeShellCommand("docker exec ${application.containerName} sh -c 'cd / && $cmd'").result
 
     override fun execCmd(application: Application, session: WebSocketSession, cmd: String) {
         val cmdArray = cmd.split(" ").toTypedArray()

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExistsPortServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExistsPortServiceImpl.kt
@@ -11,7 +11,7 @@ class ExistsPortServiceImpl (
     private val commandPort: CommandPort
 ) : ExistsPortService {
     override fun existsPort(port: Int): Boolean {
-        val commandResult = commandPort.executeShellCommandWithResult("lsof -i :${port}")
+        val commandResult = commandPort.executeShellCommand("lsof -i :${port}").result
         return commandResult.isNotEmpty() || queryApplicationPort.existsByExternalPort(port)
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetApplicationVersionServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetApplicationVersionServiceImpl.kt
@@ -20,6 +20,6 @@ class GetApplicationVersionServiceImpl(
             ApplicationType.H2_DB -> "oscarfonts/h2" to "0"
         }
         val getVersionScript = FileContent.getImageVersionShellScriptContent(baseImageName, minVersion)
-        return commandPort.executeShellCommandWithResult(getVersionScript)
+        return commandPort.executeShellCommand(getVersionScript).result
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetContainerLogServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetContainerLogServiceImpl.kt
@@ -10,5 +10,5 @@ class GetContainerLogServiceImpl(
     private val commandPort: CommandPort
 ) : GetContainerLogService {
     override fun getLogs(application: Application): List<String> =
-        commandPort.executeShellCommandWithResult("docker logs ${application.containerName}")
+        commandPort.executeShellCommand("docker logs ${application.containerName}").result
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetContainerServiceImpl.kt
@@ -10,6 +10,7 @@ class GetContainerServiceImpl(
     private val commandPort: CommandPort
 ) : GetContainerService {
     override fun getContainerNameByStatus(status: ContainerStatus): List<String> =
-        commandPort.executeShellCommandWithResult("docker ps -a --filter \"status=${status.value}\" --format \"{{.ID}}\" | xargs -I {} docker inspect --format \"{{.Name}} {{.State.ExitCode}}\" {}")
+        commandPort.executeShellCommand("docker ps -a --filter \"status=${status.value}\" --format \"{{.ID}}\" | xargs -I {} docker inspect --format \"{{.Name}} {{.State.ExitCode}}\" {}")
+            .result
             .map { it.replace("/", "") }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/RunContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/RunContainerServiceImpl.kt
@@ -34,7 +34,8 @@ class RunContainerServiceImpl(
 
     private suspend fun run(application: Application) {
         withContext(Dispatchers.IO) {
-            val exitValue = commandPort.executeShellCommand("docker start ${application.containerName}")
+            val commandResult = commandPort.executeShellCommand("docker start ${application.containerName}")
+            val exitValue = commandResult.exitValue
             if (exitValue != 0) {
                 log.error("$exitValue")
                 eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application, FailureCase.RUN_CONTAINER_FAILURE))

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/StopContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/StopContainerServiceImpl.kt
@@ -21,7 +21,8 @@ class StopContainerServiceImpl(
 
     override suspend fun stopContainer(application: Application) {
         withContext(Dispatchers.IO) {
-            val exitValue = commandPort.executeShellCommand("docker stop ${application.containerName}")
+            val commandResult = commandPort.executeShellCommand("docker stop ${application.containerName}")
+            val exitValue = commandResult.exitValue
             if (exitValue != 0) {
                 log.error("$exitValue")
                 eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application, FailureCase.STOP_CONTAINER_FAILURE))

--- a/src/main/kotlin/com/dcd/server/core/domain/application/spi/CheckExitValuePort.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/spi/CheckExitValuePort.kt
@@ -1,11 +1,12 @@
 package com.dcd.server.core.domain.application.spi
 
+import com.dcd.server.core.common.command.dto.CommandResult
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.util.FailureCase
 import kotlinx.coroutines.CoroutineScope
 
 interface CheckExitValuePort {
-    fun checkApplicationExitValue(exitValue: Int, application: Application, failureCase: FailureCase?)
+    fun checkApplicationExitValue(commandResult: CommandResult, application: Application, failureCase: FailureCase?)
 
-    fun checkApplicationExitValue(exitValue: Int, application: Application, coroutineScope: CoroutineScope, failureCase: FailureCase?)
+    fun checkApplicationExitValue(commandResult: CommandResult, application: Application, coroutineScope: CoroutineScope, failureCase: FailureCase?)
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/spi/adapter/CheckExitValueAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/spi/adapter/CheckExitValueAdapter.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.core.domain.application.spi.adapter
 
+import com.dcd.server.core.common.command.dto.CommandResult
 import com.dcd.server.core.domain.application.event.ChangeApplicationStatusEvent
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
@@ -17,14 +18,16 @@ class CheckExitValueAdapter(
 ) : CheckExitValuePort {
     private val log = LoggerFactory.getLogger(this::class.simpleName)
 
-    override fun checkApplicationExitValue(exitValue: Int, application: Application, failureCase: FailureCase?) {
+    override fun checkApplicationExitValue(commandResult: CommandResult, application: Application, failureCase: FailureCase?) {
+        val exitValue = commandResult.exitValue
         if (exitValue != 0) {
             log.error("${application.name} - $exitValue")
             eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application, failureCase))
         }
     }
 
-    override fun checkApplicationExitValue(exitValue: Int, application: Application, coroutineScope: CoroutineScope, failureCase: FailureCase?) {
+    override fun checkApplicationExitValue(commandResult: CommandResult, application: Application, coroutineScope: CoroutineScope, failureCase: FailureCase?) {
+        val exitValue = commandResult.exitValue
         if (exitValue != 0) {
             log.error("${application.name} - $exitValue")
             eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application, failureCase))

--- a/src/main/kotlin/com/dcd/server/core/domain/application/spi/adapter/CheckExitValueAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/spi/adapter/CheckExitValueAdapter.kt
@@ -22,7 +22,8 @@ class CheckExitValueAdapter(
         val exitValue = commandResult.exitValue
         if (exitValue != 0) {
             log.error("${application.name} - $exitValue")
-            eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application, failureCase))
+            val failureReasonDetail = commandResult.result.joinToString("\n")
+            eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application, failureCase, failureReasonDetail))
         }
     }
 
@@ -30,7 +31,8 @@ class CheckExitValueAdapter(
         val exitValue = commandResult.exitValue
         if (exitValue != 0) {
             log.error("${application.name} - $exitValue")
-            eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application, failureCase))
+            val failureReasonDetail = commandResult.result.joinToString("\n")
+            eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application, failureCase, failureReasonDetail))
             coroutineScope.cancel()
         }
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/domain/service/impl/GenerateHttpConfigServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/domain/service/impl/GenerateHttpConfigServiceImpl.kt
@@ -19,12 +19,12 @@ class GenerateHttpConfigServiceImpl(
     override fun generateWebServerConfig(application: Application, domain: Domain) {
         val webServerConfig = FileContent.getApplicationHttpConfig(application, domain.getDomainName())
         val httpConfigDirectory = "${domainConfigPath}/nginx/conf/${domain.id}"
-        val exitValue = commandPort.executeShellCommand(
+        val commandResult = commandPort.executeShellCommand(
             "mkdir -p $httpConfigDirectory && " +
             "cat <<'EOF' > ${httpConfigDirectory}/${application.name.replace(" ", "-")}-http.conf \n${webServerConfig}\nEOF"
         )
 
-        if (exitValue != 0)
+        if (commandResult.exitValue != 0)
             throw HttpConfigFailureException()
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/domain/service/impl/RebootNginxContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/domain/service/impl/RebootNginxContainerServiceImpl.kt
@@ -12,8 +12,8 @@ class RebootNginxContainerServiceImpl(
     private val log = LoggerFactory.getLogger(this::class.simpleName)
 
     override fun rebootNginx() {
-        val exitValue = commandPort.executeShellCommand("docker restart dcd-nginx")
-        if (exitValue != 0)
+        val commandResult = commandPort.executeShellCommand("docker restart dcd-nginx")
+        if (commandResult.exitValue != 0)
             log.error("nginx restart failure")
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/domain/service/impl/RemoveHttpConfigServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/domain/service/impl/RemoveHttpConfigServiceImpl.kt
@@ -19,9 +19,9 @@ class RemoveHttpConfigServiceImpl(
             throw DomainNotConnectedException()
 
         val httpConfigDirectory = "${domainConfigPath}/nginx/conf/${domain.id}"
-        val exitValue = commandPort.executeShellCommand("rm -r $httpConfigDirectory")
+        val commandResult = commandPort.executeShellCommand("rm -r $httpConfigDirectory")
 
-        if (exitValue != 0)
+        if (commandResult.exitValue != 0)
             throw HttpConfigRemoveFailureException()
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/service/impl/CopyDockerVolumeServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/service/impl/CopyDockerVolumeServiceImpl.kt
@@ -21,8 +21,8 @@ class CopyDockerVolumeServiceImpl(
                     alpine ash -c \"cp -a /from/. /to/\"
             """.trimIndent()
 
-        val exitValue = commandPort.executeShellCommand(volumeCopyCmd)
-        if (exitValue != 0) {
+        val commandResult = commandPort.executeShellCommand(volumeCopyCmd)
+        if (commandResult.exitValue != 0) {
             deleteVolumeService.deleteVolume(newVolume)
             throw VolumeCopyFailureException()
         }

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/service/impl/CreateDockerVolumeServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/service/impl/CreateDockerVolumeServiceImpl.kt
@@ -11,9 +11,9 @@ class CreateDockerVolumeServiceImpl(
     private val commandPort: CommandPort
 ) : CreateVolumeService {
     override fun create(volume: Volume) {
-        val exitValue = commandPort.executeShellCommand("docker volume create ${volume.volumeName}")
+        val commandResult = commandPort.executeShellCommand("docker volume create ${volume.volumeName}")
 
-        if (exitValue != 0)
+        if (commandResult.exitValue != 0)
             throw VolumeCreationFailureException()
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/service/impl/DeleteDockerVolumeServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/service/impl/DeleteDockerVolumeServiceImpl.kt
@@ -11,9 +11,9 @@ class DeleteDockerVolumeServiceImpl(
     private val commandPort: CommandPort
 ) : DeleteVolumeService {
     override fun deleteVolume(volume: Volume) {
-        val exitValue = commandPort.executeShellCommand("docker volume rm ${volume.volumeName}")
+        val commandResult = commandPort.executeShellCommand("docker volume rm ${volume.volumeName}")
 
-        if (exitValue != 0)
+        if (commandResult.exitValue != 0)
             throw VolumeDeleteFailureException()
     }
 }

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/command/adapter/CommandAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/command/adapter/CommandAdapter.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.infrastructure.global.command.adapter
 
 import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.common.command.dto.CommandResult
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import java.io.BufferedReader
@@ -11,46 +12,30 @@ import java.io.InputStreamReader
 class CommandAdapter : CommandPort {
     private val log = LoggerFactory.getLogger(this::class.simpleName)
 
-    override fun executeShellCommand(cmd: String): Int {
+    override fun executeShellCommand(cmd: String): CommandResult {
         val shellScriptCmd = arrayOf("/bin/sh", "-c", cmd)
         val p = Runtime.getRuntime().exec(shellScriptCmd)
-
-        BufferedReader(InputStreamReader(p.inputStream)).use { br ->
-            br.readLines().forEach {
-                log.debug(it)
-            }
-            br.close()
-        }
-
-        p.waitFor()
-        val exitValue = p.exitValue()
-        p.destroy()
-
-        return exitValue
-    }
-
-    override fun executeShellCommandWithResult(cmd: String): List<String> {
-        val shellScriptCmd = arrayOf("/bin/sh", "-c", cmd)
-        val p = Runtime.getRuntime().exec(shellScriptCmd)
-        val br = BufferedReader(InputStreamReader(p.inputStream))
+        val stdout = BufferedReader(InputStreamReader(p.inputStream))
+        val stderr = BufferedReader(InputStreamReader(p.errorStream))
 
         try {
-            val result = br.readLines()
+            val result = stdout.readLines() + stderr.readLines()
             p.waitFor()
+            val exitValue = p.exitValue()
             result.forEach {
                 log.debug(it)
             }
-            return result
+            return CommandResult(exitValue, result)
         } catch (ex: IOException) {
             log.error("명령어 실행 중 IO 오류 발생: ${ex.message}")
-            return emptyList()
+            return CommandResult(1, listOf("명령어 실행 중 IO 오류 발생: ${ex.message}"))
         } catch (ex: InterruptedException) {
             log.error("명령어 실행이 중단됨: ${ex.message}")
-            return emptyList()
+            return CommandResult(1, listOf("명령어 실행이 중단됨: ${ex.message}"))
         } finally {
-            br.close()
+            stderr.close()
+            stdout.close()
             p.destroy()
         }
     }
-
 }

--- a/src/main/kotlin/com/dcd/server/persistence/application/adapter/ApplicationAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/application/adapter/ApplicationAdapter.kt
@@ -2,6 +2,7 @@ package com.dcd.server.persistence.application.adapter
 
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.model.ApplicationInitialScript
+import com.dcd.server.core.domain.application.model.DeploymentResult
 import com.dcd.server.persistence.application.entity.ApplicationInitialScriptJpaEntity
 import com.dcd.server.persistence.application.entity.ApplicationJpaEntity
 import com.dcd.server.persistence.workspace.adapter.toDomain
@@ -20,7 +21,8 @@ fun Application.toEntity(): ApplicationJpaEntity =
         externalPort = this.externalPort,
         version = this.version,
         status = this.status,
-        failureReason = this.failureReason,
+        failureCase = this.deploymentResult.failureCase,
+        failureReasonDetail = this.deploymentResult.failureReasonDetail,
         labels = this.labels
     )
 
@@ -36,7 +38,7 @@ fun ApplicationJpaEntity.toDomain(): Application =
         externalPort = this.externalPort,
         version = this.version,
         status = this.status,
-        failureReason = this.failureReason,
+        deploymentResult = DeploymentResult.from(this.failureCase, this.failureReasonDetail),
         labels = this.labels
     )
 

--- a/src/main/kotlin/com/dcd/server/persistence/application/entity/ApplicationJpaEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/application/entity/ApplicationJpaEntity.kt
@@ -2,7 +2,7 @@ package com.dcd.server.persistence.application.entity
 
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
-import com.dcd.server.persistence.env.entity.ApplicationEnvEntity
+import com.dcd.server.core.domain.application.util.FailureCase
 import com.dcd.server.persistence.workspace.entity.WorkspaceJpaEntity
 import jakarta.persistence.*
 import java.util.UUID
@@ -27,7 +27,9 @@ class ApplicationJpaEntity(
     val version: String,
     @Enumerated(EnumType.STRING)
     val status: ApplicationStatus,
-    val failureReason: String?,
+    @Enumerated(EnumType.STRING)
+    val failureCase: FailureCase?,
+    val failureReasonDetail: String?,
     @ElementCollection
     @CollectionTable(name = "application_label_entity", joinColumns = [JoinColumn(name = "application_id")])
     @Column(name = "label")

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/CreateContainerServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/CreateContainerServiceImplTest.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.core.domain.application.service
 
 import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.common.command.dto.CommandResult
 import com.dcd.server.core.domain.application.service.impl.CreateContainerServiceImpl
 import com.dcd.server.core.domain.application.spi.CheckExitValuePort
 import com.dcd.server.core.domain.application.util.FailureCase
@@ -13,28 +14,25 @@ import kotlinx.coroutines.CoroutineScope
 import util.application.ApplicationGenerator
 
 class CreateContainerServiceImplTest : BehaviorSpec({
-    val commandPort = mockk<CommandPort>(relaxed = true)
+    val commandPort = mockk<CommandPort>()
     val queryVolumePort = mockk<QueryVolumePort>(relaxed = true)
     val checkExitValuePort = mockk<CheckExitValuePort>(relaxUnitFun = true)
     val createContainerService = CreateContainerServiceImpl(commandPort, queryVolumePort, checkExitValuePort)
 
     given("애플리케이션이 주어지고") {
         val application = ApplicationGenerator.generateApplication()
+        val commandResult = CommandResult(0, emptyList())
 
-        `when`("service를 실행할때") {
+        every { queryVolumePort.findAllMountByApplication(application) } returns emptyList()
+        every { commandPort.executeShellCommand(any()) } returns commandResult
+
+        `when`("service를 실행하면") {
             createContainerService.createContainer(application, application.externalPort)
-            every { queryVolumePort.findAllMountByApplication(application) } returns listOf()
 
-            then("컨테이너를 실행하는 명령을 실행해야함") {
-                verify {
-                    commandPort.executeShellCommand(
-                        "docker create --network ${application.workspace.title.replace(' ', '_')} " +
-                        "--name ${application.containerName} " +
-                        "-p ${application.externalPort}:${application.port} ${application.containerName}:latest"
-                    )
+            then("docker create 명령이 실행된다") {
+                verify(exactly = 1) {
+                    commandPort.executeShellCommand(match { it.startsWith("docker create").and(it.contains(application.containerName)) })
                 }
-                verify { checkExitValuePort.checkApplicationExitValue(0, application, any() as CoroutineScope, FailureCase.CREATE_CONTAINER_FAILURE) }
-                verify { checkExitValuePort.checkApplicationExitValue(0, application, any() as CoroutineScope, FailureCase.CONNECT_NETWORK_FAILURE) }
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/CreateDockerFileServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/CreateDockerFileServiceImplTest.kt
@@ -42,7 +42,7 @@ class CreateDockerFileServiceImplTest : BehaviorSpec({
                 verify { commandPort.executeShellCommand("mkdir -p '${application.name}'") }
             }
             then("실제로 애플리케이션 이름의 디렉토리가 생성되야함") {
-                commandPort.executeShellCommand("test -e '${application.name}'") shouldBe 0
+                commandPort.executeShellCommand("test -e '${application.name}'").exitValue shouldBe 0
             }
             then("생성된 DockerFile의 내용은 FileContent의 내용과 같아야함") {
                 val actualFileContent = StringBuilder()
@@ -71,7 +71,7 @@ class CreateDockerFileServiceImplTest : BehaviorSpec({
                 verify { commandPort.executeShellCommand("mkdir -p '${application.name}'") }
             }
             then("실제로 애플리케이션 이름의 디렉토리가 생성되야함") {
-                commandPort.executeShellCommand("test -e '${application.name}'") shouldBe 0
+                commandPort.executeShellCommand("test -e '${application.name}'").exitValue shouldBe 0
             }
             then("생성된 DockerFile의 내용은 FileContent의 내용과 같아야함") {
                 val actualFileContent = StringBuilder()
@@ -99,7 +99,7 @@ class CreateDockerFileServiceImplTest : BehaviorSpec({
                 verify { commandPort.executeShellCommand("mkdir -p '${application.name}'") }
             }
             then("실제로 애플리케이션 이름의 디렉토리가 생성되야함") {
-                commandPort.executeShellCommand("test -e '${application.name}'") shouldBe 0
+                commandPort.executeShellCommand("test -e '${application.name}'").exitValue shouldBe 0
             }
             then("생성된 DockerFile의 내용은 FileContent의 내용과 같아야함") {
                 val actualFileContent = StringBuilder()
@@ -127,7 +127,7 @@ class CreateDockerFileServiceImplTest : BehaviorSpec({
                 verify { commandPort.executeShellCommand("mkdir -p '${application.name}'") }
             }
             then("실제로 애플리케이션 이름의 디렉토리가 생성되야함") {
-                commandPort.executeShellCommand("test -e '${application.name}'") shouldBe 0
+                commandPort.executeShellCommand("test -e '${application.name}'").exitValue shouldBe 0
             }
             then("생성된 DockerFile의 내용은 FileContent의 내용과 같아야함") {
                 val actualFileContent = StringBuilder()

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/ExistsPortServiceTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/ExistsPortServiceTest.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.core.domain.application.service
 
 import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.common.command.dto.CommandResult
 import com.dcd.server.core.domain.application.service.impl.ExistsPortServiceImpl
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import io.kotest.core.spec.style.BehaviorSpec
@@ -14,8 +15,9 @@ class ExistsPortServiceTest : BehaviorSpec({
         val queryApplicationPort = mockk<QueryApplicationPort>()
         val testPort = 9999
         val commandPort = mockk<CommandPort>()
+        val commandResult = CommandResult(0, emptyList())
         every { queryApplicationPort.existsByExternalPort(testPort) } returns false
-        every { commandPort.executeShellCommandWithResult("lsof -i :${testPort}") } returns emptyList()
+        every { commandPort.executeShellCommand("lsof -i :${testPort}") } returns commandResult
 
         val service = ExistsPortServiceImpl(queryApplicationPort, commandPort)
 
@@ -23,7 +25,7 @@ class ExistsPortServiceTest : BehaviorSpec({
             val result = service.existsPort(9999)
             then("결과값은 false여야함") {
                 result shouldBe false
-                verify { commandPort.executeShellCommandWithResult("lsof -i :${testPort}") }
+                verify(exactly = 1) { commandPort.executeShellCommand("lsof -i :${testPort}") }
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/GetApplicationVersionServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/GetApplicationVersionServiceImplTest.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.core.domain.application.service
 
 import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.common.command.dto.CommandResult
 import com.dcd.server.core.common.file.FileContent
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.impl.GetApplicationVersionServiceImpl
@@ -25,7 +26,8 @@ class GetApplicationVersionServiceImplTest : BehaviorSpec({
                 "8.1.0",
                 "8.0.1"
             )
-            every { commandPort.executeShellCommandWithResult(imageVersionShellScriptContent) } returns tagList
+            val commandResult = CommandResult(0, tagList)
+            every { commandPort.executeShellCommand(imageVersionShellScriptContent) } returns commandResult
 
             val getApplicationVersionService = GetApplicationVersionServiceImpl(commandPort)
             val result = getApplicationVersionService.getAvailableVersion(applicationType)

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/StopContainerServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/StopContainerServiceImplTest.kt
@@ -1,9 +1,11 @@
 package com.dcd.server.core.domain.application.service
 
 import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.common.command.dto.CommandResult
 import com.dcd.server.core.domain.application.event.ChangeApplicationStatusEvent
 import com.dcd.server.core.domain.application.service.impl.StopContainerServiceImpl
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.string.startWith
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -22,12 +24,12 @@ class StopContainerServiceImplTest : BehaviorSpec({
             stopContainerService.stopContainer(application)
 
             then("컨테이너 정지 명령이 실행되야함") {
-                verify { commandPort.executeShellCommand("docker stop ${application.containerName}") }
+                verify { commandPort.executeShellCommand(match { it.startsWith("docker stop") }) }
             }
         }
 
         `when`("컨테이너 정지 명령이 실패했을때") {
-            every { commandPort.executeShellCommand("docker stop ${application.containerName}") } returns 125
+            every { commandPort.executeShellCommand("docker stop ${application.containerName}") } returns CommandResult(125, emptyList())
             stopContainerService.stopContainer(application)
 
             then("ContainerNotStoppedException이 발생해야함") {

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetApplicationLogUseCaseTest.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.common.command.dto.CommandResult
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.user.spi.CommandUserPort
@@ -36,7 +37,8 @@ class GetApplicationLogUseCaseTest(
         val workspace = WorkspaceGenerator.generateWorkspace(user = user)
         val application = ApplicationGenerator.generateApplication(id = targetApplicationId, workspace = workspace)
         val expectedResult = listOf("test logs")
-        every { commandPort.executeShellCommandWithResult("docker logs ${application.containerName}") } returns expectedResult
+        val commandResult = CommandResult(0, expectedResult)
+        every { commandPort.executeShellCommand("docker logs ${application.containerName}") } returns commandResult
 
         commandUserPort.save(user)
         commandWorkspacePort.save(workspace)

--- a/src/test/kotlin/util/application/ApplicationGenerator.kt
+++ b/src/test/kotlin/util/application/ApplicationGenerator.kt
@@ -1,9 +1,10 @@
 package util.application
 
 import com.dcd.server.core.domain.application.model.Application
+import com.dcd.server.core.domain.application.model.DeploymentResult
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
-import com.dcd.server.core.domain.env.model.ApplicationEnv
+import com.dcd.server.core.domain.application.util.FailureCase
 import com.dcd.server.core.domain.workspace.model.Workspace
 import util.workspace.WorkspaceGenerator
 import java.util.*
@@ -19,7 +20,8 @@ object ApplicationGenerator {
         workspace: Workspace = WorkspaceGenerator.generateWorkspace(),
         port: Int = 8080,
         status: ApplicationStatus = ApplicationStatus.STOPPED,
-        failureReason: String? = null,
+        failureCase: FailureCase? = null,
+        failureReasonDetail: String? = null,
         labels: List<String> = listOf()
     ): Application =
         Application(
@@ -33,7 +35,7 @@ object ApplicationGenerator {
             port = port,
             externalPort = port,
             status = status,
-            failureReason = failureReason,
+            deploymentResult = DeploymentResult.from(failureCase, failureReasonDetail),
             labels = labels
         )
 }

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -14,7 +14,7 @@ drop table if exists application_env_matcher_entity cascade;
 drop table if exists application_env_label_entity cascade;
 drop table if exists volume_entity cascade;
 drop table if exists volume_mount_entity cascade;
-create table application_entity (external_port integer not null, port integer not null, application_type varchar(255) check (application_type in ('SPRING_BOOT','NEST_JS','MYSQL','MARIA_DB','REDIS')), description varchar(255), failure_reason varchar(255), github_url varchar(255), id binary(16) not null, name varchar(255), status varchar(255) check (status in ('CREATED','PENDING','RUNNING','STOPPED','FAILURE')), version varchar(255), workspace_id binary(16), primary key (id));
+create table application_entity (external_port integer not null, port integer not null, application_type varchar(255) check (application_type in ('SPRING_BOOT','NEST_JS','MYSQL','MARIA_DB','REDIS')), description varchar(255), failure_case enum('CLONE_FAILURE', 'CREATE_DOCKER_FILE_FAILURE', 'IMAGE_BUILD_FAILURE', 'CREATE_CONTAINER_FAILURE', 'RUN_CONTAINER_FAILURE', 'STOP_CONTAINER_FAILURE', 'CONNECT_NETWORK_FAILURE', 'CREATE_DIRECTORY_FAILURE', 'DELETE_DIRECTORY_FAILURE', 'DELETE_CONTAINER_FAILURE', 'DELETE_IMAGE_FAILURE'), failure_reason_detail varchar(1200), github_url varchar(255), id binary(16) not null, name varchar(255), status enum('CREATED','PENDING','RUNNING','STOPPED','FAILURE'), version varchar(255), workspace_id binary(16), primary key (id));
 create table application_label_entity (application_id binary(16) not null, label varchar(255));
 create table application_initial_script_entity (id binary(16), script varchar(255), application_id binary(16) not null, primary key (id));
 create table role_entity (roles varchar(255) check (roles in ('ROLE_ADMIN','ROLE_DEVELOPER','ROLE_USER')), user_id binary(16) not null);
@@ -53,4 +53,4 @@ insert into role_entity (user_id,roles) values (X'1e1973eb3fb947ac9342c16cd63ffc
 insert into workspace_entity (description,owner_id,title,id) values ('testDescription', X'923a6407a5f84e1ebffd0621910ddfc8', 'testTitle', X'd57b42f55cc4440b8dceb4fc2e372eff');
 
 -- 애플리케이션 생성
-insert into application_entity (application_type,description,external_port,failure_reason,github_url,name,port,status,version,workspace_id,id) values ('SPRING_BOOT','testDescription', 8080, NULL, 'testUrl', 'testName', 8080, 'STOPPED','17', X'd57b42f55cc4440b8dceb4fc2e372eff', X'2fb0f3158272422f8e9fc4f765c022b2');
+insert into application_entity (application_type,description,external_port,failure_case,failure_reason_detail,github_url,name,port,status,version,workspace_id,id) values ('SPRING_BOOT','testDescription', 8080, NULL, NULL,  'testUrl', 'testName', 8080, 'STOPPED','17', X'd57b42f55cc4440b8dceb4fc2e372eff', X'2fb0f3158272422f8e9fc4f765c022b2');


### PR DESCRIPTION
## 개요
* 애플리케이션의 실패사유가 실행할 수 없는 이유를 더욱 상세하게 담을 수 있도록 리펙토링합니다.
## 작업내용
* DeploymentResult 클래스 추가및 애플리케이션 도메인에 적용
* 애플리케이션 도메인과 엔티티 어뎁팅 로직 수정
* 애플리케이션 상태 변경 이벤트가 실패 상세 메시지를 받아서 처리할 수 있도록 수정
* CommandPort에서 exitValue와 result를 담아서 반환하도록 수정
* 명령어 수행 실패시 해당 사유를 담아서 애플리케이션 상태를 변경하는 이벤트를 호출하도록 수정
* 명령어 실행시 errorStream도 읽도록 리펙토링
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?
## 기타
* 애플리케이션 엔티티 변경사항
  * `failure_reason varchar(255)` -> `failure_case enum('CLONE_FAILURE', 'CREATE_DOCKER_FILE_FAILURE', 'IMAGE_BUILD_FAILURE', 'CREATE_CONTAINER_FAILURE', 'RUN_CONTAINER_FAILURE', 'STOP_CONTAINER_FAILURE', 'CONNECT_NETWORK_FAILURE', 'CREATE_DIRECTORY_FAILURE', 'DELETE_DIRECTORY_FAILURE', 'DELETE_CONTAINER_FAILURE', 'DELETE_IMAGE_FAILURE')`
  * `failure_reason_detail varchar(1200)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **버그 수정**
  * 배포 실패 시 더 자세한 오류 정보 및 실패 사유 추적 개선
  * 셸 명령 실행 결과에 대한 정확한 처리 강화

* **기능 개선**
  * 애플리케이션 배포 및 실행 상태에 대한 진단 정보 상세화
  * 컨테이너 및 도메인 관련 작업 실패 시 명확한 오류 메시지 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->