### PR TITLE
🔀 :: [#745] - 이미지 버전 조회 리펙토링

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: create test yml file
       run: |
-        cat << EOF > ./src/main/resources/application-test.yml
+        cat << 'EOF' > ./src/main/resources/application-test.yml
         ${{secrets.TEST_YML}}
         EOF
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           ${{ runner.os }}-gradle-
         enableCrossOsArchive: true
 
-    - name: create test env file
+    - name: create test yml file
       run: |
         cat << EOF > ./src/main/resources/application-test.yml
         ${{secrets.TEST_YML}}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
 	testImplementation("io.kotest:kotest-assertions-core:5.5.5")
 	testImplementation("io.kotest:kotest-runner-junit5:5.5.5")
 	testImplementation("io.kotest:kotest-framework-engine-jvm:5.5.5")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
 
 	//jwt
 	implementation("io.jsonwebtoken:jjwt-api:0.11.5")
@@ -62,7 +63,7 @@ dependencies {
 	//docker
 	implementation("com.github.docker-java:docker-java:3.4.0")
 	implementation("com.github.docker-java:docker-java-transport-okhttp:3.4.0")
-	implementation("com.squareup.okhttp3:okhttp:3.14.9")
+	implementation("com.squareup.okhttp3:okhttp:4.12.0")
 
 	//bucket4j
 	implementation("com.bucket4j:bucket4j_jdk17-core:8.14.0")

--- a/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
@@ -66,4 +66,5 @@ enum class ErrorCode(
     FAILURE_VOLUME_CREATION("컨테이너 볼륨 생성에 실패했습니다.", 500),
     FAILURE_VOLUME_DELETE("컨테이너 볼륨 삭제에 실패했습니다.", 500),
     FAILURE_VOLUME_COPY("컨테이너 볼륨 복제에 실패했습니다.", 500),
+    IMAGE_REGISTRY_RATE_LIMIT_EXCEEDED("도커 허브의 요청 제한을 초과했습니다.", 500),
 }

--- a/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
@@ -83,63 +83,6 @@ object FileContent {
         ${getInitialScriptsString(initialScripts)}
         """.trimIndent()
 
-    fun getImageVersionShellScriptContent(imageName: String, minVersion: String): String {
-        val imagePrefix = if (imageName.contains("/")) "" else "library/"
-
-        return """
-        #!/bin/bash
-    
-        # 이미지, 페이지 사이즈, 최소 버전(threshold) 설정
-        IMAGE_NAME="${imagePrefix}$imageName"
-        PAGE_SIZE=100
-        MIN_VERSION="$minVersion"
-    
-        # 첫 페이지 URL 구성
-        URL="https://hub.docker.com/v2/repositories/${'$'}IMAGE_NAME/tags/?page_size=${'$'}PAGE_SIZE"
-    
-        # 결과를 저장할 변수 및 배열 초기화
-        LATEST_FOUND=false
-        NUMERIC_TAGS=()
-    
-        # pagination 처리: next URL이 없을 때까지 반복
-        while [ -n "${'$'}URL" ] && [ "${'$'}URL" != "null" ]; do
-            RESPONSE=\$(curl -s "${'$'}URL")
-            
-            # 현재 페이지의 태그 목록 추출
-            TAGS=\$(echo "${'$'}RESPONSE" | jq -r '.results[].name')
-            
-            for tag in ${'$'}TAGS; do
-                # latest는 따로 체크
-                if [[ "${'$'}tag" == "latest" ]]; then
-                    LATEST_FOUND=true
-                # 숫자와 점(.)만 포함된 태그 필터링
-                elif [[ "${'$'}tag" =~ ^[0-9]+(\.[0-9]+)*\$ ]]; then
-                    # 버전 비교: tag가 MIN_VERSION 이상이면 저장
-                    # sort -V를 사용하여 두 버전을 정렬한 후 첫 번째가 MIN_VERSION이면 tag가 MIN_VERSION 이상입니다.
-                    lowest=\$(printf "%s\n%s" "${'$'}MIN_VERSION" "${'$'}tag" | sort -V | head -n1)
-                    if [ "${'$'}lowest" = "${'$'}MIN_VERSION" ]; then
-                        NUMERIC_TAGS+=("${'$'}tag")
-                    fi
-                fi
-            done
-            
-            # 다음 페이지 URL 추출 (없으면 "null" 또는 빈 문자열)
-            URL=\$(echo "${'$'}RESPONSE" | jq -r '.next')
-        done
-    
-        # 최신 태그(latest)가 있으면 제일 먼저 출력
-        if ${'$'}LATEST_FOUND; then
-            echo "latest"
-        fi
-    
-        # 숫자 태그를 내림차순(-r 옵션) 버전 정렬(-V 옵션) 후 출력
-        if [ ${'$'}{#NUMERIC_TAGS[@]} -gt 0 ]; then
-            sorted_numeric_tags=\$(printf "%s\n" "${'$'}{NUMERIC_TAGS[@]}" | sort -r -V)
-            echo "${'$'}sorted_numeric_tags"
-        fi
-        """.trimIndent()
-    }
-
     fun getApplicationHttpConfig(application: Application, domain: String): String =
         """
         server {

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetApplicationVersionServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetApplicationVersionServiceImpl.kt
@@ -2,39 +2,13 @@ package com.dcd.server.core.domain.application.service.impl
 
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.GetApplicationVersionService
-import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.databind.ObjectMapper
-import org.springframework.beans.factory.annotation.Value
+import com.dcd.server.core.domain.application.spi.ImageVersionPort
 import org.springframework.stereotype.Service
-import java.net.URI
-import java.net.http.HttpClient
-import java.net.http.HttpRequest
-import java.net.http.HttpResponse
-import java.time.Duration
 
 @Service
 class GetApplicationVersionServiceImpl(
-    private val objectMapper: ObjectMapper,
-    @Value("\${docker.token}")
-    private val token: String,
+    private val imageVersionPort: ImageVersionPort
 ) : GetApplicationVersionService {
-    private val client = HttpClient.newBuilder()
-        .connectTimeout(Duration.ofSeconds(3))
-        .build()
-
-    private class TagResponse(
-        val next: String?,
-        @field:JsonProperty("results")
-        private val rawResults: List<RawTagResponse>,
-    ) {
-        val tags: List<String> = rawResults.map { it.name }
-        companion object {
-            private class RawTagResponse(
-                val name: String,
-            )
-        }
-    }
-
     private data class SemVer(
         val major: Int,
         val minor: Int = 0,
@@ -72,47 +46,12 @@ class GetApplicationVersionServiceImpl(
 
         minVersion ?: throw IllegalArgumentException("Invalid Version")
 
-        val result = fetchAllTagsByDocker(baseImageName).mapNotNull { SemVer.parse(it) }
+        val result = imageVersionPort.fetchAllVersions(baseImageName)
+            .mapNotNull { SemVer.parse(it) }
             .filter { it > minVersion }
             .distinct()
             .sortedDescending()
             .map { "${it.major}.${it.minor}.${it.patch}".trimEnd('.', '0') }
-
-        return result
-    }
-
-    private fun fetchAllTagsByDocker(imageName: String): List<String> {
-        val imagePrefix = if (imageName.contains("/")) "" else "library/"
-
-        var next: String? = "https://registry.hub.docker.com/v2/repositories/$imagePrefix$imageName/tags?page_size=100"
-
-        val result = mutableListOf<String>()
-
-        while (next != null) {
-
-            val request = HttpRequest.newBuilder()
-                .uri(URI.create(next))
-                .timeout(Duration.ofSeconds(5))
-                .header("Authorization", "$token")
-                .GET()
-                .build()
-
-            val response = client.send(request, HttpResponse.BodyHandlers.ofString())
-
-            if (response.statusCode() == 429) {
-                throw RuntimeException("Docker Hub rate limit exceeded")
-            }
-
-            if (response.statusCode() !in 200..299) {
-                throw RuntimeException("Docker Hub error: ${response.statusCode()}")
-            }
-
-            val body = response.body()
-            val tagResponse = objectMapper.readValue(body, TagResponse::class.java)
-
-            result += tagResponse.tags
-            next = tagResponse.next
-        }
 
         return result
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetApplicationVersionServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetApplicationVersionServiceImpl.kt
@@ -4,12 +4,39 @@ import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.common.file.FileContent
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.GetApplicationVersionService
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
 
 @Service
 class GetApplicationVersionServiceImpl(
     private val commandPort: CommandPort
+    @Value("\${docker.token}")
+    private val token: String,
 ) : GetApplicationVersionService {
+    private val client = HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(3))
+        .build()
+
+    private class TagResponse(
+        val next: String?,
+        @field:JsonProperty("results")
+        private val rawResults: List<RawTagResponse>,
+    ) {
+        val tags: List<String> = rawResults.map { it.name }
+        companion object {
+            private class RawTagResponse(
+                val name: String,
+            )
+        }
+    }
+
     override fun getAvailableVersion(applicationType: ApplicationType): List<String> {
         val (baseImageName, minVersion) = when (applicationType) {
             ApplicationType.SPRING_BOOT -> "openjdk" to "12"
@@ -21,5 +48,41 @@ class GetApplicationVersionServiceImpl(
         }
         val getVersionScript = FileContent.getImageVersionShellScriptContent(baseImageName, minVersion)
         return commandPort.executeShellCommand(getVersionScript).result
+    }
+
+    private fun fetchAllTagsByDocker(imageName: String): List<String> {
+        val imagePrefix = if (imageName.contains("/")) "" else "library/"
+
+        var next: String? = "https://registry.hub.docker.com/v2/repositories/$imagePrefix$imageName/tags?page_size=100"
+
+        val result = mutableListOf<String>()
+
+        while (next != null) {
+
+            val request = HttpRequest.newBuilder()
+                .uri(URI.create(next))
+                .timeout(Duration.ofSeconds(5))
+                .header("Authorization", "$token")
+                .GET()
+                .build()
+
+            val response = client.send(request, HttpResponse.BodyHandlers.ofString())
+
+            if (response.statusCode() == 429) {
+                throw RuntimeException("Docker Hub rate limit exceeded")
+            }
+
+            if (response.statusCode() !in 200..299) {
+                throw RuntimeException("Docker Hub error: ${response.statusCode()}")
+            }
+
+            val body = response.body()
+            val tagResponse = objectMapper.readValue(body, TagResponse::class.java)
+
+            result += tagResponse.tags
+            next = tagResponse.next
+        }
+
+        return result
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetApplicationVersionServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetApplicationVersionServiceImpl.kt
@@ -1,7 +1,5 @@
 package com.dcd.server.core.domain.application.service.impl
 
-import com.dcd.server.core.common.command.CommandPort
-import com.dcd.server.core.common.file.FileContent
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.GetApplicationVersionService
 import com.fasterxml.jackson.annotation.JsonProperty
@@ -16,7 +14,7 @@ import java.time.Duration
 
 @Service
 class GetApplicationVersionServiceImpl(
-    private val commandPort: CommandPort
+    private val objectMapper: ObjectMapper,
     @Value("\${docker.token}")
     private val token: String,
 ) : GetApplicationVersionService {
@@ -37,17 +35,50 @@ class GetApplicationVersionServiceImpl(
         }
     }
 
+    private data class SemVer(
+        val major: Int,
+        val minor: Int = 0,
+        val patch: Int = 0
+    ) : Comparable<SemVer> {
+
+        override fun compareTo(other: SemVer): Int =
+            compareValuesBy(this, other, SemVer::major, SemVer::minor, SemVer::patch)
+
+        companion object {
+            private val regex = Regex("""^\d+(\.\d+){0,2}$""")
+
+            fun parse(value: String): SemVer? {
+                if (!regex.matches(value)) return null
+
+                val parts = value.split(".")
+                return SemVer(
+                    parts.getOrNull(0)?.toInt() ?: 0,
+                    parts.getOrNull(1)?.toInt() ?: 0,
+                    parts.getOrNull(2)?.toInt() ?: 0
+                )
+            }
+        }
+    }
+
     override fun getAvailableVersion(applicationType: ApplicationType): List<String> {
         val (baseImageName, minVersion) = when (applicationType) {
-            ApplicationType.SPRING_BOOT -> "openjdk" to "12"
-            ApplicationType.NEST_JS -> "node" to "17"
-            ApplicationType.MARIA_DB -> "mariadb" to "10"
-            ApplicationType.MYSQL -> "mysql" to "8"
-            ApplicationType.REDIS -> "redis" to "6"
-            ApplicationType.H2_DB -> "oscarfonts/h2" to "0"
+            ApplicationType.SPRING_BOOT -> "openjdk" to SemVer.parse("12")
+            ApplicationType.NEST_JS -> "node" to SemVer.parse("17")
+            ApplicationType.MARIA_DB -> "mariadb" to SemVer.parse("10")
+            ApplicationType.MYSQL -> "mysql" to SemVer.parse("8")
+            ApplicationType.REDIS -> "redis" to SemVer.parse("6")
+            ApplicationType.H2_DB -> "oscarfonts/h2" to SemVer.parse("0")
         }
-        val getVersionScript = FileContent.getImageVersionShellScriptContent(baseImageName, minVersion)
-        return commandPort.executeShellCommand(getVersionScript).result
+
+        minVersion ?: throw IllegalArgumentException("Invalid Version")
+
+        val result = fetchAllTagsByDocker(baseImageName).mapNotNull { SemVer.parse(it) }
+            .filter { it > minVersion }
+            .distinct()
+            .sortedDescending()
+            .map { "${it.major}.${it.minor}.${it.patch}".trimEnd('.', '0') }
+
+        return result
     }
 
     private fun fetchAllTagsByDocker(imageName: String): List<String> {

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetApplicationVersionServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetApplicationVersionServiceImpl.kt
@@ -51,7 +51,7 @@ class GetApplicationVersionServiceImpl(
             .filter { it > minVersion }
             .distinct()
             .sortedDescending()
-            .map { "${it.major}.${it.minor}.${it.patch}".trimEnd('.', '0') }
+            .map { "${it.major}.${it.minor}.${it.patch}" }
 
         return result
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/spi/ImageVersionPort.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/spi/ImageVersionPort.kt
@@ -1,0 +1,5 @@
+package com.dcd.server.core.domain.application.spi
+
+interface ImageVersionPort {
+    fun fetchAllVersions(imageName: String): List<String>
+}

--- a/src/main/kotlin/com/dcd/server/infrastructure/domain/application/adapter/DockerTagAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/domain/application/adapter/DockerTagAdapter.kt
@@ -16,10 +16,10 @@ class DockerTagAdapter(
     private val objectMapper: ObjectMapper,
     @Value("\${docker.token}")
     private val token: String,
+    @Value("\${docker.url}")
+    private val registryUrl: String,
+    private val client: HttpClient
 ) : ImageVersionPort {
-    private val client = HttpClient.newBuilder()
-        .connectTimeout(Duration.ofSeconds(3))
-        .build()
 
     private class TagResponse(
         val next: String?,
@@ -37,7 +37,7 @@ class DockerTagAdapter(
     override fun fetchAllVersions(imageName: String): List<String> {
         val imagePrefix = if (imageName.contains("/")) "" else "library/"
 
-        var next: String? = "https://registry.hub.docker.com/v2/repositories/$imagePrefix$imageName/tags?page_size=100"
+        var next: String? = "${registryUrl}/v2/repositories/$imagePrefix$imageName/tags?page_size=100"
 
         val result = mutableListOf<String>()
 

--- a/src/main/kotlin/com/dcd/server/infrastructure/domain/application/adapter/DockerTagAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/domain/application/adapter/DockerTagAdapter.kt
@@ -1,0 +1,72 @@
+package com.dcd.server.infrastructure.domain.application.adapter
+
+import com.dcd.server.core.domain.application.spi.ImageVersionPort
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+
+@Component
+class DockerTagAdapter(
+    private val objectMapper: ObjectMapper,
+    @Value("\${docker.token}")
+    private val token: String,
+) : ImageVersionPort {
+    private val client = HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(3))
+        .build()
+
+    private class TagResponse(
+        val next: String?,
+        @field:JsonProperty("results")
+        private val rawResults: List<RawTagResponse>,
+    ) {
+        val tags: List<String> = rawResults.map { it.name }
+        companion object {
+            private class RawTagResponse(
+                val name: String,
+            )
+        }
+    }
+
+    override fun fetchAllVersions(imageName: String): List<String> {
+        val imagePrefix = if (imageName.contains("/")) "" else "library/"
+
+        var next: String? = "https://registry.hub.docker.com/v2/repositories/$imagePrefix$imageName/tags?page_size=100"
+
+        val result = mutableListOf<String>()
+
+        while (next != null) {
+
+            val request = HttpRequest.newBuilder()
+                .uri(URI.create(next))
+                .timeout(Duration.ofSeconds(5))
+                .header("Authorization", "$token")
+                .GET()
+                .build()
+
+            val response = client.send(request, HttpResponse.BodyHandlers.ofString())
+
+            if (response.statusCode() == 429) {
+                throw RuntimeException("Docker Hub rate limit exceeded")
+            }
+
+            if (response.statusCode() !in 200..299) {
+                throw RuntimeException("Docker Hub error: ${response.statusCode()}")
+            }
+
+            val body = response.body()
+            val tagResponse = objectMapper.readValue(body, TagResponse::class.java)
+
+            result += tagResponse.tags
+            next = tagResponse.next
+        }
+
+        return result
+    }
+}

--- a/src/main/kotlin/com/dcd/server/infrastructure/domain/application/adapter/DockerTagAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/domain/application/adapter/DockerTagAdapter.kt
@@ -1,6 +1,7 @@
 package com.dcd.server.infrastructure.domain.application.adapter
 
 import com.dcd.server.core.domain.application.spi.ImageVersionPort
+import com.dcd.server.infrastructure.domain.application.exception.DockerHubRateLimitExceededException
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Value
@@ -46,14 +47,14 @@ class DockerTagAdapter(
             val request = HttpRequest.newBuilder()
                 .uri(URI.create(next))
                 .timeout(Duration.ofSeconds(5))
-                .header("Authorization", "$token")
+                .header("Authorization", token)
                 .GET()
                 .build()
 
             val response = client.send(request, HttpResponse.BodyHandlers.ofString())
 
             if (response.statusCode() == 429) {
-                throw RuntimeException("Docker Hub rate limit exceeded")
+                throw DockerHubRateLimitExceededException()
             }
 
             if (response.statusCode() !in 200..299) {

--- a/src/main/kotlin/com/dcd/server/infrastructure/domain/application/exception/DockerHubRateLimitExceededException.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/domain/application/exception/DockerHubRateLimitExceededException.kt
@@ -1,0 +1,7 @@
+package com.dcd.server.infrastructure.domain.application.exception
+
+import com.dcd.server.core.common.error.BasicException
+import com.dcd.server.core.common.error.ErrorCode
+
+class DockerHubRateLimitExceededException : BasicException(ErrorCode.IMAGE_REGISTRY_RATE_LIMIT_EXCEEDED) {
+}

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/config/HttpClientConfiguration.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/config/HttpClientConfiguration.kt
@@ -1,0 +1,15 @@
+package com.dcd.server.infrastructure.global.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.net.http.HttpClient
+import java.time.Duration
+
+@Configuration
+class HttpClientConfiguration {
+    @Bean
+    fun httpClient(): HttpClient =
+        HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(3))
+            .build()
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,3 +50,6 @@ aes:
 
 domain:
   config-path: ${DOMAIN_CONFIG_PATH}
+
+docker:
+  token: ${DOCKER_TOKEN}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,4 +52,5 @@ domain:
   config-path: ${DOMAIN_CONFIG_PATH}
 
 docker:
+  url: ${DOCKER_REGISTRY_URL}
   token: ${DOCKER_TOKEN}

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/GetApplicationVersionServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/GetApplicationVersionServiceImplTest.kt
@@ -23,6 +23,8 @@ class GetApplicationVersionServiceImplTest : BehaviorSpec({
             "12.0.1",
             "17",
             "17.0.2",
+            "20.0.10",
+            "100.0.0",
             "invalid",
             "latest",
             "17.0.2" // duplicate
@@ -34,9 +36,11 @@ class GetApplicationVersionServiceImplTest : BehaviorSpec({
 
             then("최소 버전(12) 초과의 semver만 정렬 후 반환된다") {
                 result shouldBe listOf(
+                    "100.0.0",
+                    "20.0.10",
                     "17.0.2",
-                    "17",
-                    "12.0.1"
+                    "17.0.0",
+                    "12.0.1",
                 )
             }
 

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/GetApplicationVersionServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/GetApplicationVersionServiceImplTest.kt
@@ -1,10 +1,8 @@
 package com.dcd.server.core.domain.application.service
 
-import com.dcd.server.core.common.command.CommandPort
-import com.dcd.server.core.common.command.dto.CommandResult
-import com.dcd.server.core.common.file.FileContent
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.impl.GetApplicationVersionServiceImpl
+import com.dcd.server.core.domain.application.spi.ImageVersionPort
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -12,28 +10,57 @@ import io.mockk.mockk
 import io.mockk.verify
 
 class GetApplicationVersionServiceImplTest : BehaviorSpec({
-    given("ApplicationType이 주어지고") {
-        val applicationType = ApplicationType.MYSQL
-        val commandPort = mockk<CommandPort>()
 
-        `when`("getAvailableVersion 실행할때") {
-            val imageVersionShellScriptContent = FileContent.getImageVersionShellScriptContent("mysql", "8")
-            val tagList = listOf(
-                "latest",
-                "11.1.0",
-                "10.0.0",
-                "9.0.0",
-                "8.1.0",
-                "8.0.1"
-            )
-            val commandResult = CommandResult(0, tagList)
-            every { commandPort.executeShellCommand(imageVersionShellScriptContent) } returns commandResult
+    val imageVersionPort = mockk<ImageVersionPort>()
+    val service = GetApplicationVersionServiceImpl(imageVersionPort)
 
-            val getApplicationVersionService = GetApplicationVersionServiceImpl(commandPort)
-            val result = getApplicationVersionService.getAvailableVersion(applicationType)
-            then("latest가 있어야함") {
-                result.size shouldBe 6
-                result shouldBe tagList
+    given("Docker 태그 목록이 주어졌을 때") {
+
+        every { imageVersionPort.fetchAllVersions("openjdk") } returns listOf(
+            "8",
+            "11",
+            "12",
+            "12.0.1",
+            "17",
+            "17.0.2",
+            "invalid",
+            "latest",
+            "17.0.2" // duplicate
+        )
+
+        `when`("SPRING_BOOT 버전을 조회하면") {
+
+            val result = service.getAvailableVersion(ApplicationType.SPRING_BOOT)
+
+            then("최소 버전(12) 초과의 semver만 정렬 후 반환된다") {
+                result shouldBe listOf(
+                    "17.0.2",
+                    "17",
+                    "12.0.1"
+                )
+            }
+
+            then("올바른 이미지명이 Port에 전달된다") {
+                verify(exactly = 1) {
+                    imageVersionPort.fetchAllVersions("openjdk")
+                }
+            }
+        }
+    }
+
+    given("유효하지 않은 태그만 존재할 때") {
+
+        every { imageVersionPort.fetchAllVersions("redis") } returns listOf(
+            "latest",
+            "alpine",
+            "foo"
+        )
+
+        `when`("REDIS 버전을 조회하면") {
+            val result = service.getAvailableVersion(ApplicationType.REDIS)
+
+            then("빈 리스트가 반환된다") {
+                result shouldBe emptyList()
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/infrastructure/domain/application/adapter/DockerTagAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/infrastructure/domain/application/adapter/DockerTagAdapterTest.kt
@@ -51,7 +51,6 @@ class DockerTagAdapterTest : BehaviorSpec({
         println(mockWebServer.url("/").toString().removeSuffix("/"))
 
         `when`("태그를 조회하면") {
-            val url = mockWebServer.url("/v2/repositories/library/test/tags?page_size=100")
             val result = adapter.fetchAllVersions("test")
 
             then("태그 목록이 반환된다") {

--- a/src/test/kotlin/com/dcd/server/infrastructure/domain/application/adapter/DockerTagAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/infrastructure/domain/application/adapter/DockerTagAdapterTest.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.infrastructure.domain.application.adapter
 
+import com.dcd.server.infrastructure.domain.application.exception.DockerHubRateLimitExceededException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.kotest.assertions.throwables.shouldThrow
@@ -23,7 +24,6 @@ class DockerTagAdapterTest : BehaviorSpec({
     }
 
     given("Docker Hub API가 정상 응답을 반환할 때") {
-
         val body = """
             {
               "next": null,
@@ -61,7 +61,6 @@ class DockerTagAdapterTest : BehaviorSpec({
     }
 
     given("429 응답을 받을 때") {
-
         mockWebServer.enqueue(
             MockResponse().setResponseCode(429)
         )
@@ -76,6 +75,28 @@ class DockerTagAdapterTest : BehaviorSpec({
         `when`("태그 조회를 하면") {
 
             then("Rate limit 예외가 발생한다") {
+                shouldThrow<DockerHubRateLimitExceededException> {
+                    adapter.fetchAllVersions("test")
+                }
+            }
+        }
+    }
+
+    given("429 응답이 아닌 400번대 응답을 받을때") {
+        mockWebServer.enqueue(
+            MockResponse().setResponseCode(401)
+        )
+
+        val adapter = DockerTagAdapter(
+            objectMapper = objectMapper,
+            token = "test",
+            registryUrl = mockWebServer.url("/").toString().removeSuffix("/"),
+            client = client
+        )
+
+        `when`("태그 조회를 하면") {
+
+            then("RuntimeException이 발생한다.") {
                 shouldThrow<RuntimeException> {
                     adapter.fetchAllVersions("test")
                 }

--- a/src/test/kotlin/com/dcd/server/infrastructure/domain/application/adapter/DockerTagAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/infrastructure/domain/application/adapter/DockerTagAdapterTest.kt
@@ -1,0 +1,85 @@
+package com.dcd.server.infrastructure.domain.application.adapter
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import java.net.http.HttpClient
+
+class DockerTagAdapterTest : BehaviorSpec({
+    val mockWebServer = MockWebServer()
+    val objectMapper = ObjectMapper().registerKotlinModule()
+    val client = HttpClient.newHttpClient()
+
+    beforeSpec {
+        mockWebServer.start()
+    }
+
+    afterSpec {
+        mockWebServer.shutdown()
+    }
+
+    given("Docker Hub API가 정상 응답을 반환할 때") {
+
+        val body = """
+            {
+              "next": null,
+              "results": [
+                {"name": "1.0.0"},
+                {"name": "2.0"},
+                {"name": "latest"}
+              ]
+            }
+        """.trimIndent()
+
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(body)
+        )
+
+        val adapter = DockerTagAdapter(
+            objectMapper = objectMapper,
+            client = client,
+            registryUrl = mockWebServer.url("/").toString().removeSuffix("/"),
+            token = "test",
+        )
+
+        println(mockWebServer.url("/").toString().removeSuffix("/"))
+
+        `when`("태그를 조회하면") {
+            val url = mockWebServer.url("/v2/repositories/library/test/tags?page_size=100")
+            val result = adapter.fetchAllVersions("test")
+
+            then("태그 목록이 반환된다") {
+                result shouldBe listOf("1.0.0", "2.0", "latest")
+            }
+        }
+    }
+
+    given("429 응답을 받을 때") {
+
+        mockWebServer.enqueue(
+            MockResponse().setResponseCode(429)
+        )
+
+        val adapter = DockerTagAdapter(
+            objectMapper = objectMapper,
+            token = "test",
+            registryUrl = mockWebServer.url("/").toString().removeSuffix("/"),
+            client = client
+        )
+
+        `when`("태그 조회를 하면") {
+
+            then("Rate limit 예외가 발생한다") {
+                shouldThrow<RuntimeException> {
+                    adapter.fetchAllVersions("test")
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
## 개요
* 이미지 버전 조회시 shell 스크립트를 호출하는 구조에서 직접 API를 호출하도록 수정합니다.
## 작업내용
* 이미지 버전 조회 스크립트 내용 제거
* 도커 토큰 프로퍼티 추가
* 베이스 이미지의 모든 태그를 조회하는 port/adapter 추가
* `GetApplicationVersionServiceImpl`에서 받아온 태그를 바탕으로 필터링후 결과를 반환하도록 수정
* DockerHubRateLimitExceededException 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 도커 레지스트리에서 이미지 태그(버전)를 직접 조회하는 기능을 추가했습니다.
  * 레지스트리 접속을 위한 설정 항목(docker.url, docker.token) 및 HTTP 클라이언트 구성을 포함했습니다.

* **Bug Fixes**
  * 도커 허브 요청 제한(429) 발생 시 명시적인 에러 처리를 추가했습니다.

* **Tests**
  * 레지스트리 조회 및 에러 경로를 검증하는 단위 테스트를 추가했습니다.

* **Chores**
  * OkHttp 의존성을 4.12.0으로 업그레이드했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->