### PR TITLE
🔀 :: [#759] - 로그인및 회원가입시 bloomFilter를 사용하도록 리펙토링

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/SignInUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/SignInUseCase.kt
@@ -2,19 +2,25 @@ package com.dcd.server.core.domain.auth.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.common.service.SecurityService
+import com.dcd.server.core.common.spi.CountBloomFilterPort
 import com.dcd.server.core.domain.auth.dto.request.SignInReqDto
 import com.dcd.server.core.domain.auth.dto.response.TokenResDto
 import com.dcd.server.core.domain.auth.exception.UserNotFoundException
 import com.dcd.server.core.domain.auth.spi.GenerateTokenPort
+import com.dcd.server.core.domain.user.model.User
 import com.dcd.server.core.domain.user.spi.QueryUserPort
 
 @UseCase
 class SignInUseCase(
     private val queryUserPort: QueryUserPort,
     private val securityService: SecurityService,
-    private val generateTokenPort: GenerateTokenPort
+    private val generateTokenPort: GenerateTokenPort,
+    private val bloomFilterPort: CountBloomFilterPort
 ) {
     fun execute(signInReqDto: SignInReqDto): TokenResDto {
+        if (!bloomFilterPort.exists(User.USER_INFO_BLOOM_FILTER, signInReqDto.email))
+            throw UserNotFoundException()
+
         val user = (queryUserPort.findByEmail(signInReqDto.email)
             ?: throw UserNotFoundException()) // 해당 유저를 찾을 수 없음
         securityService.matchPassword(signInReqDto.password, user.password)

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/SignUpUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/SignUpUseCase.kt
@@ -3,10 +3,12 @@ package com.dcd.server.core.domain.auth.usecase
 import com.dcd.server.core.common.annotation.CheckEmailCertificate
 import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.common.service.SecurityService
+import com.dcd.server.core.common.spi.CountBloomFilterPort
 import com.dcd.server.core.domain.auth.dto.extension.toEntity
 import com.dcd.server.core.domain.auth.dto.request.SignUpReqDto
 import com.dcd.server.core.domain.auth.exception.AlreadyExistsUserException
 import com.dcd.server.core.domain.auth.model.enums.EmailAuthUsage
+import com.dcd.server.core.domain.user.model.User
 import com.dcd.server.core.domain.user.spi.CommandUserPort
 import com.dcd.server.core.domain.user.spi.QueryUserPort
 
@@ -14,11 +16,16 @@ import com.dcd.server.core.domain.user.spi.QueryUserPort
 class SignUpUseCase(
     private val securityService: SecurityService,
     private val commandUserPort: CommandUserPort,
-    private val queryUserPort: QueryUserPort
+    private val queryUserPort: QueryUserPort,
+    private val bloomFilterPort: CountBloomFilterPort
 ) {
     @CheckEmailCertificate("#signUpReqDto.email", EmailAuthUsage.SIGNUP)
     fun execute(signUpReqDto: SignUpReqDto) {
-        if(queryUserPort.existsByEmail(signUpReqDto.email))
+        val email = signUpReqDto.email
+
+        //유저 존재 여부 검사시 bloomFilter의 존재여부 판단을 우선적으로 판단함
+        val bloomFilterQueryResult = bloomFilterPort.exists(User.USER_INFO_BLOOM_FILTER, email)
+        if(bloomFilterQueryResult && queryUserPort.existsByEmail(email))
             throw AlreadyExistsUserException()
         val encodePassword = securityService.encodePassword(signUpReqDto.password)
         val user = signUpReqDto.toEntity(encodePassword)

--- a/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/SignUpUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/auth/usecase/SignUpUseCase.kt
@@ -27,8 +27,12 @@ class SignUpUseCase(
         val bloomFilterQueryResult = bloomFilterPort.exists(User.USER_INFO_BLOOM_FILTER, email)
         if(bloomFilterQueryResult && queryUserPort.existsByEmail(email))
             throw AlreadyExistsUserException()
+
         val encodePassword = securityService.encodePassword(signUpReqDto.password)
         val user = signUpReqDto.toEntity(encodePassword)
         commandUserPort.save(user)
+
+        // 유저 가입후 bloomFilter에 유저 이메일 저장
+        bloomFilterPort.add(User.USER_INFO_BLOOM_FILTER, user.email)
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/user/model/User.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/user/model/User.kt
@@ -12,6 +12,10 @@ data class User(
     val roles: MutableList<Role>,
     val status: Status
 ) {
+    companion object {
+        const val USER_INFO_BLOOM_FILTER = "user-info-bloom-filter"
+    }
+
     override fun equals(other: Any?): Boolean {
         if (other !is User) return false
         return this.id == other.id

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/adapter/CuckooFilterAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/adapter/CuckooFilterAdapter.kt
@@ -13,7 +13,9 @@ class CuckooFilterAdapter(
 ) : CountBloomFilterPort {
     private val log = LoggerFactory.getLogger(this::class.simpleName)
 
-    private val DEFAULT_CAPACITY = 100000L
+    companion object {
+        private const val DEFAULT_CAPACITY = 100000L
+    }
 
     override fun add(filterName: String, item: String): Boolean {
         return try {
@@ -21,14 +23,19 @@ class CuckooFilterAdapter(
 
             // CuckooFilter가 없으면 생성
             if (!cuckooFilter.isExists) {
-                cuckooFilter.init(DEFAULT_CAPACITY)
+                try {
+                    cuckooFilter.init(DEFAULT_CAPACITY)
+                } catch (e: Exception) {
+                    log.error("Error initializing Cuckoo Filter: {}", filterName, e)
+                    throw BloomFilterReservationException()
+                }
             }
 
             cuckooFilter.addIfAbsent(item)
         } catch (e: Exception) {
             if (e is BloomFilterReservationException) throw e
             log.error("Error adding to Cuckoo Filter: {}", filterName, e)
-            throw BloomFilterReservationException()
+            true
         }
     }
 
@@ -37,12 +44,9 @@ class CuckooFilterAdapter(
             val cuckooFilter = redissonClient.getCuckooFilter<String>(filterName)
             cuckooFilter.remove(item)
         } catch (e: Exception) {
-            if (e is RedisException && e.message?.contains("Not found") == true)
-                false
-            else {
-                log.error("Error removing from Cuckoo Filter: {}", filterName, e)
-                throw e
-            }
+            // 에러 발생시 로깅후 false positive
+            log.error("Error removing from Cuckoo Filter: {}", filterName, e)
+            true
         }
     }
 
@@ -52,7 +56,7 @@ class CuckooFilterAdapter(
             cuckooFilter.exists(item)
         } catch (e: Exception) {
             log.error("Error checking existence in Cuckoo Filter: {}", filterName, e)
-            throw BloomFilterReservationException()
+            true
         }
     }
 }

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/SignInUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/SignInUseCaseTest.kt
@@ -2,10 +2,12 @@ package com.dcd.server.core.domain.auth.usecase
 
 import com.dcd.server.ServerApplication
 import com.dcd.server.core.common.service.exception.PasswordNotCorrectException
+import com.dcd.server.core.common.spi.CountBloomFilterPort
 import com.dcd.server.core.domain.auth.dto.request.SignInReqDto
 import com.dcd.server.core.domain.auth.dto.response.TokenResDto
 import com.dcd.server.core.domain.auth.exception.UserNotFoundException
 import com.dcd.server.core.domain.auth.spi.GenerateTokenPort
+import com.dcd.server.core.domain.user.model.User
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
@@ -19,12 +21,20 @@ import java.time.LocalDateTime
 @SpringBootTest(classes = [ServerApplication::class])
 class SignInUseCaseTest(
     private val signInUseCase: SignInUseCase,
+    private val bloomFilterPort: CountBloomFilterPort,
     @MockkBean
     private val generateTokenPort: GenerateTokenPort
 ) : BehaviorSpec({
 
     given("이메일이 주어지고") {
         val testEmail = "testEmail"
+
+        beforeContainer {
+            bloomFilterPort.add(User.USER_INFO_BLOOM_FILTER, testEmail)
+        }
+        afterContainer {
+            bloomFilterPort.remove(User.USER_INFO_BLOOM_FILTER, testEmail)
+        }
 
         `when`("올바른 패스워드로 실행할때") {
             val accessTokenExp = LocalDateTime.of(2023, 9, 5, 8, 3)
@@ -60,7 +70,7 @@ class SignInUseCaseTest(
         }
     }
 
-    given("존재하지 않는 이메일이 주어지고") {
+    given("블룸 필터에 존재하지 않는 이메일이 주어지고") {
         val testEmail = "notFoundEmail"
         val testPassword = "password"
 
@@ -70,6 +80,27 @@ class SignInUseCaseTest(
             then("해당 유저가 없을때 UserNotFoundException을 반환해야함") {
                 shouldThrow<UserNotFoundException> {
                     signInUseCase.execute(requestDto)
+                }
+            }
+        }
+    }
+
+    given("블룸 필터에서 거짓 긍정 문제가 발생하는 경우") {
+        val testEmail = "falsePositiveEmail"
+        val testPassword = "password"
+
+        beforeContainer {
+            bloomFilterPort.add(User.USER_INFO_BLOOM_FILTER, testEmail)
+        }
+        afterContainer {
+            bloomFilterPort.remove(User.USER_INFO_BLOOM_FILTER, testEmail)
+        }
+
+        `when`("usecase를 실행하면") {
+
+            then("DB 조회에서 막혀야함") {
+                shouldThrow<UserNotFoundException> {
+                    signInUseCase.execute(SignInReqDto(testEmail, testPassword))
                 }
             }
         }

--- a/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/SignUpUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/auth/usecase/SignUpUseCaseTest.kt
@@ -1,11 +1,13 @@
 package com.dcd.server.core.domain.auth.usecase
 
 import com.dcd.server.core.common.aop.exception.NotCertificateEmailException
+import com.dcd.server.core.common.spi.CountBloomFilterPort
 import com.dcd.server.core.domain.auth.dto.request.SignUpReqDto
 import com.dcd.server.core.domain.auth.exception.AlreadyExistsUserException
 import com.dcd.server.core.domain.auth.model.EmailAuth
 import com.dcd.server.core.domain.auth.model.enums.EmailAuthUsage
 import com.dcd.server.core.domain.auth.spi.CommandEmailAuthPort
+import com.dcd.server.core.domain.user.model.User
 import com.dcd.server.core.domain.user.spi.QueryUserPort
 import com.dcd.server.persistence.auth.repository.EmailAuthRepository
 import io.kotest.assertions.throwables.shouldThrow
@@ -20,12 +22,13 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional
 @SpringBootTest
 @ActiveProfiles("test")
-class SignupUseCaseTest(
+class SignUpUseCaseTest(
     private val signUpUseCase: SignUpUseCase,
     private val commandEmailAuthPort: CommandEmailAuthPort,
     private val emailAuthRepository: EmailAuthRepository,
     private val queryUserPort: QueryUserPort,
-    private val passwordEncoder: PasswordEncoder
+    private val passwordEncoder: PasswordEncoder,
+    private val bloomFilterPort: CountBloomFilterPort
 ) : BehaviorSpec({
 
     val targetEmail = "targetEmail"
@@ -47,6 +50,14 @@ class SignupUseCaseTest(
         val testEmail = "testEmail"
         val testName = "testName"
         val testPassword = "testPassword"
+
+        beforeContainer {
+            bloomFilterPort.add(User.USER_INFO_BLOOM_FILTER, testEmail)
+        }
+        afterContainer {
+            bloomFilterPort.remove(User.USER_INFO_BLOOM_FILTER, testEmail)
+            bloomFilterPort.remove(User.USER_INFO_BLOOM_FILTER, targetEmail)
+        }
 
         `when`("이메일 인증을 하지 않은 유저가 실행할때") {
             val request = SignUpReqDto(testEmail, testPassword, testName)
@@ -82,6 +93,10 @@ class SignupUseCaseTest(
                 result?.email shouldBe targetEmail
                 result?.name shouldBe testName
                 passwordEncoder.matches(request.password, result?.password) shouldBe true
+            }
+
+            then("유저 정보 bloomFilter에 유저 정보가 존재해야함") {
+                bloomFilterPort.exists(User.USER_INFO_BLOOM_FILTER, targetEmail) shouldBe true
             }
         }
 

--- a/src/test/kotlin/com/dcd/server/infrastructure/global/adapter/CuckooFilterAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/infrastructure/global/adapter/CuckooFilterAdapterTest.kt
@@ -117,14 +117,14 @@ class CuckooFilterAdapterTest(
         }
 
         `when`("필터가 존재하지 않는 상태에서 삭제하면") {
-            then("false를 반환해야 한다") {
+            then("true를 반환해야 한다") {
                 val filterName = "test-filter-${UUID.randomUUID()}"
                 filterNamesToCleanup.add(filterName)
                 val item = "item"
 
                 val result = cuckooFilterAdapter.remove(filterName, item)
 
-                result shouldBe false
+                result shouldBe true
             }
         }
     }


### PR DESCRIPTION
## 개요
* 로그인및 회원가입시 bloomFilter를 사용하도록 리펙토링합니다.
## 작업내용
* User 도메인 클래스에 bloom filter 이름을 상수로 선언
* 회원가입시 bloomFilter를 검증하도록 리펙토링
* 회원가입이 정상적으로 이루어지고, bloomFilter에 정보를 삽입하는 로직 추가
* SignInUseCaseTest에 bloomFilter 관련 테스트 케이스 추가
* SignUpUseCaseTest에 bloomFilter 관련 테스트 케이스 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **최적화**
  * 회원가입 및 로그인에서 이메일 사전 검증을 도입해 성능과 응답성을 개선
  * 일부 오류 상황 처리 로직을 변경해 검증/삭제 동작의 안정성 향상

* **테스트**
  * 인증 플로우 관련 테스트를 보강하고 경계/오탐 시나리오를 추가 검증
<!-- end of auto-generated comment: release notes by coderabbit.ai -->