### PR TITLE
:twisted_rightwards_arrows: :: [#763] - 볼륨 사이즈 추가

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
@@ -24,7 +24,7 @@ enum class ErrorCode(
     NOT_CONNECTED_DOMAIN("도메인이 애플리케이션에 연결되어 있지 않음", 400),
     ALREADY_EXISTS_VOLUME("이미 존재하는 볼륨", 400),
     ALREADY_EXISTS_VOLUME_MOUNT("볼륨 마운트가 존재합니다.", 400),
-    INVALID_VOLUME_OPTION("볼륨 설정이 올바르지않음", 400)
+    INVALID_VOLUME_OPTION("볼륨 설정이 올바르지않음", 400),
 
     UNAUTHORIZED("권한이 없음", 401),
     EXPIRED_TOKEN("토큰이 만료됨", 401),

--- a/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
@@ -24,6 +24,7 @@ enum class ErrorCode(
     NOT_CONNECTED_DOMAIN("도메인이 애플리케이션에 연결되어 있지 않음", 400),
     ALREADY_EXISTS_VOLUME("이미 존재하는 볼륨", 400),
     ALREADY_EXISTS_VOLUME_MOUNT("볼륨 마운트가 존재합니다.", 400),
+    INVALID_VOLUME_OPTION("볼륨 설정이 올바르지않음", 400)
 
     UNAUTHORIZED("권한이 없음", 401),
     EXPIRED_TOKEN("토큰이 만료됨", 401),

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/dto/extension/VolumeDtoExtension.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/dto/extension/VolumeDtoExtension.kt
@@ -16,6 +16,8 @@ fun CreateVolumeReqDto.toEntity(workspace: Workspace): Volume =
         id = UUID.randomUUID(),
         name = this.name,
         description = this.description,
+        size = this.size,
+        sizeUnit = this.sizeUnit,
         workspace = workspace,
     )
 
@@ -24,6 +26,8 @@ fun UpdateVolumeReqDto.toEntity(volume: Volume): Volume =
         id = volume.id,
         name = this.name,
         description = this.description,
+        size = this.size,
+        sizeUnit = this.sizeUnit,
         workspace = volume.workspace,
     )
 
@@ -31,7 +35,9 @@ fun Volume.toResDto(): VolumeSimpleResDto =
     VolumeSimpleResDto(
         id = this.id,
         name = this.name,
-        description = this.description
+        description = this.description,
+        size = this.size,
+        sizeUnit = this.sizeUnit
     )
 
 fun Volume.toDetailResDto(volumeMountList: List<VolumeMount>): VolumeDetailResDto =
@@ -39,6 +45,8 @@ fun Volume.toDetailResDto(volumeMountList: List<VolumeMount>): VolumeDetailResDt
         id = this.id,
         name = this.name,
         description = this.description,
+        size = this.size,
+        sizeUnit = this.sizeUnit,
         mountList = volumeMountList.map { it.toResDto() }
     )
 

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/dto/request/CreateVolumeReqDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/dto/request/CreateVolumeReqDto.kt
@@ -1,6 +1,10 @@
 package com.dcd.server.core.domain.volume.dto.request
 
+import com.dcd.server.core.domain.volume.model.enums.VolumeSizeUnit
+
 data class CreateVolumeReqDto(
     val name: String,
-    val description: String
+    val description: String,
+    val size: Long? = null,
+    val sizeUnit: VolumeSizeUnit? = null
 )

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/dto/request/UpdateVolumeReqDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/dto/request/UpdateVolumeReqDto.kt
@@ -1,6 +1,10 @@
 package com.dcd.server.core.domain.volume.dto.request
 
+import com.dcd.server.core.domain.volume.model.enums.VolumeSizeUnit
+
 data class UpdateVolumeReqDto(
     val name: String,
-    val description: String
+    val description: String,
+    val size: Long? = null,
+    val sizeUnit: VolumeSizeUnit? = null
 )

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/dto/response/VolumeDetailResDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/dto/response/VolumeDetailResDto.kt
@@ -1,10 +1,13 @@
 package com.dcd.server.core.domain.volume.dto.response
 
