### PR TITLE
:twisted_rightwards_arrows: :: [#775] - 컨테이너 명령 실행을 ContainerPort에서 수행하도록 리펙토링

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/spi/ContainerActions.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/spi/ContainerActions.kt
@@ -13,4 +13,5 @@ interface ContainerActions {
     fun getContainer(status: ContainerStatus): List<String>
     fun getContainerLogs(application: Application): List<String>
     fun buildImage(application: Application, dockerfilePath: String)
+    fun executeCmd(application: Application, workingDir: String, cmd: String, onResponse: (String) -> Unit)
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExecContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExecContainerServiceImpl.kt
@@ -1,11 +1,9 @@
 package com.dcd.server.core.domain.application.service.impl
 
 import com.dcd.server.core.common.command.CommandPort
+import com.dcd.server.core.common.spi.ContainerPort
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.service.ExecContainerService
-import com.github.dockerjava.api.DockerClient
-import com.github.dockerjava.api.async.ResultCallback
-import com.github.dockerjava.api.model.Frame
 import org.springframework.stereotype.Service
 import org.springframework.web.socket.TextMessage
 import org.springframework.web.socket.WebSocketSession
@@ -14,11 +12,18 @@ import java.util.Stack
 
 @Service
 class ExecContainerServiceImpl(
-    private val dockerClient: DockerClient,
+    private val containerPort: ContainerPort,
     private val commandPort: CommandPort
 ) : ExecContainerService {
-    override fun execCmd(application: Application, cmd: String): List<String> =
-        commandPort.executeShellCommand("docker exec ${application.containerName} sh -c 'cd / && $cmd'").result
+    override fun execCmd(application: Application, cmd: String): List<String> {
+        val result = mutableListOf<String>()
+        containerPort.execute {
+            executeCmd(application, "/", cmd) { output ->
+                result.add(output)
+            }
+        }
+        return result
+    }
 
     override fun execCmd(application: Application, session: WebSocketSession, cmd: String) {
         val cmdArray = cmd.split(" ").toTypedArray()
@@ -42,18 +47,18 @@ class ExecContainerServiceImpl(
             return
         }
 
-        // Docker attach API 호출
-        val execInstance = dockerClient.execCreateCmd(application.containerName)
-            .withAttachStdout(true)
-            .withAttachStderr(true)
-            .withCmd(*cmdArray)
-            .withWorkingDir(workingDir)
-            .exec()
+        session.sendMessage(TextMessage("cmd start"))
 
+        containerPort.execute {
+            executeCmd(application, workingDir, cmd) { output ->
+                session.sendMessage(TextMessage(output))
+            }
+        }
 
-        dockerClient.execStartCmd(execInstance.id)
-            .withDetach(false)
-            .exec(AttachResultCallback(session))
+        session.sendMessage(TextMessage("current dir = $workingDir"))
+        session.sendMessage(TextMessage("cmd end"))
+
+        session.close()
     }
 
     private fun updateWorkingDir(dirStack: Stack<String>, newDir: String) {
@@ -67,38 +72,6 @@ class ExecContainerServiceImpl(
             newDir == "." -> return
             newDir.isBlank() -> return
             else -> { dirStack.push(newDir) }
-        }
-    }
-
-    private class AttachResultCallback(
-        private val session: WebSocketSession,
-    ) : ResultCallback.Adapter<Frame>() {
-        override fun onStart(stream: Closeable?) {
-            if (session.isOpen)
-                session.sendMessage(TextMessage("cmd start"))
-            super.onStart(stream)
-        }
-
-        override fun onNext(frame: Frame) {
-            if (session.isOpen)
-                session.sendMessage(TextMessage(frame.payload))
-        }
-
-        override fun onError(throwable: Throwable) {
-            throwable.printStackTrace()
-            session.close()
-        }
-
-        override fun onComplete() {
-            @Suppress("UNCHECKED_CAST")
-            val dirStack = (session.attributes["workingDir"] as? Stack<String>) ?: Stack<String>()
-            val workingDir = "/${dirStack.joinToString("/")}"
-
-            if (session.isOpen) {
-                session.sendMessage(TextMessage("current dir = $workingDir"))
-                session.sendMessage(TextMessage("cmd end"))
-            }
-            super.onComplete()
         }
     }
 }

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
@@ -208,7 +208,7 @@ class DockerCommandExecutor(
                     }
 
                     override fun onError(throwable: Throwable?) {
-                        onResponse("Error: ${throwable?.message}")
+                        throwable?.printStackTrace()
                     }
                 })
         }

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
@@ -187,7 +187,7 @@ class DockerCommandExecutor(
         }
 
         override fun executeCmd(application: Application, workingDir: String, cmd: String, onResponse: (String) -> Unit) {
-            val cmdArray = arrayOf("/bin/sh", "-c", "'$cmd'")
+            val cmdArray = arrayOf("/bin/sh", "-c", cmd)
 
             // Docker attach API 호출
             val execInstance = dockerClient.execCreateCmd(application.containerName)

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
@@ -185,5 +185,32 @@ class DockerCommandExecutor(
                 throw DockerCommandException(application, FailureCase.DELETE_IMAGE_FAILURE, e.message)
             }
         }
