### PR TITLE
:twisted_rightwards_arrows: :: [#765] - 이미지 빌드시 정합성이 맞지 않음

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/BuildDockerImageServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/BuildDockerImageServiceImpl.kt
@@ -21,26 +21,7 @@ class BuildDockerImageServiceImpl(
     override suspend fun buildImageByApplicationId(id: String) {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
-        val directoryName = "'${application.name}'"
-        withContext(Dispatchers.IO) {
-            val commandResult = when (application.applicationType) {
-                ApplicationType.SPRING_BOOT -> {
-                    commandPort.executeShellCommand("cd ./$directoryName && ./gradlew clean build")
-                        .run {
-                            if (this.exitValue == 0)
-                                commandPort.executeShellCommand("cd ./$directoryName && docker build -t ${application.containerName}:latest .")
-                            else this
-                        }
-                }
-
-                else -> {
-                    commandPort.executeShellCommand("cd ./$directoryName && docker build -t ${application.containerName}:latest .")
-                }
-            }
-            if (commandResult.exitValue != 0)
-                commandPort.executeShellCommand("rm -rf $directoryName")
-            checkExitValuePort.checkApplicationExitValue(commandResult, application, this, FailureCase.IMAGE_BUILD_FAILURE)
-        }
+        buildImageByApplication(application)
     }
 
     override suspend fun buildImageByApplication(application: Application) {


### PR DESCRIPTION
## 개요
* NEST 타입의 애플리케이션을 아이디로 빌드시 프로젝트 빌드를 하지 않는 현상을 수정합니다.
## 작업내용
* 실질적인 애플리케이션의 빌드는 하나의 메서드에서 진행하도록 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * Docker 이미지 빌드 서비스의 내부 로직을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->