### PR TITLE
:twisted_rightwards_arrows: :: [#755] - BloomFilter를 사용할 수 있게하는 서비스 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
@@ -66,5 +66,6 @@ enum class ErrorCode(
     FAILURE_VOLUME_CREATION("컨테이너 볼륨 생성에 실패했습니다.", 500),
     FAILURE_VOLUME_DELETE("컨테이너 볼륨 삭제에 실패했습니다.", 500),
     FAILURE_VOLUME_COPY("컨테이너 볼륨 복제에 실패했습니다.", 500),
+    FAILURE_BLOOM_FILTER_RESERVATION("블룸 필터 예약에 실패했습니다.", 500),
     IMAGE_REGISTRY_RATE_LIMIT_EXCEEDED("도커 허브의 요청 제한을 초과했습니다.", 500),
 }

--- a/src/main/kotlin/com/dcd/server/core/common/service/CountBloomFilterService.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/service/CountBloomFilterService.kt
@@ -1,0 +1,7 @@
+package com.dcd.server.core.common.service
+
+interface CountBloomFilterService {
+    fun add(filterName: String, item: String): Boolean
+    fun remove(filterName: String, item: String): Boolean
+    fun exists(filterName: String, item: String): Boolean
+}

--- a/src/main/kotlin/com/dcd/server/core/common/service/exception/BloomFilterReservationException.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/service/exception/BloomFilterReservationException.kt
@@ -1,0 +1,6 @@
+package com.dcd.server.core.common.service.exception
+
+import com.dcd.server.core.common.error.BasicException
+import com.dcd.server.core.common.error.ErrorCode
+
+class BloomFilterReservationException : BasicException(ErrorCode.FAILURE_BLOOM_FILTER_RESERVATION)

--- a/src/main/kotlin/com/dcd/server/core/common/service/impl/CuckooFilterServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/service/impl/CuckooFilterServiceImpl.kt
@@ -17,7 +17,7 @@ class CuckooFilterServiceImpl(
         if (redisTemplate.hasKey(filterName).not()) {
             redisTemplate.execute { connection ->
                 val result = connection.commands().execute("CF.RESERVE", filterName.toByteArray(), "100000".toByteArray()) as? String
-                if (result != "OK") {
+                if (result != "OK" && result?.contains("item exists")!!.not()) {
                     log.error("Failed to reserve Cuckoo Filter: {}", filterName)
                     throw BloomFilterReservationException()
                 }

--- a/src/main/kotlin/com/dcd/server/core/common/service/impl/CuckooFilterServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/service/impl/CuckooFilterServiceImpl.kt
@@ -17,7 +17,7 @@ class CuckooFilterServiceImpl(
         if (redisTemplate.hasKey(filterName).not()) {
             redisTemplate.execute { connection ->
                 val result = connection.commands().execute("CF.RESERVE", filterName.toByteArray(), "100000".toByteArray()) as? String
-                if (result != "OK" && result?.contains("item exists")!!.not()) {
+                if (result != "OK" && result?.contains("item exists") != true) {
                     log.error("Failed to reserve Cuckoo Filter: {}", filterName)
                     throw BloomFilterReservationException()
                 }

--- a/src/main/kotlin/com/dcd/server/core/common/service/impl/CuckooFilterServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/service/impl/CuckooFilterServiceImpl.kt
@@ -1,0 +1,46 @@
+package com.dcd.server.core.common.service.impl
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.data.redis.core.StringRedisTemplate
+import com.dcd.server.core.common.service.CountBloomFilterService
+import com.dcd.server.core.common.service.exception.BloomFilterReservationException
+
+@Service
+class CuckooFilterServiceImpl(
+    private val redisTemplate: StringRedisTemplate
+) : CountBloomFilterService {
+    private val log = LoggerFactory.getLogger(this::class.simpleName)
+
+    override fun add(filterName: String, item: String): Boolean {
+        // 해당하는 Cuckoo Filter가 존재하지 않으면 생성
+        if (redisTemplate.hasKey(filterName).not()) {
+            redisTemplate.execute { connection ->
+                val result = connection.commands().execute("CF.RESERVE", filterName.toByteArray(), "100000".toByteArray()) as? String
+                if (result != "OK") {
+                    log.error("Failed to reserve Cuckoo Filter: {}", filterName)
+                    throw BloomFilterReservationException()
+                }
+            }
+        }
+
+        return redisTemplate.execute { connection ->
+            val result = connection.commands().execute("CF.ADDNX", filterName.toByteArray(), item.toByteArray())
+            (result as? Long) == 1L
+        } ?: false
+    }
+
+    override fun remove(filterName: String, item: String): Boolean {
+        return redisTemplate.execute { connection ->
+            val result = connection.commands().execute("CF.DEL", filterName.toByteArray(), item.toByteArray())
+            (result as? Long) == 1L
+        } ?: false
+    }
+
+    override fun exists(filterName: String, item: String): Boolean {
+        return redisTemplate.execute { connection ->
+            val result = connection.commands().execute("CF.EXISTS", filterName.toByteArray(), item.toByteArray())
+            (result as? Long) == 1L
+        } ?: false
+    }
+}

--- a/src/test/kotlin/com/dcd/server/core/common/service/CuckooFilterServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/common/service/CuckooFilterServiceImplTest.kt
@@ -1,0 +1,179 @@
+package com.dcd.server.core.common.service
+
+import com.dcd.server.core.common.service.exception.BloomFilterReservationException
+import com.dcd.server.core.common.service.impl.CuckooFilterServiceImpl
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.redis.connection.RedisCommands
+import org.springframework.data.redis.connection.RedisConnection
+import org.springframework.data.redis.core.RedisCallback
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.test.context.ActiveProfiles
+
+@SpringBootTest
+@ActiveProfiles("test")
+class CuckooFilterServiceImplTest(
+    rawTemplate: StringRedisTemplate
+) : BehaviorSpec({
+    val redisTemplate = spyk(rawTemplate)
+    val cuckooFilterService = CuckooFilterServiceImpl(redisTemplate)
+    val redisConnection = spyk(redisTemplate.getConnectionFactory()!!.getConnection())
+    val redisCommands = spyk(redisConnection.commands())
+
+    beforeSpec {
+        // redisTemplate.execute() 호출 시 콜백을 직접 실행하도록 설정
+        every { redisTemplate.execute(any<RedisCallback<Any>>()) } answers {
+            val callback = firstArg<RedisCallback<Any>>()
+            callback.doInRedis(redisConnection)
+        }
+        // redisConnection에서 commands() 호출 시 redisCommands 반환
+        every { redisConnection.commands() } returns redisCommands
+    }
+
+    given("Cuckoo filter add 동작") {
+
+        `when`("필터가 존재하지 않으면 CF.RESERVE 호출 후 CF.ADDNX 성공") {
+            val filterName = "test-filter"
+            val item = "item"
+
+            every { redisTemplate.hasKey(filterName) } returns false
+            every {
+                redisCommands.execute("CF.RESERVE", filterName.toByteArray(), "100000".toByteArray())
+            } returns "OK"
+            every {
+                redisCommands.execute("CF.ADDNX", filterName.toByteArray(), item.toByteArray())
+            } returns 1L
+
+            then("true를 반환하고, CF.RESERVE와 CF.ADDNX가 호출되어야 한다") {
+                val result = cuckooFilterService.add(filterName, item)
+                
+                result shouldBe true
+                verify(exactly = 1) { redisTemplate.hasKey(filterName) }
+                verify(exactly = 1) { redisCommands.execute("CF.RESERVE", filterName.toByteArray(), "100000".toByteArray()) }
+                verify(exactly = 1) { redisCommands.execute("CF.ADDNX", filterName.toByteArray(), item.toByteArray()) }
+            }
+        }
+
+        `when`("필터가 이미 존재하면 CF.RESERVE를 생략하고 CF.ADDNX만 호출") {
+            val filterName = "test-filter"
+            val item = "item"
+
+            clearMocks(redisTemplate, redisCommands, answers = false)
+            every { redisTemplate.hasKey(filterName) } returns true
+            every {
+                redisCommands.execute("CF.ADDNX", filterName.toByteArray(), item.toByteArray())
+            } returns 0L
+
+            then("false를 반환하고, CF.RESERVE는 호출되지 않아야 한다") {
+                val result = cuckooFilterService.add(filterName, item)
+                
+                result shouldBe false
+                verify(exactly = 1) { redisTemplate.hasKey(filterName) }
+                verify(exactly = 0) { redisCommands.execute("CF.RESERVE", any(), any()) }
+                verify(exactly = 1) { redisCommands.execute("CF.ADDNX", filterName.toByteArray(), item.toByteArray()) }
+            }
+        }
+
+        `when`("필터 예약(CF.RESERVE) 실패 시 예외 발생") {
+            val filterName = "test-filter"
+            val item = "item"
+
+            clearMocks(redisTemplate, redisCommands, answers = false)
+            every { redisTemplate.hasKey(filterName) } returns false
+            every {
+                redisCommands.execute("CF.RESERVE", filterName.toByteArray(), "100000".toByteArray())
+            } returns "ERROR"
+
+            then("BloomFilterReservationException 예외가 발생해야 하고, CF.ADDNX는 호출되지 않아야 한다") {
+                shouldThrow<BloomFilterReservationException> {
+                    cuckooFilterService.add(filterName, item)
+                }
+                
+                verify(exactly = 1) { redisTemplate.hasKey(filterName) }
+                verify(exactly = 1) { redisCommands.execute("CF.RESERVE", filterName.toByteArray(), "100000".toByteArray()) }
+                verify(exactly = 0) { redisCommands.execute("CF.ADDNX", any(), any()) }
+            }
+        }
+    }
+
+    given("Cuckoo filter remove 동작") {
+
+        `when`("CF.DEL이 1을 반환하면 true") {
+            val filterName = "test-filter"
+            val item = "item"
+
+            clearMocks(redisTemplate, redisCommands, answers = false)
+            every {
+                redisCommands.execute("CF.DEL", filterName.toByteArray(), item.toByteArray())
+            } returns 1L
+
+            then("true를 반환하고, CF.DEL이 호출되어야 한다") {
+                val result = cuckooFilterService.remove(filterName, item)
+                
+                result shouldBe true
+                verify(exactly = 1) { redisCommands.execute("CF.DEL", filterName.toByteArray(), item.toByteArray()) }
+            }
+        }
+
+        `when`("CF.DEL이 0을 반환하면 false") {
+            val filterName = "test-filter"
+            val item = "item"
+
+            clearMocks(redisTemplate, redisCommands, answers = false)
+            every {
+                redisCommands.execute("CF.DEL", filterName.toByteArray(), item.toByteArray())
+            } returns 0L
+
+            then("false를 반환해야 한다") {
+                val result = cuckooFilterService.remove(filterName, item)
+                
+                result shouldBe false
+                verify(exactly = 1) { redisCommands.execute("CF.DEL", filterName.toByteArray(), item.toByteArray()) }
+            }
+        }
+    }
+
+    given("Cuckoo filter exists 동작") {
+
+        `when`("CF.EXISTS가 1을 반환하면 true") {
+            val filterName = "test-filter"
+            val item = "item"
+
+            clearMocks(redisTemplate, redisCommands, answers = false)
+            every {
+                redisCommands.execute("CF.EXISTS", filterName.toByteArray(), item.toByteArray())
+            } returns 1L
+
+            then("true를 반환해야 한다") {
+                val result = cuckooFilterService.exists(filterName, item)
+                
+                result shouldBe true
+                verify(exactly = 1) { redisCommands.execute("CF.EXISTS", filterName.toByteArray(), item.toByteArray()) }
+            }
+        }
+
+        `when`("CF.EXISTS가 0을 반환하면 false") {
+            val filterName = "test-filter"
+            val item = "item"
+
+            clearMocks(redisTemplate, redisCommands, answers = false)
+            every {
+                redisCommands.execute("CF.EXISTS", filterName.toByteArray(), item.toByteArray())
+            } returns 0L
+
+            then("false를 반환해야 한다") {
+                val result = cuckooFilterService.exists(filterName, item)
+                
+                result shouldBe false
+                verify(exactly = 1) { redisCommands.execute("CF.EXISTS", filterName.toByteArray(), item.toByteArray()) }
+            }
+        }
+    }
+})


### PR DESCRIPTION
## 개요
* BloomFlter를 사용할 수 있게하는 서비스를 추가합니다.
## 작업내용
* CountBloomFilterService 인터페이스 추가
* Redis CuckooFilter를 사용해서 필터내의 아이템을 삭제할 수 있는 구현체 추가
* 해당 구현체의 테스트 작성
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cuckoo Filter 기반 필터 서비스 추가 — 항목 추가, 제거, 존재 여부 확인 지원

* **Bug Fixes**
  * 필터 예약 실패 시 전용 오류 코드 및 예외 처리 추가하여 실패 상황을 명확히 처리

* **Tests**
  * Cuckoo Filter 동작(예약, 추가, 제거, 조회)에 대한 단위/통합 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->