+
+        override fun executeCmd(application: Application, workingDir: String, cmd: String, onResponse: (String) -> Unit) {
+            val cmdArray = cmd.split(" ").toTypedArray()
+
+            // Docker attach API 호출
+            val execInstance = dockerClient.execCreateCmd(application.containerName)
+                .withAttachStdout(true)
+                .withAttachStderr(true)
+                .withCmd(*cmdArray)
+                .withWorkingDir(workingDir)
+                .exec()
+
+
+            dockerClient.execStartCmd(execInstance.id)
+                .withDetach(false)
+                .exec(object : ResultCallback.Adapter<Frame>() {
+                    override fun onNext(frame: Frame?) {
+                        frame?.let {
+                            onResponse(String(it.payload).trim())
+                        }
+                    }
+
+                    override fun onError(throwable: Throwable?) {
+                        onResponse("Error: ${throwable?.message}")
+                    }
+                })
+        }
     }
 }

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
@@ -187,7 +187,7 @@ class DockerCommandExecutor(
         }
 
         override fun executeCmd(application: Application, workingDir: String, cmd: String, onResponse: (String) -> Unit) {
-            val cmdArray = cmd.split(" ").toTypedArray()
+            val cmdArray = arrayOf("/bin/sh", "-c", "'$cmd'")
 
             // Docker attach API 호출
             val execInstance = dockerClient.execCreateCmd(application.containerName)

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
@@ -208,7 +208,7 @@ class DockerCommandExecutor(
                     }
 
                     override fun onError(throwable: Throwable?) {
-                        throwable?.printStackTrace()
+                        onResponse("Error: ${throwable?.message}")
                     }
                 })
         }

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
@@ -23,6 +23,7 @@ import com.github.dockerjava.api.model.Volume
 import com.github.dockerjava.api.model.BuildResponseItem
 import com.github.dockerjava.api.command.BuildImageResultCallback
 import com.github.dockerjava.core.command.LogContainerResultCallback
+import java.util.concurrent.TimeUnit
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
 import org.slf4j.LoggerFactory
@@ -211,6 +212,7 @@ class DockerCommandExecutor(
                         onResponse("Error: ${throwable?.message}")
                     }
                 })
+                .awaitCompletion(60, TimeUnit.SECONDS)
         }
     }
 }


### PR DESCRIPTION
## 개요
* 컨테이너에서 명령을 수행할때 containerPort를 통해 수행할 수 있도록 리펙토링합니다.
## 작업내용
* 컨테이너에 명령을 실행시키는 ContainerAction 추가
* ExecContainerService 구현체에서 ContainerPort를 사용하도록 리펙토링
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 작업 디렉토리를 지정하여 명령을 실행하는 기능 추가
  * 명령 실행 결과를 실시간으로 스트리밍하는 방식으로 개선

* **개선 사항**
  * 명령 실행 흐름 최적화 및 안정성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->