### PR TITLE
:twisted_rightwards_arrows: :: [#753] - 애플리케이션 응답 나누기

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/extenstion/ApplicationDtoExtension.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/extenstion/ApplicationDtoExtension.kt
@@ -2,7 +2,7 @@ package com.dcd.server.core.domain.application.dto.extenstion
 
 import com.dcd.server.core.domain.application.dto.request.CreateApplicationReqDto
 import com.dcd.server.core.domain.application.dto.response.ApplicationProfileResDto
-import com.dcd.server.core.domain.application.dto.response.ApplicationResDto
+import com.dcd.server.core.domain.application.dto.response.ApplicationDetailResDto
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.model.ApplicationInitialScript
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
@@ -24,8 +24,8 @@ fun CreateApplicationReqDto.toEntity(workspace: Workspace, externalPort: Int): A
         labels = this.labels
     )
 
-fun Application.toDto(envList: List<ApplicationEnv>, initialScriptList: List<ApplicationInitialScript>): ApplicationResDto =
-    ApplicationResDto(
+fun Application.toDto(envList: List<ApplicationEnv>, initialScriptList: List<ApplicationInitialScript>): ApplicationDetailResDto =
+    ApplicationDetailResDto(
         id = this.id,
         name = this.name,
         description = this.description,

--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/extenstion/ApplicationDtoExtension.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/extenstion/ApplicationDtoExtension.kt
@@ -3,6 +3,7 @@ package com.dcd.server.core.domain.application.dto.extenstion
 import com.dcd.server.core.domain.application.dto.request.CreateApplicationReqDto
 import com.dcd.server.core.domain.application.dto.response.ApplicationProfileResDto
 import com.dcd.server.core.domain.application.dto.response.ApplicationDetailResDto
+import com.dcd.server.core.domain.application.dto.response.ApplicationResDto
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.model.ApplicationInitialScript
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
@@ -63,4 +64,18 @@ fun Application.toWorkspaceDto(): WorkspaceApplicationResDto =
         port = this.port,
         externalPort = this.externalPort,
         status = this.status
+    )
+
+fun Application.toResDto(): ApplicationResDto =
+    ApplicationResDto(
+        id = this.id,
+        name = this.name,
+        description = this.description,
+        applicationType = this.applicationType,
+        githubUrl = this.githubUrl,
+        port = this.port,
+        externalPort = this.externalPort,
+        version = this.version,
+        status = this.status,
+        labels = this.labels
     )

--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/response/ApplicationDetailResDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/response/ApplicationDetailResDto.kt
@@ -3,7 +3,7 @@ package com.dcd.server.core.domain.application.dto.response
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 
-data class ApplicationResDto(
+data class ApplicationDetailResDto(
     val id: String,
     val name: String,
     val description: String?,

--- a/src/main/kotlin/com/dcd/server/core/domain/application/dto/response/ApplicationResDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/dto/response/ApplicationResDto.kt
@@ -1,0 +1,17 @@
+package com.dcd.server.core.domain.application.dto.response
+
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
+import com.dcd.server.core.domain.application.model.enums.ApplicationType
+
+data class ApplicationResDto(
+    val id: String,
+    val name: String,
+    val description: String?,
+    val applicationType: ApplicationType,
+    val githubUrl: String?,
+    val port: Int,
+    val externalPort: Int,
+    val version: String,
+    val status: ApplicationStatus,
+    val labels: List<String>
+)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCase.kt
@@ -4,7 +4,7 @@ import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.common.data.WorkspaceInfo
 import com.dcd.server.core.common.data.dto.response.ListResDto
 import com.dcd.server.core.domain.application.dto.extenstion.toDto
-import com.dcd.server.core.domain.application.dto.response.ApplicationResDto
+import com.dcd.server.core.domain.application.dto.response.ApplicationDetailResDto
 import com.dcd.server.core.domain.application.spi.QueryApplicationInitialScriptPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.env.spi.QueryApplicationEnvPort
@@ -17,7 +17,7 @@ class GetAllApplicationUseCase(
     private val queryApplicationEnvPort: QueryApplicationEnvPort,
     private val queryApplicationInitialScriptPort: QueryApplicationInitialScriptPort,
 ) {
-    fun execute(labels: List<String>?): ListResDto<ApplicationResDto> {
+    fun execute(labels: List<String>?): ListResDto<ApplicationDetailResDto> {
         val workspace = workspaceInfo.workspace
             ?: throw WorkspaceNotFoundException()
 

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCase.kt
@@ -2,7 +2,7 @@ package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.domain.application.dto.extenstion.toDto
-import com.dcd.server.core.domain.application.dto.response.ApplicationResDto
+import com.dcd.server.core.domain.application.dto.response.ApplicationDetailResDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.spi.QueryApplicationInitialScriptPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
@@ -14,7 +14,7 @@ class GetOneApplicationUseCase(
     private val queryApplicationEnvPort: QueryApplicationEnvPort,
     private val queryApplicationInitialScriptPort: QueryApplicationInitialScriptPort
 ) {
-    fun execute(id: String): ApplicationResDto {
+    fun execute(id: String): ApplicationDetailResDto {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
         val applicationEnvList = queryApplicationEnvPort.findByApplication(application)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCase.kt
@@ -1,8 +1,8 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
-import com.dcd.server.core.domain.application.dto.extenstion.toDto
-import com.dcd.server.core.domain.application.dto.response.ApplicationDetailResDto
+import com.dcd.server.core.domain.application.dto.extenstion.toResDto
+import com.dcd.server.core.domain.application.dto.response.ApplicationResDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.spi.QueryApplicationInitialScriptPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
@@ -14,11 +14,9 @@ class GetOneApplicationUseCase(
     private val queryApplicationEnvPort: QueryApplicationEnvPort,
     private val queryApplicationInitialScriptPort: QueryApplicationInitialScriptPort
 ) {
-    fun execute(id: String): ApplicationDetailResDto {
+    fun execute(id: String): ApplicationResDto {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
-        val applicationEnvList = queryApplicationEnvPort.findByApplication(application)
-        val initialScripts = queryApplicationInitialScriptPort.findAllByApplication(application)
-        return application.toDto(applicationEnvList, initialScripts)
+        return application.toResDto()
     }
 }

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
@@ -71,7 +71,7 @@ class ApplicationWebAdapter(
 
     @GetMapping("/{applicationId}")
     @WorkspaceOwnerVerification("#workspaceId")
-    fun getOneApplication(@PathVariable workspaceId: String, @PathVariable applicationId: String): ResponseEntity<ApplicationDetailResponse> =
+    fun getOneApplication(@PathVariable workspaceId: String, @PathVariable applicationId: String): ResponseEntity<ApplicationResponse> =
         getOneApplicationUseCase.execute(applicationId)
             .let { ResponseEntity.ok(it.toResponse()) }
 

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
@@ -65,13 +65,13 @@ class ApplicationWebAdapter(
     fun getAllApplication(
         @PathVariable workspaceId: String,
         @RequestParam(required = false) labels: List<String>? = null
-    ): ResponseEntity<ListResponse<ApplicationResponse>> =
+    ): ResponseEntity<ListResponse<ApplicationDetailResponse>> =
         getAllApplicationUseCase.execute(labels)
             .let { ResponseEntity.ok(it.toResponse { resDto -> resDto.toResponse() }) }
 
     @GetMapping("/{applicationId}")
     @WorkspaceOwnerVerification("#workspaceId")
-    fun getOneApplication(@PathVariable workspaceId: String, @PathVariable applicationId: String): ResponseEntity<ApplicationResponse> =
+    fun getOneApplication(@PathVariable workspaceId: String, @PathVariable applicationId: String): ResponseEntity<ApplicationDetailResponse> =
         getOneApplicationUseCase.execute(applicationId)
             .let { ResponseEntity.ok(it.toResponse()) }
 

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationResponseDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationResponseDataExtension.kt
@@ -5,8 +5,8 @@ import com.dcd.server.core.domain.workspace.dto.response.WorkspaceApplicationRes
 import com.dcd.server.presentation.domain.application.data.response.*
 import com.dcd.server.presentation.domain.workspace.data.response.WorkspaceApplicationResponse
 
-fun ApplicationResDto.toResponse(): ApplicationResponse =
-    ApplicationResponse(
+fun ApplicationDetailResDto.toResponse(): ApplicationDetailResponse =
+    ApplicationDetailResponse(
         id = this.id,
         name = this.name,
         description = this.description,

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationResponseDataExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/exetension/ApplicationResponseDataExtension.kt
@@ -60,3 +60,17 @@ fun CreateApplicationResDto.toResponse(): CreateApplicationResponse =
     CreateApplicationResponse(
         applicationId = this.applicationId
     )
+
+fun ApplicationResDto.toResponse(): ApplicationResponse =
+    ApplicationResponse(
+        id = this.id,
+        name = this.name,
+        description = this.description,
+        applicationType = this.applicationType,
+        githubUrl = this.githubUrl,
+        port = this.port,
+        externalPort = this.externalPort,
+        version = this.version,
+        status = this.status,
+        labels = this.labels
+    )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/response/ApplicationDetailResponse.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/response/ApplicationDetailResponse.kt
@@ -3,7 +3,7 @@ package com.dcd.server.presentation.domain.application.data.response
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
 import com.dcd.server.core.domain.application.model.enums.ApplicationType
 
-data class ApplicationResponse(
+data class ApplicationDetailResponse(
     val id: String,
     val name: String,
     val description: String?,

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/data/response/ApplicationResponse.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/data/response/ApplicationResponse.kt
@@ -1,0 +1,17 @@
+package com.dcd.server.presentation.domain.application.data.response
+
+import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
+import com.dcd.server.core.domain.application.model.enums.ApplicationType
+
+data class ApplicationResponse(
+    val id: String,
+    val name: String,
+    val description: String?,
+    val applicationType: ApplicationType,
+    val githubUrl: String?,
+    val port: Int,
+    val externalPort: Int,
+    val version: String,
+    val status: ApplicationStatus,
+    val labels: List<String>
+)

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCaseTest.kt
@@ -1,6 +1,6 @@
 package com.dcd.server.core.domain.application.usecase
 
-import com.dcd.server.core.domain.application.dto.extenstion.toDto
+import com.dcd.server.core.domain.application.dto.extenstion.toResDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.user.spi.QueryUserPort
@@ -36,7 +36,7 @@ class GetOneApplicationUseCaseTest(
             val result = getOneApplicationUseCase.execute(application.id)
 
             then("result는 application의 내용이랑 같아야함") {
-                result shouldBeEqualToComparingFields application.toDto(listOf(), listOf())
+                result shouldBeEqualToComparingFields application.toResDto()
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -57,7 +57,7 @@ class ApplicationWebAdapterTest : BehaviorSpec({
     }
 
     given("ApplicationListResponse가 주어지고") {
-        val applicationResponse = ApplicationResDto(
+        val applicationResponse = ApplicationDetailResDto(
             id = "testId",
             name = "test",
             description = "test",
@@ -88,7 +88,7 @@ class ApplicationWebAdapterTest : BehaviorSpec({
 
     given("ApplicationResponseDto가 주어지고") {
         val testId = "testId"
-        val applicationResponse = ApplicationResDto(
+        val applicationResponse = ApplicationDetailResDto(
             id = testId,
             name = "test",
             description = "test",

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -88,21 +88,17 @@ class ApplicationWebAdapterTest : BehaviorSpec({
 
     given("ApplicationResponseDto가 주어지고") {
         val testId = "testId"
-        val applicationResponse = ApplicationDetailResDto(
+        val applicationResponse = ApplicationResDto(
             id = testId,
             name = "test",
             description = "test",
             applicationType = ApplicationType.SPRING_BOOT,
-            env = mapOf(),
             githubUrl = "testUrl",
             port = 8080,
             externalPort = 8080,
             version = "latest",
             status = ApplicationStatus.STOPPED,
             labels = listOf(),
-            failureReason = null,
-            failureReasonDetail = null,
-            initialScripts = emptyList(),
         )
         `when`("getOneApplication 메서드를 실행할때") {
             every { getOneApplicationUseCase.execute(testId) } returns applicationResponse


### PR DESCRIPTION
## 개요
* 상세(단일) 조회와 리스트 조회의 응답 객체를 분리함으로써 응답 페이로드를 감소시켜 네트워크 오버헤드를 줄입니다.
## 작업내용
* 애플리케이션 리스트 조회를 위한 축약된 응답 클래스 추가
* 애플리케이션 리스트 조회시 축약된 응답 클래스를 사용하도록 리펙토링
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [x] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 리팩토링

* **Refactor**
  * 애플리케이션 API 응답 구조가 최적화되었습니다.
  * 애플리케이션 목록 조회 응답에 환경 변수, 실패 원인, 초기 스크립트 정보가 포함되었습니다.
  * 단일 애플리케이션 조회 응답이 기본 정보로 단순화되었습니다.
  * 관련 테스트가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->