### PR TITLE
:twisted_rightwards_arrows: :: [#779] - 도커 API 활용시 deprecated된 부분 해결

### DIFF
--- a/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
@@ -271,14 +271,21 @@ class DockerCommandExecutor(
                 // 임시 컨테이너 시작 및 명령 실행
                 dockerClient.startContainerCmd(tempContainerName).exec()
 
+                var exitCode = -1
+                val callback = object : ResultCallback.Adapter<WaitResponse>() {
+                    override fun onNext(item: WaitResponse?) {
+                        exitCode = item?.statusCode ?: -1
+                        super.onNext(item)
+                    }
+                }
+
                 // 명령 실행 완료 대기
                 dockerClient.waitContainerCmd(tempContainerName)
-                    .exec(ResultCallback.Adapter<WaitResponse>())
+                    .exec(callback)
                     .awaitCompletion()
-                    .also {
-                        if (it.statusCode != 0)
-                            throw VolumeCopyFailureException()
-                    }
+
+                if (exitCode != 0)
+                    throw VolumeCopyFailureException()
             } catch (e: VolumeCopyFailureException) {
                 throw e
             } catch (e: Exception) {

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
@@ -30,8 +30,6 @@ import com.github.dockerjava.api.model.Ports
 import com.github.dockerjava.api.model.Volume
 import com.github.dockerjava.api.model.BuildResponseItem
 import com.github.dockerjava.api.command.BuildImageResultCallback
-import com.github.dockerjava.core.command.LogContainerResultCallback
-import com.github.dockerjava.core.command.WaitContainerResultCallback
 import java.util.concurrent.TimeUnit
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
@@ -146,7 +144,8 @@ class DockerCommandExecutor(
                 val logList = mutableListOf<String>()
 
                 // 콜백 클래스 정의
-                val callback = object : LogContainerResultCallback() {
+                val callback =
+                    object : ResultCallback.Adapter<Frame>() {
                     override fun onNext(item: Frame?) {
                         item?.let {
                             // trimEnd를 사용해 불필요한 개행 문자를 제거

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
@@ -268,14 +268,9 @@ class DockerCommandExecutor(
                 dockerClient.startContainerCmd(tempContainerName).exec()
 
                 // 명령 실행 완료 대기
-                val statusCode = dockerClient.waitContainerCmd(tempContainerName)
-                    .exec(WaitContainerResultCallback())
-                    .awaitStatusCode()
-                if (statusCode != 0) {
-                    throw VolumeCopyFailureException()
-                }
-            } catch (e: VolumeCopyFailureException) {
-                throw e
+                dockerClient.waitContainerCmd(tempContainerName)
+                    .exec(ResultCallback.Adapter<WaitResponse>())
+                    .awaitCompletion()
             } catch (e: Exception) {
                 throw VolumeCopyFailureException()
             }

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
@@ -206,10 +206,9 @@ class DockerCommandExecutor(
                 .withWorkingDir(workingDir)
                 .exec()
 
-
-            dockerClient.execStartCmd(execInstance.id)
-                .withDetach(false)
-                .exec(object : ResultCallback.Adapter<Frame>() {
+            //콜백 클래스 정의
+            val callback =
+                object : ResultCallback.Adapter<Frame>() {
                     override fun onNext(frame: Frame?) {
                         frame?.let {
                             onResponse(String(it.payload).trim())
@@ -219,7 +218,11 @@ class DockerCommandExecutor(
                     override fun onError(throwable: Throwable?) {
                         onResponse("Error: ${throwable?.message}")
                     }
-                })
+                }
+
+            dockerClient.execStartCmd(execInstance.id)
+                .withDetach(false)
+                .exec(callback)
                 .awaitCompletion(60, TimeUnit.SECONDS)
         }
 

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
@@ -29,6 +29,7 @@ import com.github.dockerjava.api.model.PortBinding
 import com.github.dockerjava.api.model.Ports
 import com.github.dockerjava.api.model.Volume
 import com.github.dockerjava.api.model.BuildResponseItem
+import com.github.dockerjava.api.model.WaitResponse
 import com.github.dockerjava.api.command.BuildImageResultCallback
 import java.util.concurrent.TimeUnit
 import org.springframework.context.ApplicationEventPublisher
@@ -77,11 +78,11 @@ class DockerCommandExecutor(
                 
                 val response = dockerClient.createContainerCmd("${application.containerName}:${application.version}")
                     .withName(application.containerName)
-                    .withNetworkMode(PRIMARY_NETWORK)
                     .withExposedPorts(exposedPort)
                     .withVolumes(containerVolumes)
                     .withHostConfig(
                         HostConfig.newHostConfig()
+                            .withNetworkMode(PRIMARY_NETWORK)
                             .withPortBindings(portBindings)
                             .withBinds(binds)
                     )
@@ -146,14 +147,14 @@ class DockerCommandExecutor(
                 // 콜백 클래스 정의
                 val callback =
                     object : ResultCallback.Adapter<Frame>() {
-                    override fun onNext(item: Frame?) {
-                        item?.let {
-                            // trimEnd를 사용해 불필요한 개행 문자를 제거
-                            logList.add(String(it.payload).trimEnd())
+                        override fun onNext(item: Frame?) {
+                            item?.let {
+                                // trimEnd를 사용해 불필요한 개행 문자를 제거
+                                logList.add(String(it.payload).trimEnd())
+                            }
+                            super.onNext(item)
                         }
-                        super.onNext(item)
                     }
-                }
 
                 // 로그 조회 명령 설정
                 dockerClient.logContainerCmd(application.containerName)

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
@@ -275,6 +275,12 @@ class DockerCommandExecutor(
                 dockerClient.waitContainerCmd(tempContainerName)
                     .exec(ResultCallback.Adapter<WaitResponse>())
                     .awaitCompletion()
+                    .also {
+                        if (it.statusCode != 0)
+                            throw VolumeCopyFailureException()
+                    }
+            } catch (e: VolumeCopyFailureException) {
+                throw e
             } catch (e: Exception) {
                 throw VolumeCopyFailureException()
             }


### PR DESCRIPTION
## 개요
* docker API 활용시 deprecated된 메서드와 클래스를 사용하는 부분을 해결합니다.
## 작업내용
* deprecated된 클래스를 사용하는 부분 수정
* deprecated된 메서드를 사용하는 부분 수정
* callback 클래스를 선언해서 변수로 저장하도록 분리
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Docker 명령 실행 로직의 내부 구현을 개선했습니다.

---

**참고**: 이 업데이트는 주로 내부 인프라 개선 사항으로, 사용자에게 보이는 기능 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->