+import com.dcd.server.core.domain.volume.model.enums.VolumeSizeUnit
 import java.util.UUID
 
 data class VolumeDetailResDto(
     val id: UUID,
     val name: String,
     val description: String,
+    val size: Long?,
+    val sizeUnit: VolumeSizeUnit?,
     val mountList: List<VolumeMountResDto>
 )

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/dto/response/VolumeSimpleResDto.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/dto/response/VolumeSimpleResDto.kt
@@ -1,9 +1,12 @@
 package com.dcd.server.core.domain.volume.dto.response
 
+import com.dcd.server.core.domain.volume.model.enums.VolumeSizeUnit
 import java.util.UUID
 
 data class VolumeSimpleResDto(
     val id: UUID,
     val name: String,
-    val description: String
+    val description: String,
+    val size: Long?,
+    val sizeUnit: VolumeSizeUnit?
 )

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/exception/InvalidVolumeOptionException.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/exception/InvalidVolumeOptionException.kt
@@ -1,6 +1,6 @@
 package com.dcd.server.core.domain.volume.exception
 
-import com.dcd.server.core.common.exception.BasicException
-import com.dcd.server.core.common.exception.ErrorCode
+import com.dcd.server.core.common.error.BasicException
+import com.dcd.server.core.common.error.ErrorCode
 
 class InvalidVolumeOptionException : BasicException(ErrorCode.INVALID_VOLUME_OPTION)

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/exception/InvalidVolumeOptionException.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/exception/InvalidVolumeOptionException.kt
@@ -1,0 +1,6 @@
+package com.dcd.server.core.domain.volume.exception
+
+import com.dcd.server.core.common.exception.BasicException
+import com.dcd.server.core.common.exception.ErrorCode
+
+class InvalidVolumeOptionException : BasicException(ErrorCode.INVALID_VOLUME_OPTION)

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/model/Volume.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/model/Volume.kt
@@ -1,12 +1,15 @@
 package com.dcd.server.core.domain.volume.model
 
 import com.dcd.server.core.domain.workspace.model.Workspace
