### PR TITLE
🔀 :: [#760] - 정상적으로 Redis 모듈 명령을 실행할 수 없는 현상 수정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
 	runtimeOnly("com.h2database:h2")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
+	implementation("org.redisson:redisson:4.3.0")
 
 	//test
 	testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,13 +6,13 @@ networks:
 services:
   db:
     container_name: dcd-db
-    image: mariadb:latest
+    image: mariadb:11.8.2
     env_file: dcd-db.env
     ports:
       - 3307:3306
   redis:
     container_name: dcd-redis
-    image: redis:latest
+    image: redis:8.6.2
     env_file: dcd-redis.env
     environment:
       - REDIS_DISABLE_COMMANDS=FLUSHDB,FLUSHALL

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/adapter/CuckooFilterAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/adapter/CuckooFilterAdapter.kt
@@ -7,7 +7,7 @@ import com.dcd.server.core.common.spi.CountBloomFilterPort
 import com.dcd.server.core.common.service.exception.BloomFilterReservationException
 
 @Service
-class CuckooFilterServiceAdapter(
+class CuckooFilterAdapter(
     private val redissonClient: RedissonClient
 ) : CountBloomFilterPort {
     private val log = LoggerFactory.getLogger(this::class.simpleName)

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/adapter/CuckooFilterAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/adapter/CuckooFilterAdapter.kt
@@ -1,12 +1,12 @@
 package com.dcd.server.infrastructure.global.adapter
 
 import org.slf4j.LoggerFactory
-import org.springframework.stereotype.Service
 import org.redisson.api.RedissonClient
 import com.dcd.server.core.common.spi.CountBloomFilterPort
 import com.dcd.server.core.common.service.exception.BloomFilterReservationException
+import org.springframework.stereotype.Component
 
-@Service
+@Component
 class CuckooFilterAdapter(
     private val redissonClient: RedissonClient
 ) : CountBloomFilterPort {

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/adapter/CuckooFilterAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/adapter/CuckooFilterAdapter.kt
@@ -4,6 +4,7 @@ import org.slf4j.LoggerFactory
 import org.redisson.api.RedissonClient
 import com.dcd.server.core.common.spi.CountBloomFilterPort
 import com.dcd.server.core.common.service.exception.BloomFilterReservationException
+import org.redisson.client.RedisException
 import org.springframework.stereotype.Component
 
 @Component
@@ -36,8 +37,12 @@ class CuckooFilterAdapter(
             val cuckooFilter = redissonClient.getCuckooFilter<String>(filterName)
             cuckooFilter.remove(item)
         } catch (e: Exception) {
-            log.error("Error removing from Cuckoo Filter: {}", filterName, e)
-            false
+            if (e is RedisException && e.message?.contains("Not found") == true)
+                false
+            else {
+                log.error("Error removing from Cuckoo Filter: {}", filterName, e)
+                throw e
+            }
         }
     }
 

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/adapter/CuckooFilterServiceAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/adapter/CuckooFilterServiceAdapter.kt
@@ -3,8 +3,6 @@ package com.dcd.server.infrastructure.global.adapter
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.redisson.api.RedissonClient
-import org.redisson.client.RedisException
-import org.redisson.client.codec.StringCodec
 import com.dcd.server.core.common.spi.CountBloomFilterPort
 import com.dcd.server.core.common.service.exception.BloomFilterReservationException
 
@@ -14,18 +12,18 @@ class CuckooFilterServiceAdapter(
 ) : CountBloomFilterPort {
     private val log = LoggerFactory.getLogger(this::class.simpleName)
 
-    private val DEFAULT_CAPACITY = 10000L
+    private val DEFAULT_CAPACITY = 100000L
 
     override fun add(filterName: String, item: String): Boolean {
         return try {
             val cuckooFilter = redissonClient.getCuckooFilter<String>(filterName)
-            
+
             // CuckooFilter가 없으면 생성
-            if (!cuckooFilter.exists()) {
+            if (!cuckooFilter.isExists) {
                 cuckooFilter.init(DEFAULT_CAPACITY)
             }
-            
-            cuckooFilter.add(item)
+
+            cuckooFilter.addIfAbsent(item)
         } catch (e: Exception) {
             if (e is BloomFilterReservationException) throw e
             log.error("Error adding to Cuckoo Filter: {}", filterName, e)
@@ -39,7 +37,7 @@ class CuckooFilterServiceAdapter(
             cuckooFilter.remove(item)
         } catch (e: Exception) {
             log.error("Error removing from Cuckoo Filter: {}", filterName, e)
-            throw BloomFilterReservationException()
+            false
         }
     }
 

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/adapter/CuckooFilterServiceAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/adapter/CuckooFilterServiceAdapter.kt
@@ -2,45 +2,54 @@ package com.dcd.server.infrastructure.global.adapter
 
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import org.springframework.data.redis.core.StringRedisTemplate
+import org.redisson.api.RedissonClient
+import org.redisson.client.RedisException
+import org.redisson.client.codec.StringCodec
 import com.dcd.server.core.common.spi.CountBloomFilterPort
 import com.dcd.server.core.common.service.exception.BloomFilterReservationException
 
 @Service
 class CuckooFilterServiceAdapter(
-    private val redisTemplate: StringRedisTemplate
+    private val redissonClient: RedissonClient
 ) : CountBloomFilterPort {
     private val log = LoggerFactory.getLogger(this::class.simpleName)
 
-    override fun add(filterName: String, item: String): Boolean {
-        // 해당하는 Cuckoo Filter가 존재하지 않으면 생성
-        if (redisTemplate.hasKey(filterName).not()) {
-            redisTemplate.execute { connection ->
-                val result = connection.commands().execute("CF.RESERVE", filterName.toByteArray(), "100000".toByteArray()) as? String
-                if (result != "OK" && result?.contains("item exists") != true) {
-                    log.error("Failed to reserve Cuckoo Filter: {}", filterName)
-                    throw BloomFilterReservationException()
-                }
-            }
-        }
+    private val DEFAULT_CAPACITY = 10000L
 
-        return redisTemplate.execute { connection ->
-            val result = connection.commands().execute("CF.ADDNX", filterName.toByteArray(), item.toByteArray())
-            (result as? Long) == 1L
-        } ?: false
+    override fun add(filterName: String, item: String): Boolean {
+        return try {
+            val cuckooFilter = redissonClient.getCuckooFilter<String>(filterName)
+            
+            // CuckooFilter가 없으면 생성
+            if (!cuckooFilter.exists()) {
+                cuckooFilter.init(DEFAULT_CAPACITY)
+            }
+            
+            cuckooFilter.add(item)
+        } catch (e: Exception) {
+            if (e is BloomFilterReservationException) throw e
+            log.error("Error adding to Cuckoo Filter: {}", filterName, e)
+            throw BloomFilterReservationException()
+        }
     }
 
     override fun remove(filterName: String, item: String): Boolean {
-        return redisTemplate.execute { connection ->
-            val result = connection.commands().execute("CF.DEL", filterName.toByteArray(), item.toByteArray())
-            (result as? Long) == 1L
-        } ?: false
+        return try {
+            val cuckooFilter = redissonClient.getCuckooFilter<String>(filterName)
+            cuckooFilter.remove(item)
+        } catch (e: Exception) {
+            log.error("Error removing from Cuckoo Filter: {}", filterName, e)
+            throw BloomFilterReservationException()
+        }
     }
 
     override fun exists(filterName: String, item: String): Boolean {
-        return redisTemplate.execute { connection ->
-            val result = connection.commands().execute("CF.EXISTS", filterName.toByteArray(), item.toByteArray())
-            (result as? Long) == 1L
-        } ?: false
+        return try {
+            val cuckooFilter = redissonClient.getCuckooFilter<String>(filterName)
+            cuckooFilter.exists(item)
+        } catch (e: Exception) {
+            log.error("Error checking existence in Cuckoo Filter: {}", filterName, e)
+            throw BloomFilterReservationException()
+        }
     }
 }

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/adapter/RedissonLockAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/adapter/RedissonLockAdapter.kt
@@ -7,7 +7,7 @@ import org.slf4j.LoggerFactory
 import java.util.concurrent.TimeUnit
 
 @Service
-class RedissonLockServiceAdapter(
+class RedissonLockAdapter(
     private val redissonClient: RedissonClient
 ) : LockPort {
     private val log = LoggerFactory.getLogger(this::class.simpleName)

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/adapter/RedissonLockAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/adapter/RedissonLockAdapter.kt
@@ -2,11 +2,11 @@ package com.dcd.server.infrastructure.global.adapter
 
 import com.dcd.server.core.common.spi.LockPort
 import org.redisson.api.RedissonClient
-import org.springframework.stereotype.Service
 import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
 import java.util.concurrent.TimeUnit
 
-@Service
+@Component
 class RedissonLockAdapter(
     private val redissonClient: RedissonClient
 ) : LockPort {

--- a/src/test/kotlin/com/dcd/server/infrastructure/global/adapter/CuckooFilterAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/infrastructure/global/adapter/CuckooFilterAdapterTest.kt
@@ -9,8 +9,8 @@ import java.util.UUID
 
 @SpringBootTest
 @ActiveProfiles("test")
-class CuckooFilterServiceAdapterTest(
-    private val cuckooFilterAdapter: CuckooFilterServiceAdapter,
+class CuckooFilterAdapterTest(
+    private val cuckooFilterAdapter: CuckooFilterAdapter,
     private val redissonClient: RedissonClient
 ) : BehaviorSpec({
 

--- a/src/test/kotlin/com/dcd/server/infrastructure/global/adapter/CuckooFilterServiceAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/infrastructure/global/adapter/CuckooFilterServiceAdapterTest.kt
@@ -1,177 +1,185 @@
 package com.dcd.server.infrastructure.global.adapter
 
-import com.dcd.server.core.common.service.exception.BloomFilterReservationException
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
-import io.mockk.clearMocks
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.spyk
-import io.mockk.verify
+import org.redisson.api.RedissonClient
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.data.redis.connection.RedisCommands
-import org.springframework.data.redis.connection.RedisConnection
-import org.springframework.data.redis.core.RedisCallback
-import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.test.context.ActiveProfiles
+import java.util.UUID
 
 @SpringBootTest
 @ActiveProfiles("test")
 class CuckooFilterServiceAdapterTest(
-    rawTemplate: StringRedisTemplate
+    private val cuckooFilterAdapter: CuckooFilterServiceAdapter,
+    private val redissonClient: RedissonClient
 ) : BehaviorSpec({
-    val redisTemplate = spyk(rawTemplate)
-    val cuckooFilterService = CuckooFilterServiceAdapter(redisTemplate)
-    val redisConnection = spyk(redisTemplate.getConnectionFactory()!!.getConnection())
-    val redisCommands = spyk(redisConnection.commands())
 
-    beforeSpec {
-        // redisTemplate.execute() 호출 시 콜백을 직접 실행하도록 설정
-        every { redisTemplate.execute(any<RedisCallback<Any>>()) } answers {
-            val callback = firstArg<RedisCallback<Any>>()
-            callback.doInRedis(redisConnection)
+    val filterNamesToCleanup = mutableListOf<String>()
+
+    afterEach {
+        filterNamesToCleanup.forEach { filterName ->
+            try {
+                redissonClient.getCuckooFilter<String>(filterName).delete()
+            } catch (e: Exception) {
+                // 필터가 없는 경우 무시
+            }
         }
-        // redisConnection에서 commands() 호출 시 redisCommands 반환
-        every { redisConnection.commands() } returns redisCommands
+        filterNamesToCleanup.clear()
     }
 
     given("Cuckoo filter add 동작") {
 
-        `when`("필터가 존재하지 않으면 CF.RESERVE 호출 후 CF.ADDNX 성공") {
-            val filterName = "test-filter"
-            val item = "item"
+        `when`("필터가 존재하지 않으면 init 호출 후 add 성공") {
 
-            every { redisTemplate.hasKey(filterName) } returns false
-            every {
-                redisCommands.execute("CF.RESERVE", filterName.toByteArray(), "100000".toByteArray())
-            } returns "OK"
-            every {
-                redisCommands.execute("CF.ADDNX", filterName.toByteArray(), item.toByteArray())
-            } returns 1L
+            then("true를 반환해야 한다") {
+                val filterName = "test-filter-${UUID.randomUUID()}"
+                filterNamesToCleanup.add(filterName)
+                val item = "item"
 
-            then("true를 반환하고, CF.RESERVE와 CF.ADDNX가 호출되어야 한다") {
-                val result = cuckooFilterService.add(filterName, item)
-                
+                val result = cuckooFilterAdapter.add(filterName, item)
+
                 result shouldBe true
-                verify(exactly = 1) { redisTemplate.hasKey(filterName) }
-                verify(exactly = 1) { redisCommands.execute("CF.RESERVE", filterName.toByteArray(), "100000".toByteArray()) }
-                verify(exactly = 1) { redisCommands.execute("CF.ADDNX", filterName.toByteArray(), item.toByteArray()) }
+
+                // 필터가 생성되었는지 확인
+                val cuckooFilter = redissonClient.getCuckooFilter<String>(filterName)
+                cuckooFilter.isExists shouldBe true
+                cuckooFilter.exists(item) shouldBe true
             }
         }
 
-        `when`("필터가 이미 존재하면 CF.RESERVE를 생략하고 CF.ADDNX만 호출") {
-            val filterName = "test-filter"
-            val item = "item"
+        `when`("필터가 이미 존재하고 같은 아이템을 다시 추가하면") {
 
-            clearMocks(redisTemplate, redisCommands, answers = false)
-            every { redisTemplate.hasKey(filterName) } returns true
-            every {
-                redisCommands.execute("CF.ADDNX", filterName.toByteArray(), item.toByteArray())
-            } returns 0L
+            then("첫 번째는 true, 두 번째는 false를 반환해야 한다") {
+                val filterName = "test-filter-${UUID.randomUUID()}"
+                filterNamesToCleanup.add(filterName)
+                val item = "item"
 
-            then("false를 반환하고, CF.RESERVE는 호출되지 않아야 한다") {
-                val result = cuckooFilterService.add(filterName, item)
-                
-                result shouldBe false
-                verify(exactly = 1) { redisTemplate.hasKey(filterName) }
-                verify(exactly = 0) { redisCommands.execute("CF.RESERVE", any(), any()) }
-                verify(exactly = 1) { redisCommands.execute("CF.ADDNX", filterName.toByteArray(), item.toByteArray()) }
+                val firstAdd = cuckooFilterAdapter.add(filterName, item)
+                val secondAdd = cuckooFilterAdapter.add(filterName, item)
+
+                firstAdd shouldBe true
+                secondAdd shouldBe false
             }
         }
 
-        `when`("필터 예약(CF.RESERVE) 실패 시 예외 발생") {
-            val filterName = "test-filter"
-            val item = "item"
+        `when`("필터에 여러 아이템을 추가하면") {
 
-            clearMocks(redisTemplate, redisCommands, answers = false)
-            every { redisTemplate.hasKey(filterName) } returns false
-            every {
-                redisCommands.execute("CF.RESERVE", filterName.toByteArray(), "100000".toByteArray())
-            } returns "ERROR"
+            then("모두 true를 반환해야 한다") {
+                val filterName = "test-filter-${UUID.randomUUID()}"
+                filterNamesToCleanup.add(filterName)
+                val item1 = "item1"
+                val item2 = "item2"
 
-            then("BloomFilterReservationException 예외가 발생해야 하고, CF.ADDNX는 호출되지 않아야 한다") {
-                shouldThrow<BloomFilterReservationException> {
-                    cuckooFilterService.add(filterName, item)
-                }
-                
-                verify(exactly = 1) { redisTemplate.hasKey(filterName) }
-                verify(exactly = 1) { redisCommands.execute("CF.RESERVE", filterName.toByteArray(), "100000".toByteArray()) }
-                verify(exactly = 0) { redisCommands.execute("CF.ADDNX", any(), any()) }
+                val result1 = cuckooFilterAdapter.add(filterName, item1)
+                val result2 = cuckooFilterAdapter.add(filterName, item2)
+
+                result1 shouldBe true
+                result2 shouldBe true
+
+                val cuckooFilter = redissonClient.getCuckooFilter<String>(filterName)
+                cuckooFilter.exists(item1) shouldBe true
+                cuckooFilter.exists(item2) shouldBe true
             }
         }
     }
 
     given("Cuckoo filter remove 동작") {
 
-        `when`("CF.DEL이 1을 반환하면 true") {
-            val filterName = "test-filter"
-            val item = "item"
+        `when`("존재하는 아이템을 삭제하면") {
 
-            clearMocks(redisTemplate, redisCommands, answers = false)
-            every {
-                redisCommands.execute("CF.DEL", filterName.toByteArray(), item.toByteArray())
-            } returns 1L
+            then("true를 반환해야 한다") {
+                val filterName = "test-filter-${UUID.randomUUID()}"
+                filterNamesToCleanup.add(filterName)
+                val item = "item"
 
-            then("true를 반환하고, CF.DEL이 호출되어야 한다") {
-                val result = cuckooFilterService.remove(filterName, item)
-                
+                cuckooFilterAdapter.add(filterName, item)
+                val result = cuckooFilterAdapter.remove(filterName, item)
+
                 result shouldBe true
-                verify(exactly = 1) { redisCommands.execute("CF.DEL", filterName.toByteArray(), item.toByteArray()) }
+
+                val cuckooFilter = redissonClient.getCuckooFilter<String>(filterName)
+                cuckooFilter.exists(item) shouldBe false
             }
         }
 
-        `when`("CF.DEL이 0을 반환하면 false") {
-            val filterName = "test-filter"
-            val item = "item"
-
-            clearMocks(redisTemplate, redisCommands, answers = false)
-            every {
-                redisCommands.execute("CF.DEL", filterName.toByteArray(), item.toByteArray())
-            } returns 0L
+        `when`("존재하지 않는 아이템을 삭제하면") {
 
             then("false를 반환해야 한다") {
-                val result = cuckooFilterService.remove(filterName, item)
-                
+                val filterName = "test-filter-${UUID.randomUUID()}"
+                filterNamesToCleanup.add(filterName)
+                val item = "non-existent-item"
+
+                cuckooFilterAdapter.add(filterName, "other-item")
+                val result = cuckooFilterAdapter.remove(filterName, item)
+
                 result shouldBe false
-                verify(exactly = 1) { redisCommands.execute("CF.DEL", filterName.toByteArray(), item.toByteArray()) }
+            }
+        }
+
+        `when`("필터가 존재하지 않는 상태에서 삭제하면") {
+            then("false를 반환해야 한다") {
+                val filterName = "test-filter-${UUID.randomUUID()}"
+                filterNamesToCleanup.add(filterName)
+                val item = "item"
+
+                val result = cuckooFilterAdapter.remove(filterName, item)
+
+                result shouldBe false
             }
         }
     }
 
     given("Cuckoo filter exists 동작") {
 
-        `when`("CF.EXISTS가 1을 반환하면 true") {
-            val filterName = "test-filter"
-            val item = "item"
-
-            clearMocks(redisTemplate, redisCommands, answers = false)
-            every {
-                redisCommands.execute("CF.EXISTS", filterName.toByteArray(), item.toByteArray())
-            } returns 1L
-
+        `when`("존재하는 아이템을 확인하면") {
             then("true를 반환해야 한다") {
-                val result = cuckooFilterService.exists(filterName, item)
-                
+                val filterName = "test-filter-${UUID.randomUUID()}"
+                filterNamesToCleanup.add(filterName)
+                val item = "item"
+
+                cuckooFilterAdapter.add(filterName, item)
+                val result = cuckooFilterAdapter.exists(filterName, item)
+
                 result shouldBe true
-                verify(exactly = 1) { redisCommands.execute("CF.EXISTS", filterName.toByteArray(), item.toByteArray()) }
             }
         }
 
-        `when`("CF.EXISTS가 0을 반환하면 false") {
-            val filterName = "test-filter"
-            val item = "item"
-
-            clearMocks(redisTemplate, redisCommands, answers = false)
-            every {
-                redisCommands.execute("CF.EXISTS", filterName.toByteArray(), item.toByteArray())
-            } returns 0L
-
+        `when`("존재하지 않는 아이템을 확인하면") {
             then("false를 반환해야 한다") {
-                val result = cuckooFilterService.exists(filterName, item)
-                
+                val filterName = "test-filter-${UUID.randomUUID()}"
+                filterNamesToCleanup.add(filterName)
+                val item = "non-existent-item"
+
+                cuckooFilterAdapter.add(filterName, "other-item")
+                val result = cuckooFilterAdapter.exists(filterName, item)
+
                 result shouldBe false
-                verify(exactly = 1) { redisCommands.execute("CF.EXISTS", filterName.toByteArray(), item.toByteArray()) }
+            }
+        }
+
+        `when`("필터가 존재하지 않는 상태에서 확인하면") {
+            then("false를 반환해야 한다") {
+                val filterName = "test-filter-${UUID.randomUUID()}"
+                filterNamesToCleanup.add(filterName)
+                val item = "item"
+
+                val result = cuckooFilterAdapter.exists(filterName, item)
+
+                result shouldBe false
+            }
+        }
+
+        `when`("아이템 추가 후 삭제하고 확인하면") {
+            then("false를 반환해야 한다") {
+                val filterName = "test-filter-${UUID.randomUUID()}"
+                filterNamesToCleanup.add(filterName)
+                val item = "item"
+
+                cuckooFilterAdapter.add(filterName, item)
+                cuckooFilterAdapter.remove(filterName, item)
+                val result = cuckooFilterAdapter.exists(filterName, item)
+
+                result shouldBe false
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/infrastructure/global/adapter/RedissonLockAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/infrastructure/global/adapter/RedissonLockAdapterTest.kt
@@ -1,6 +1,5 @@
-package com.dcd.server.core.common.service
+package com.dcd.server.infrastructure.global.adapter
 
-import com.dcd.server.infrastructure.global.adapter.RedissonLockServiceAdapter
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.assertions.throwables.shouldThrow
@@ -14,10 +13,10 @@ import java.util.concurrent.TimeUnit
 import org.redisson.api.RLock
 import org.redisson.api.RedissonClient
 
-class RedissonLockServiceImplTest : BehaviorSpec({
+class RedissonLockAdapterTest : BehaviorSpec({
     val redissonClient = mockk<RedissonClient>()
     val lock = mockk<RLock>()
-    val lockService = RedissonLockServiceAdapter(redissonClient)
+    val lockService = RedissonLockAdapter(redissonClient)
 
     Given("락 획득이 성공했을 때") {
         clearAllMocks()

--- a/src/test/kotlin/com/dcd/server/infrastructure/global/adapter/RedissonLockRaceConditionTest.kt
+++ b/src/test/kotlin/com/dcd/server/infrastructure/global/adapter/RedissonLockRaceConditionTest.kt
@@ -1,7 +1,6 @@
-package com.dcd.server.core.common.service
+package com.dcd.server.infrastructure.global.adapter
 
 import com.dcd.server.core.common.spi.LockPort
-import com.dcd.server.infrastructure.global.adapter.RedissonLockServiceAdapter
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import java.util.concurrent.CountDownLatch
@@ -10,6 +9,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
+import java.util.concurrent.TimeUnit
 
 @Transactional
 @SpringBootTest
@@ -49,9 +49,9 @@ class RedissonLockRaceConditionTest(
                 }
             }
 
-            readyLatch.await(5, java.util.concurrent.TimeUnit.SECONDS) shouldBe true
+            readyLatch.await(5, TimeUnit.SECONDS) shouldBe true
             startLatch.countDown()
-            endLatch.await(5, java.util.concurrent.TimeUnit.SECONDS) shouldBe true
+            endLatch.await(5, TimeUnit.SECONDS) shouldBe true
 
             executor.shutdown()
 


### PR DESCRIPTION
## 개요
* 현재 Redis 모듈 명령에서 CuckooFilter와 같은 모듈 명령을 실행할 수 없는 현상을 수정합니다.
## 작업내용
* redisson 최신 버전을 가져오게끔 수정
* CuckooFilterAdapter에서 RedissonClient를 사용하도록 수정
* docker-compose로 사용할 redis와 mariadb 이미지 태그 명시
* CuckooFilterServiceAdapterTest를 통합테스트로 수정
* Adapter 네이밍 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [ ] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Redis 및 MariaDB 인프라 버전 업그레이드: Redis 8.6.2, MariaDB 11.8.2로 업데이트
  * Redisson 라이브러리 의존성 추가(버전 4.3.0)
  * Redis 기반 필터링 메커니즘 내부 구조 개선

* **Tests**
  * 업데이트된 인프라 구현에 맞춘 테스트 스위트 개선 및 정리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->