### PR TITLE
:twisted_rightwards_arrows: :: [#749] - Lock 적용 로직을 서비스로 분리

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/aop/LockAspect.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/aop/LockAspect.kt
@@ -2,23 +2,19 @@ package com.dcd.server.core.common.aop
 
 import com.dcd.server.core.common.annotation.Lock
 import com.dcd.server.core.common.aop.util.CustomExpressionParser
+import com.dcd.server.core.common.service.LockService
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation.Around
 import org.aspectj.lang.annotation.Aspect
 import org.aspectj.lang.reflect.MethodSignature
-import org.redisson.api.RedissonClient
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import java.lang.reflect.Method
-import java.util.concurrent.TimeUnit
 
 @Aspect
 @Component
 class LockAspect(
-    private val redissonClient: RedissonClient,
+    private val lockService: LockService,
 ) {
-    private val log = LoggerFactory.getLogger(this::class.simpleName)
-
     @Around("@annotation(com.dcd.server.core.common.annotation.Lock)")
     @Throws(Throwable::class)
     fun redissonLock(joinPoint: ProceedingJoinPoint) {
@@ -28,21 +24,8 @@ class LockAspect(
         val parameterValue =
             CustomExpressionParser.getDynamicValue(signature.parameterNames, joinPoint.args, annotation.lockName)
         val lockKey = "${method.declaringClass.simpleName}_${method.name}_$parameterValue"
-        val lock = redissonClient.getLock(lockKey)
-        try {
-            val lockable = lock.tryLock(annotation.waitTime, annotation.leaseTime, TimeUnit.MILLISECONDS)
-            if (!lockable) {
-                log.error("Lock 획득 실패: $lockKey")
-                return
-            }
-            log.debug("로직 수행")
+        lockService.lock(lockKey, annotation.waitTime, annotation.leaseTime) {
             joinPoint.proceed()
-        } catch (e: InterruptedException) {
-            log.error("에러 발생")
-            throw e
-        } finally {
-            log.debug("락 해제")
-            lock.unlock()
         }
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/common/service/LockService.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/service/LockService.kt
@@ -1,0 +1,5 @@
+package com.dcd.server.core.common.service
+
+interface LockService {
+    fun <T> lock(lockKey: String, waitTime: Long, leaseTime: Long, block: () -> T): T?
+}

--- a/src/main/kotlin/com/dcd/server/core/common/service/impl/RedissonLockServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/service/impl/RedissonLockServiceImpl.kt
@@ -1,0 +1,35 @@
+package com.dcd.server.core.common.service.impl
+
+import com.dcd.server.core.common.service.LockService
+import org.redisson.api.RedissonClient
+import org.springframework.stereotype.Service
+import org.slf4j.LoggerFactory
+import java.util.concurrent.TimeUnit
+
+@Service
+class RedissonLockServiceImpl(
+    private val redissonClient: RedissonClient,
+) : LockService {
+    private val log = LoggerFactory.getLogger(this::class.simpleName)
+
+    override fun <T> lock(lockKey: String, waitTime: Long, leaseTime: Long, block: () -> T): T? {
+        val lock = redissonClient.getLock(lockKey)
+        try {
+            val lockable = lock.tryLock(waitTime, leaseTime, TimeUnit.MILLISECONDS)
+            if (!lockable) {
+                log.error("Lock 획득 실패: $lockKey")
+                return null
+            }
+            log.debug("로직 수행")
+            return block()
+        } catch (e: InterruptedException) {
+            log.error("에러 발생")
+            throw e
+        } finally {
+            if (lock.isHeldByCurrentThread) {
+                log.debug("Lock 해제: $lockKey")
+                lock.unlock()
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/dcd/server/core/common/service/RedissonLockRaceConditionTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/common/service/RedissonLockRaceConditionTest.kt
@@ -23,6 +23,7 @@ class RedissonLockRaceConditionTest(
         val executor = Executors.newFixedThreadPool(threadCount)
 
         val startLatch = CountDownLatch(1)
+        val readyLatch = CountDownLatch(threadCount)
         val endLatch = CountDownLatch(threadCount)
 
         val counter = AtomicInteger(0)
@@ -33,6 +34,7 @@ class RedissonLockRaceConditionTest(
 
                 executor.submit {
                     try {
+                        readyLatch.countDown()
                         startLatch.await()
 
                         lockService.lock("race-lock", 0, 5000) {
@@ -46,8 +48,9 @@ class RedissonLockRaceConditionTest(
                 }
             }
 
+            readyLatch.await(5, java.util.concurrent.TimeUnit.SECONDS) shouldBe true
             startLatch.countDown()
-            endLatch.await()
+            endLatch.await(5, java.util.concurrent.TimeUnit.SECONDS) shouldBe true
 
             executor.shutdown()
 

--- a/src/test/kotlin/com/dcd/server/core/common/service/RedissonLockRaceConditionTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/common/service/RedissonLockRaceConditionTest.kt
@@ -35,7 +35,7 @@ class RedissonLockRaceConditionTest(
                     try {
                         startLatch.await()
 
-                        lockService.lock("race-lock", 3000, 5000) {
+                        lockService.lock("race-lock", 0, 5000) {
                             Thread.sleep(100)
                             counter.incrementAndGet()
                         }

--- a/src/test/kotlin/com/dcd/server/core/common/service/RedissonLockRaceConditionTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/common/service/RedissonLockRaceConditionTest.kt
@@ -1,0 +1,58 @@
+package com.dcd.server.core.common.service
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class RedissonLockRaceConditionTest(
+    private val lockService: LockService
+) : BehaviorSpec({
+
+    Given("동시에 여러 스레드가 같은 락을 요청할 때") {
+
+        val threadCount = 10
+        val executor = Executors.newFixedThreadPool(threadCount)
+
+        val startLatch = CountDownLatch(1)
+        val endLatch = CountDownLatch(threadCount)
+
+        val counter = AtomicInteger(0)
+
+        When("모든 스레드를 동시에 실행하면") {
+
+            repeat(threadCount) {
+
+                executor.submit {
+                    try {
+                        startLatch.await()
+
+                        lockService.lock("race-lock", 3000, 5000) {
+                            Thread.sleep(100)
+                            counter.incrementAndGet()
+                        }
+
+                    } finally {
+                        endLatch.countDown()
+                    }
+                }
+            }
+
+            startLatch.countDown()
+            endLatch.await()
+
+            executor.shutdown()
+
+            Then("block은 단 한 번만 실행된다") {
+                counter.get() shouldBe 1
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/dcd/server/core/common/service/RedissonLockRaceConditionTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/common/service/RedissonLockRaceConditionTest.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.core.common.service
 
+import com.dcd.server.core.common.service.impl.RedissonLockServiceImpl
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import java.util.concurrent.CountDownLatch

--- a/src/test/kotlin/com/dcd/server/core/common/service/RedissonLockServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/common/service/RedissonLockServiceImplTest.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.core.common.service
 
+import com.dcd.server.core.common.service.impl.RedissonLockServiceImpl
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.assertions.throwables.shouldThrow
@@ -21,7 +22,7 @@ class RedissonLockServiceImplTest : BehaviorSpec({
 
     beforeTest {
         clearAllMocks()
-        every { redissonClient.getLock(any()) } returns lock
+        every { redissonClient.getLock(any() as String) } returns lock
         lockService = RedissonLockServiceImpl(redissonClient)
     }
 

--- a/src/test/kotlin/com/dcd/server/core/common/service/RedissonLockServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/common/service/RedissonLockServiceImplTest.kt
@@ -10,68 +10,59 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.Runs
 import io.mockk.verify
+import java.util.concurrent.TimeUnit
 import org.redisson.api.RLock
 import org.redisson.api.RedissonClient
 
 class RedissonLockServiceImplTest : BehaviorSpec({
-
     val redissonClient = mockk<RedissonClient>()
     val lock = mockk<RLock>()
-
-    lateinit var lockService: RedissonLockServiceImpl
-
-    beforeTest {
-        clearAllMocks()
-        every { redissonClient.getLock(any() as String) } returns lock
-        lockService = RedissonLockServiceImpl(redissonClient)
-    }
+    val lockService = RedissonLockServiceImpl(redissonClient)
 
     Given("락 획득이 성공했을 때") {
+        clearAllMocks()
 
-        every { lock.tryLock(any(), any(), any()) } returns true
+        every { redissonClient.getLock(any<String>()) } returns lock
+        every { lock.tryLock(any<Long>(), any<Long>(), any<TimeUnit>()) } returns true
         every { lock.isHeldByCurrentThread } returns true
         every { lock.unlock() } just Runs
 
         When("block을 실행하면") {
-
             val result = lockService.lock("test-lock", 1000, 3000) {
                 "success"
             }
 
-            Then("block 결과를 반환한다") {
+            Then("block 결과를 반환하고, unlock이 호출된다") {
                 result shouldBe "success"
-            }
-
-            Then("unlock이 호출된다") {
                 verify { lock.unlock() }
             }
         }
     }
 
     Given("락 획득이 실패했을 때") {
+        clearAllMocks()
 
-        every { lock.tryLock(any(), any(), any()) } returns false
+        every { redissonClient.getLock(any<String>()) } returns lock
+        every { lock.tryLock(any<Long>(), any<Long>(), any<TimeUnit>()) } returns false
         every { lock.isHeldByCurrentThread } returns false
 
         When("lock을 실행하면") {
-
             val result = lockService.lock("test-lock", 1000, 3000) {
                 "should not run"
             }
 
-            Then("null을 반환한다") {
+            Then("null을 반환하고 unlock은 호출되지 않는다") {
                 result shouldBe null
-            }
-
-            Then("unlock은 호출되지 않는다") {
                 verify(exactly = 0) { lock.unlock() }
             }
         }
     }
 
     Given("block 실행 중 예외가 발생하면") {
+        clearAllMocks()
 
-        every { lock.tryLock(any(), any(), any()) } returns true
+        every { redissonClient.getLock(any<String>()) } returns lock
+        every { lock.tryLock(any<Long>(), any<Long>(), any<TimeUnit>()) } returns true
         every { lock.isHeldByCurrentThread } returns true
         every { lock.unlock() } just Runs
 

--- a/src/test/kotlin/com/dcd/server/core/common/service/RedissonLockServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/common/service/RedissonLockServiceImplTest.kt
@@ -51,6 +51,7 @@ class RedissonLockServiceImplTest : BehaviorSpec({
     Given("락 획득이 실패했을 때") {
 
         every { lock.tryLock(any(), any(), any()) } returns false
+        every { lock.isHeldByCurrentThread } returns false
 
         When("lock을 실행하면") {
 

--- a/src/test/kotlin/com/dcd/server/core/common/service/RedissonLockServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/common/service/RedissonLockServiceImplTest.kt
@@ -1,0 +1,90 @@
+package com.dcd.server.core.common.service
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.assertions.throwables.shouldThrow
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.Runs
+import io.mockk.verify
+import org.redisson.api.RLock
+import org.redisson.api.RedissonClient
+
+class RedissonLockServiceImplTest : BehaviorSpec({
+
+    val redissonClient = mockk<RedissonClient>()
+    val lock = mockk<RLock>()
+
+    lateinit var lockService: RedissonLockServiceImpl
+
+    beforeTest {
+        clearAllMocks()
+        every { redissonClient.getLock(any()) } returns lock
+        lockService = RedissonLockServiceImpl(redissonClient)
+    }
+
+    Given("락 획득이 성공했을 때") {
+
+        every { lock.tryLock(any(), any(), any()) } returns true
+        every { lock.isHeldByCurrentThread } returns true
+        every { lock.unlock() } just Runs
+
+        When("block을 실행하면") {
+
+            val result = lockService.lock("test-lock", 1000, 3000) {
+                "success"
+            }
+
+            Then("block 결과를 반환한다") {
+                result shouldBe "success"
+            }
+
+            Then("unlock이 호출된다") {
+                verify { lock.unlock() }
+            }
+        }
+    }
+
+    Given("락 획득이 실패했을 때") {
+
+        every { lock.tryLock(any(), any(), any()) } returns false
+
+        When("lock을 실행하면") {
+
+            val result = lockService.lock("test-lock", 1000, 3000) {
+                "should not run"
+            }
+
+            Then("null을 반환한다") {
+                result shouldBe null
+            }
+
+            Then("unlock은 호출되지 않는다") {
+                verify(exactly = 0) { lock.unlock() }
+            }
+        }
+    }
+
+    Given("block 실행 중 예외가 발생하면") {
+
+        every { lock.tryLock(any(), any(), any()) } returns true
+        every { lock.isHeldByCurrentThread } returns true
+        every { lock.unlock() } just Runs
+
+        When("block에서 exception이 발생하면") {
+
+            Then("unlock은 반드시 호출된다") {
+
+                shouldThrow<RuntimeException> {
+                    lockService.lock("test-lock", 1000, 3000) {
+                        throw RuntimeException("error")
+                    }
+                }
+
+                verify { lock.unlock() }
+            }
+        }
+    }
+})


### PR DESCRIPTION
## 개요
* Redisson 분산락을 적용하는 로직을 서비스로 분리합니다.
## 작업내용
* 분산락 적용 서비스 추가
* LockAspect가 LockService를 통해서 Redisson 분산락을 적용하도록 리펙토링
* Redisson 락 관련 테스트 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?
## 기타
* 어노테이션을 적용하기 어려운 상황에서 서비스를 호출해서 락을 적용하는것이 가능해짐

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **리팩터링**
  * 잠금 처리 호출부를 Redisson에서 추상화된 LockService로 전환해 호출부를 간소화하고 로그·명시적 예외/해제 처리를 제거했습니다.

* **새 기능**
  * LockService 인터페이스 추가 및 분산 잠금을 제공하는 구현체(Redisson 기반) 추가로 잠금 추상화와 구현 분리를 도입했습니다.

* **테스트**
  * 동시성 배타성 검증 통합 테스트와 구현체 동작을 검증하는 단위 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->