+import com.dcd.server.core.domain.volume.model.enums.VolumeSizeUnit
 import java.util.UUID
 
 class Volume(
     val id: UUID,
     val name: String,
     val description: String,
+    val size: Long? = null,
+    val sizeUnit: VolumeSizeUnit? = null, // size가 지정되었는데 null인 경우 기본 단위는 byte로 간주
     val workspace: Workspace
 ) {
     val volumeName: String = "${name.replace(" ", "_")}-$id"

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/model/enums/VolumeSizeUnit.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/model/enums/VolumeSizeUnit.kt
@@ -1,0 +1,8 @@
+package com.dcd.server.core.domain.volume.model.enums
+
+enum class VolumeSizeUnit(val symbol: String) {
+    BYTES("b"),
+    KB("k"),
+    MB("m"),
+    GB("g")
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/service/impl/CreateDockerVolumeServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/service/impl/CreateDockerVolumeServiceImpl.kt
@@ -13,7 +13,7 @@ class CreateDockerVolumeServiceImpl(
     override fun create(volume: Volume) {
         StringBuilder().apply {
             append("docker volume create")
-            volume.size?.let { append(" --opt size=${it}${volume.sizeUnit?.value ?: "b"}") }
+            volume.size?.let { append(" --opt size=${it}${volume.sizeUnit?.symbol ?: "b"}") }
             append(" ${volume.volumeName}")
         }.toString().also { command ->
             val commandResult = commandPort.executeShellCommand(command)

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/service/impl/CreateDockerVolumeServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/service/impl/CreateDockerVolumeServiceImpl.kt
@@ -13,7 +13,7 @@ class CreateDockerVolumeServiceImpl(
     override fun create(volume: Volume) {
         StringBuilder().apply {
             append("docker volume create")
-            volume.size?.let { append(" --opt size=${it}${volume.sizeUnit?.symbol ?: "b"}") }
+            volume.size?.let { append(" --opt o=size=${it}${volume.sizeUnit?.symbol ?: "b"}") }
             append(" ${volume.volumeName}")
         }.toString().also { command ->
             val commandResult = commandPort.executeShellCommand(command)

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/service/impl/CreateDockerVolumeServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/service/impl/CreateDockerVolumeServiceImpl.kt
@@ -11,9 +11,14 @@ class CreateDockerVolumeServiceImpl(
     private val commandPort: CommandPort
 ) : CreateVolumeService {
     override fun create(volume: Volume) {
-        val commandResult = commandPort.executeShellCommand("docker volume create ${volume.volumeName}")
-
-        if (commandResult.exitValue != 0)
-            throw VolumeCreationFailureException()
+        StringBuilder().apply {
+            append("docker volume create")
+            volume.size?.let { append(" --opt size=${it}${volume.sizeUnit?.value ?: "b"}") }
+            append(" ${volume.volumeName}")
+        }.toString().also { command ->
+            val commandResult = commandPort.executeShellCommand(command)
+            if (commandResult.exitValue != 0)
+                throw VolumeCreationFailureException()
+        }
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/usecase/CreateVolumeUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/usecase/CreateVolumeUseCase.kt
@@ -5,6 +5,7 @@ import com.dcd.server.core.common.data.WorkspaceInfo
 import com.dcd.server.core.domain.volume.dto.extension.toEntity
 import com.dcd.server.core.domain.volume.dto.request.CreateVolumeReqDto
 import com.dcd.server.core.domain.volume.exception.AlreadyExistsVolumeException
+import com.dcd.server.core.domain.volume.exception.InvalidVolumeOptionException
 import com.dcd.server.core.domain.volume.service.CreateVolumeService
 import com.dcd.server.core.domain.volume.spi.CommandVolumePort
 import com.dcd.server.core.domain.volume.spi.QueryVolumePort
@@ -20,6 +21,9 @@ class CreateVolumeUseCase(
     fun execute(createVolumeReqDto: CreateVolumeReqDto) {
         val workspace = (workspaceInfo.workspace
             ?: throw WorkspaceNotFoundException())
+
+        if(createVolumeReqDto.size == null && createVolumeReqDto.sizeUnit != null)
+            throw InvalidVolumeOptionException()
 
         val existsVolume = queryVolumePort.existsVolumeByNameAndWorkspace(createVolumeReqDto.name, workspace)
         if (existsVolume)

--- a/src/main/kotlin/com/dcd/server/core/domain/volume/usecase/UpdateVolumeUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/volume/usecase/UpdateVolumeUseCase.kt
@@ -6,6 +6,7 @@ import com.dcd.server.core.domain.volume.dto.extension.toEntity
 import com.dcd.server.core.domain.volume.dto.request.UpdateVolumeReqDto
 import com.dcd.server.core.domain.volume.exception.AlreadyExistsVolumeMountException
 import com.dcd.server.core.domain.volume.exception.VolumeNotFoundException
+import com.dcd.server.core.domain.volume.exception.InvalidVolumeOptionException
 import com.dcd.server.core.domain.volume.service.CopyVolumeService
 import com.dcd.server.core.domain.volume.service.CreateVolumeService
 import com.dcd.server.core.domain.volume.service.DeleteVolumeService
@@ -32,6 +33,9 @@ class UpdateVolumeUseCase(
 
         if (workspace != volume.workspace)
             throw VolumeNotFoundException()
+
+        if(request.size == null && request.sizeUnit != null)
+            throw InvalidVolumeOptionException()
 
         val volumeMountList = queryVolumePort.findAllMountByVolume(volume)
         if (volumeMountList.isNotEmpty())

--- a/src/main/kotlin/com/dcd/server/persistence/volume/adapter/VolumeAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/volume/adapter/VolumeAdapter.kt
@@ -14,6 +14,8 @@ fun Volume.toEntity(): VolumeJpaEntity =
         id = this.id,
         name = this.name,
         description = this.description,
+        size = this.size,
+        sizeUnit = this.sizeUnit,
         workspace = this.workspace.toEntity()
     )
 
@@ -22,6 +24,8 @@ fun VolumeJpaEntity.toDomain(): Volume =
         id = this.id,
         name = this.name,
         description = this.description,
+        size = this.size,
+        sizeUnit = this.sizeUnit,
         workspace = this.workspace.toDomain()
     )
 

--- a/src/main/kotlin/com/dcd/server/persistence/volume/entity/VolumeJpaEntity.kt
+++ b/src/main/kotlin/com/dcd/server/persistence/volume/entity/VolumeJpaEntity.kt
@@ -1,8 +1,11 @@
 package com.dcd.server.persistence.volume.entity
 
 import com.dcd.server.persistence.workspace.entity.WorkspaceJpaEntity
+import com.dcd.server.core.domain.volume.model.enums.VolumeSizeUnit
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.Enumerated
+import jakarta.persistence.EnumType
 import jakarta.persistence.FetchType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
@@ -18,6 +21,9 @@ class VolumeJpaEntity(
     val id: UUID,
     val name: String,
     val description: String,
+    val size: Long? = null,
+    @Enumerated(EnumType.STRING)
+    val sizeUnit: VolumeSizeUnit? = null, // size가 지정되었는데 null인 경우 기본 단위는 byte로 간주
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "workspace_id")
     val workspace: WorkspaceJpaEntity,

--- a/src/main/kotlin/com/dcd/server/presentation/domain/volume/data/extension/VolumeRequestExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/volume/data/extension/VolumeRequestExtension.kt
@@ -10,13 +10,17 @@ import com.dcd.server.presentation.domain.volume.data.request.UpdateVolumeReques
 fun CreateVolumeRequest.toDto(): CreateVolumeReqDto =
     CreateVolumeReqDto(
         name = this.name,
-        description = this.description
+        description = this.description,
+        size = this.size,
+        sizeUnit = this.sizeUnit
     )
 
 fun UpdateVolumeRequest.toDto(): UpdateVolumeReqDto =
     UpdateVolumeReqDto(
         name = this.name,
-        description = this.description
+        description = this.description,
+        size = this.size,
+        sizeUnit = this.sizeUnit
     )
 
 fun MountVolumeRequest.toDto(): MountVolumeReqDto =

--- a/src/main/kotlin/com/dcd/server/presentation/domain/volume/data/extension/VolumeResponseExtension.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/volume/data/extension/VolumeResponseExtension.kt
@@ -14,7 +14,9 @@ fun VolumeSimpleResDto.toResponse(): VolumeSimpleResponse =
     VolumeSimpleResponse(
         id = this.id,
         name = this.name,
-        description = this.description
+        description = this.description,
+        size = this.size,
+        sizeUnit = this.sizeUnit
     )
 
 fun VolumeListResDto.toResponse(): VolumeListResponse =
@@ -34,5 +36,7 @@ fun VolumeDetailResDto.toResponse(): VolumeDetailResponse =
         id = this.id,
         name = this.name,
         description = this.description,
+        size = this.size,
+        sizeUnit = this.sizeUnit,
         mountList = this.mountList.map { it.toResponse() }
     )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/volume/data/request/CreateVolumeRequest.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/volume/data/request/CreateVolumeRequest.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.presentation.domain.volume.data.request
 
+import com.dcd.server.core.domain.volume.model.enums.VolumeSizeUnit
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Pattern
 
@@ -8,5 +9,7 @@ data class CreateVolumeRequest(
     @field:Pattern(regexp = "^[a-zA-Z0-9][a-zA-Z0-9_.\\s-]{0,62}$")
     val name: String,
     @field:NotBlank
-    val description: String
+    val description: String,
+    val size: Long? = null,
+    val sizeUnit: VolumeSizeUnit? = null
 )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/volume/data/request/UpdateVolumeRequest.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/volume/data/request/UpdateVolumeRequest.kt
@@ -1,5 +1,6 @@
 package com.dcd.server.presentation.domain.volume.data.request
 
+import com.dcd.server.core.domain.volume.model.enums.VolumeSizeUnit
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Pattern
 
@@ -8,5 +9,7 @@ data class UpdateVolumeRequest(
     @field:Pattern(regexp = "^[a-zA-Z0-9][a-zA-Z0-9_.\\s-]{0,62}$")
     val name: String,
     @field:NotBlank
-    val description: String
+    val description: String,
+    val size: Long? = null,
+    val sizeUnit: VolumeSizeUnit? = null
 )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/volume/data/response/VolumeDetailResponse.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/volume/data/response/VolumeDetailResponse.kt
@@ -1,10 +1,13 @@
 package com.dcd.server.presentation.domain.volume.data.response
 
+import com.dcd.server.core.domain.volume.model.enums.VolumeSizeUnit
 import java.util.UUID
 
 data class VolumeDetailResponse(
     val id: UUID,
     val name: String,
     val description: String,
+    val size: Long?,
+    val sizeUnit: VolumeSizeUnit?,
     val mountList: List<VolumeMountResponse>
 )

--- a/src/main/kotlin/com/dcd/server/presentation/domain/volume/data/response/VolumeSimpleResponse.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/volume/data/response/VolumeSimpleResponse.kt
@@ -1,9 +1,12 @@
 package com.dcd.server.presentation.domain.volume.data.response
 
+import com.dcd.server.core.domain.volume.model.enums.VolumeSizeUnit
 import java.util.UUID
 
 data class VolumeSimpleResponse(
     val id: UUID,
     val name: String,
-    val description: String
+    val description: String,
+    val size: Long?,
+    val sizeUnit: VolumeSizeUnit?
 )

--- a/src/test/kotlin/com/dcd/server/core/domain/volume/usecase/CreateVolumeUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/volume/usecase/CreateVolumeUseCaseTest.kt
@@ -5,6 +5,8 @@ import com.dcd.server.core.common.data.WorkspaceInfo
 import com.dcd.server.core.domain.volume.dto.extension.toEntity
 import com.dcd.server.core.domain.volume.dto.request.CreateVolumeReqDto
 import com.dcd.server.core.domain.volume.exception.AlreadyExistsVolumeException
+import com.dcd.server.core.domain.volume.exception.InvalidVolumeOptionException
+import com.dcd.server.core.domain.volume.model.enums.VolumeSizeUnit
 import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
 import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
 import com.dcd.server.persistence.user.adapter.toEntity
@@ -103,6 +105,57 @@ class CreateVolumeUseCaseTest(
                 shouldThrow<WorkspaceNotFoundException> {
                     createVolumeUseCase.execute(createVolumeReqDto)
                 }
+            }
+        }
+    }
+
+    given("목표 워크스페이스와 크기는 지정되지 않았으나 크기 단위가 지정된 볼륨 생성 요청이 주어지고") {
+        val targetWorkspace = queryWorkspacePort.findById("d57b42f5-5cc4-440b-8dce-b4fc2e372eff")!!
+        workspaceInfo.workspace = targetWorkspace
+        volumeRepository.deleteAll()
+
+        val createVolumeReqDto = CreateVolumeReqDto(
+            name = "testVolumeInvalid",
+            description = "test without size but with sizeUnit",
+            size = null,
+            sizeUnit = VolumeSizeUnit.MB
+        )
+
+        `when`("유스케이스를 실행할때") {
+
+            then("InvalidVolumeOptionException이 발생해야함") {
+                shouldThrow<InvalidVolumeOptionException> {
+                    createVolumeUseCase.execute(createVolumeReqDto)
+                }
+            }
+        }
+    }
+
+    given("목표 워크스페이스와 크기 지정이 포함된 볼륨 생성 요청이 주어지고") {
+        val targetWorkspace = queryWorkspacePort.findById("d57b42f5-5cc4-440b-8dce-b4fc2e372eff")!!
+        workspaceInfo.workspace = targetWorkspace
+        volumeRepository.deleteAll()
+
+        val createVolumeReqDto = CreateVolumeReqDto(
+            name = "testVolumeWithSize",
+            description = "test with size",
+            size = 1024,
+            sizeUnit = VolumeSizeUnit.MB
+        )
+
+        `when`("목표 워크스페이스에 중복되는 이름의 볼륨이 없을때") {
+            createVolumeUseCase.execute(createVolumeReqDto)
+
+            then("크기 정보가 포함된 볼륨이 정상적으로 생성되어야함") {
+                val volumeList = volumeRepository.findAll()
+                volumeList.size shouldBe 1
+
+                val targetVolume = volumeList.first()
+                targetVolume.name shouldBe createVolumeReqDto.name
+                targetVolume.description shouldBe createVolumeReqDto.description
+                targetVolume.size shouldBe createVolumeReqDto.size
+                targetVolume.sizeUnit shouldBe createVolumeReqDto.sizeUnit
+                targetVolume.workspace.id.toString() shouldBe workspaceInfo.workspace!!.id
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/core/domain/volume/usecase/UpdateVolumeUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/volume/usecase/UpdateVolumeUseCaseTest.kt
@@ -8,6 +8,8 @@ import com.dcd.server.core.domain.volume.exception.AlreadyExistsVolumeMountExcep
 import com.dcd.server.core.domain.volume.exception.VolumeNotFoundException
 import com.dcd.server.core.domain.volume.model.Volume
 import com.dcd.server.core.domain.volume.model.VolumeMount
+import com.dcd.server.core.domain.volume.exception.InvalidVolumeOptionException
+import com.dcd.server.core.domain.volume.model.enums.VolumeSizeUnit
 import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
 import com.dcd.server.persistence.volume.adapter.toDomain
 import com.dcd.server.persistence.volume.adapter.toEntity
@@ -139,6 +141,57 @@ class UpdateVolumeUseCaseTest(
                 shouldThrow<VolumeNotFoundException> {
                     updateVolumeUseCase.execute(targetVolumeId, request)
                 }
+            }
+        }
+    }
+
+    given("타겟 볼륨 아이디와 크기는 지정되지 않았으나 크기 단위가 지정된 수정 요청이 주어지고") {
+        beforeContainer {
+            val targetWorkspace = queryWorkspacePort.findById("d57b42f5-5cc4-440b-8dce-b4fc2e372eff")!!
+            workspaceInfo.workspace = targetWorkspace
+        }
+
+        val request = UpdateVolumeReqDto(
+            name = "updateInvalid",
+            description = "updateDescription",
+            size = null,
+            sizeUnit = VolumeSizeUnit.GB
+        )
+
+        `when`("유스케이스를 실행할때") {
+
+            then("InvalidVolumeOptionException이 발생해야함") {
+                shouldThrow<InvalidVolumeOptionException> {
+                    updateVolumeUseCase.execute(targetVolumeId, request)
+                }
+            }
+        }
+    }
+
+    given("타겟 볼륨 아이디와 크기 정보가 포함된 수정 요청이 주어지고") {
+        beforeContainer {
+            val targetWorkspace = queryWorkspacePort.findById("d57b42f5-5cc4-440b-8dce-b4fc2e372eff")!!
+            workspaceInfo.workspace = targetWorkspace
+        }
+
+        val request = UpdateVolumeReqDto(
+            name = "updateWithSize",
+            description = "updateDescription",
+            size = 2048,
+            sizeUnit = VolumeSizeUnit.MB
+        )
+
+        `when`("유스케이스를 실행할때") {
+            updateVolumeUseCase.execute(targetVolumeId, request)
+
+            then("크기 정보가 포함된 볼륨 정보가 수정되어야함") {
+                val targetVolume = volumeRepository.findByIdOrNull(targetVolumeId)
+
+                targetVolume shouldNotBe null
+                targetVolume!!.name shouldBe request.name
+                targetVolume.description shouldBe request.description
+                targetVolume.size shouldBe request.size
+                targetVolume.sizeUnit shouldBe request.sizeUnit
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/presentation/domain/volume/VolumeWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/volume/VolumeWebAdapterTest.kt
@@ -101,7 +101,7 @@ class VolumeWebAdapterTest : BehaviorSpec({
         val testVolumeId = UUID.randomUUID()
 
         `when`("볼륨 단일 조회 메서드를 실행할때") {
-            val volumeDetailResDto = VolumeDetailResDto(testVolumeId, "testVolume", "testDescription", listOf())
+            val volumeDetailResDto = VolumeDetailResDto(testVolumeId, "testVolume", "testDescription", null, null,listOf())
             every { getOneVolumeUseCase.execute(testVolumeId) } returns volumeDetailResDto
 
             val result = volumeWebAdapter.getVolume(testWorkspaceId, testVolumeId)
@@ -120,7 +120,7 @@ class VolumeWebAdapterTest : BehaviorSpec({
 
         `when`("볼륨 목록 조회 메서드를 실행할때") {
             val volumeListResDto =
-                VolumeListResDto(listOf(VolumeSimpleResDto(UUID.randomUUID(), "testVolume", "testDescription")))
+                VolumeListResDto(listOf(VolumeSimpleResDto(UUID.randomUUID(), "testVolume", "testDescription", null, null)))
             every { getAllVolumeUseCase.execute() } returns volumeListResDto
 
             val result = volumeWebAdapter.getAllVolume(testWorkspaceId)

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -25,7 +25,7 @@ create table application_env_entity (id BINARY(16) not null, description varchar
 create table application_env_detail_entity (id BINARY(16) not null, encryption bit not null, env_key varchar(255), env_value varchar(255), env_id BINARY(16), primary key (id));
 create table application_env_matcher_entity (id BINARY(16) not null, application_id BINARY(16), env_id BINARY(16), primary key (id));
 create table application_env_label_entity (application_env_id BINARY(16) not null, label varchar(255));
-create table volume_entity (id BINARY(16) not null, description varchar(255), name varchar(255), workspace_id BINARY(16) not null, primary key (id));
+create table volume_entity (id BINARY(16) not null, description varchar(255), name varchar(255), size BIGINT, size_unit VARCHAR(255) check (size_unit in ('BYTES','KB','MB','GB')), workspace_id BINARY(16) not null, primary key (id));
 create table volume_mount_entity (application_id binary(16) not null, volume_id binary(16) not null, mount_path varchar(255) not null, read_only bit not null, primary key (application_id, volume_id));
 alter table if exists volume_entity add constraint FKhp1ggnqtveky8po2cwsb45una foreign key (workspace_id) references workspace_entity (id) on delete cascade;
 alter table if exists volume_mount_entity add constraint FKr5bb2ev813ioxtylyobgdphel foreign key (application_id) references application_entity (id) on delete cascade;


### PR DESCRIPTION
## 개요
* 볼륨의 사이즈를 지정할 수 있는 기능을 추가합니다.
## 작업내용
* 볼륨 사이즈 지정 단위 enum 클래스 추가
* 볼륨 사이즈 관련 필드 추가
* 도커 볼륨 생성시 볼륨 도메인의 사이즈 옵션에 따른 볼륨의 크기 제한 명령 추가
* 볼륨 사이즈 관련 테스트 케이스 추가
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?
## 기타
* `size`는 지정됐지만, `sizeUnit`이 지정되지 않은 경우 `sizeUnit`은 `BYTES`로 취급
* `size` 지정없이 `sizeUnit` 지정시 에러 발생
* 호스트 환경에서 quota 설정 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 볼륨 생성·수정 시 크기(size)와 단위(BYTES, KB, MB, GB)를 지정할 수 있음

* **개선 사항**
  * 크기와 단위 조합에 대한 입력 유효성 검사 강화로 잘못된 옵션 제출 시 사전 차단 및 명확한 오류 처리 적용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->