### PR TITLE
:twisted_rightwards_arrows: :: [#791] - 컨테이너 접속시 입출력 스트림을 활용해서 명령을 수행하도록 리펙토링

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ getImageVersion.sh
 ### terraform ###
 terraform/.terraform.lock.hcl
 terraform/.terraform
+
+## dcd ##
+dcd-info

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,8 +63,7 @@ dependencies {
 
 	//docker
 	implementation("com.github.docker-java:docker-java:3.4.0")
-	implementation("com.github.docker-java:docker-java-transport-okhttp:3.4.0")
-	implementation("com.squareup.okhttp3:okhttp:4.12.0")
+	implementation("com.github.docker-java:docker-java-transport-httpclient5:3.4.0")
 
 	//bucket4j
 	implementation("com.bucket4j:bucket4j_jdk17-core:8.14.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,8 +62,8 @@ dependencies {
 	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.6.4")
 
 	//docker
-	implementation("com.github.docker-java:docker-java:3.4.0")
-	implementation("com.github.docker-java:docker-java-transport-httpclient5:3.4.0")
+	implementation("com.github.docker-java:docker-java:3.6.0")
+	implementation("com.github.docker-java:docker-java-transport-zerodep:3.6.0")
 
 	//bucket4j
 	implementation("com.bucket4j:bucket4j_jdk17-core:8.14.0")

--- a/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/error/ErrorCode.kt
@@ -64,6 +64,7 @@ enum class ErrorCode(
     WORKSPACE_DISCONNECTION_FAILED("워크스페이스 연결 해제에 실패했습니다.", 500),
     CONTAINER_NOT_RUN("해당 애플리케이션을 실행할 수 없음", 500),
     CONTAINER_NOT_STOPPED("해당 애플리케이션을 정지할 수 없음", 500),
+    CONTAINER_NOT_CONNECTED("컨테이너에 연결되지 않았습니다.", 500),
     CONTAINER_NOT_CREATED("해당 애플리케이션의 이미지를 컨테이너로 빌드할 수 없음", 500),
     IMAGE_NOT_BUILT("해당 애플리케이션을 이미지로 빌드할 수 없음", 500),
     INTERNAL_ERROR("서버 내부 에러", 500),

--- a/src/main/kotlin/com/dcd/server/core/common/spi/ContainerActions.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/spi/ContainerActions.kt
@@ -5,6 +5,8 @@ import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.volume.model.Volume
 import com.dcd.server.core.domain.volume.model.VolumeMount
 import com.dcd.server.core.domain.workspace.model.Workspace
+import java.io.InputStream
+import java.io.OutputStream
 
 interface ContainerActions {
     fun createContainer(application: Application, volumeMounts: List<VolumeMount>)
@@ -15,6 +17,7 @@ interface ContainerActions {
     fun getContainer(status: ContainerStatus): List<String>
     fun getContainerLogs(application: Application): List<String>
     fun buildImage(application: Application, dockerfilePath: String)
+    fun attachContainer(application: Application, onResponse: (String) -> Unit): OutputStream
     fun executeCmd(application: Application, workingDir: String, cmd: String, onResponse: (String) -> Unit)
     fun executeCmd(containerName: String, cmd: String)
 

--- a/src/main/kotlin/com/dcd/server/core/domain/application/exception/ContainerNotConnectedException.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/exception/ContainerNotConnectedException.kt
@@ -1,0 +1,7 @@
+package com.dcd.server.core.domain.application.exception
+
+import com.dcd.server.core.common.error.BasicException
+import com.dcd.server.core.common.error.ErrorCode
+
+class ContainerNotConnectedException : BasicException(ErrorCode.CONTAINER_NOT_CONNECTED) {
+}

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/ExecContainerService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/ExecContainerService.kt
@@ -8,4 +8,5 @@ interface ExecContainerService {
     fun execCmd(application: Application, cmd: String): List<String>
     fun execCmd(application: Application, session: WebSocketSession, cmd: String)
     fun initContainerTty(application: Application, session: WebSocketSession)
+    fun closeContainerTty(session: WebSocketSession)
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/ExecContainerService.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/ExecContainerService.kt
@@ -2,8 +2,10 @@ package com.dcd.server.core.domain.application.service
 
 import com.dcd.server.core.domain.application.model.Application
 import org.springframework.web.socket.WebSocketSession
+import java.io.OutputStream
 
 interface ExecContainerService {
     fun execCmd(application: Application, cmd: String): List<String>
     fun execCmd(application: Application, session: WebSocketSession, cmd: String)
+    fun initContainerTty(application: Application, session: WebSocketSession)
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExecContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExecContainerServiceImpl.kt
@@ -45,4 +45,8 @@ class ExecContainerServiceImpl(
         }?.let {
             containerInputStreams[session.id] = it
         } ?: throw ContainerNotConnectedException()
+
+    override fun closeContainerTty(session: WebSocketSession) {
+        containerInputStreams.remove(session.id)?.close()
+    }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExecContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExecContainerServiceImpl.kt
@@ -2,19 +2,22 @@ package com.dcd.server.core.domain.application.service.impl
 
 import com.dcd.server.core.common.command.CommandPort
 import com.dcd.server.core.common.spi.ContainerPort
+import com.dcd.server.core.domain.application.exception.ContainerNotConnectedException
 import com.dcd.server.core.domain.application.model.Application
 import com.dcd.server.core.domain.application.service.ExecContainerService
 import org.springframework.stereotype.Service
 import org.springframework.web.socket.TextMessage
 import org.springframework.web.socket.WebSocketSession
 import java.io.*
-import java.util.Stack
+import java.util.concurrent.ConcurrentHashMap
 
 @Service
 class ExecContainerServiceImpl(
     private val containerPort: ContainerPort,
     private val commandPort: CommandPort
 ) : ExecContainerService {
+    private val containerInputStreams = ConcurrentHashMap<String, OutputStream>()
+
     override fun execCmd(application: Application, cmd: String): List<String> {
         val result = mutableListOf<String>()
         containerPort.execute {
@@ -26,15 +29,20 @@ class ExecContainerServiceImpl(
     }
 
     override fun execCmd(application: Application, session: WebSocketSession, cmd: String) {
+        containerInputStreams[session.id]?.let {
+            it.write("${cmd}\n".toByteArray())
+            it.flush()
+        } ?: throw ContainerNotConnectedException()
+    }
+
     override fun initContainerTty(application: Application, session: WebSocketSession) =
         containerPort.execute {
             attachContainer(application) { response ->
                 if (session.isOpen) {
-                    println("ws test1: ${response}")
                     session.sendMessage(TextMessage(response))
-    }
+                }
             }
         }?.let {
             containerInputStreams[session.id] = it
-        } ?: throw RuntimeException("컨테이너에 연결되지 않았습니다.")
+        } ?: throw ContainerNotConnectedException()
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExecContainerServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/ExecContainerServiceImpl.kt
@@ -26,52 +26,15 @@ class ExecContainerServiceImpl(
     }
 
     override fun execCmd(application: Application, session: WebSocketSession, cmd: String) {
-        val cmdArray = cmd.split(" ").toTypedArray()
-
-        @Suppress("UNCHECKED_CAST")
-        val dirStack = (session.attributes["workingDir"] as? Stack<String>) ?: Stack<String>()
-        val workingDir = "/${dirStack.joinToString("/")}"
-
-        if (cmd.contains("cd")) {
-            val newDirList = cmdArray[1].split("/")
-
-            newDirList.forEach { newDir ->
-                updateWorkingDir(dirStack, newDir)
-            }
-            val updatedWorkingDir = "/${dirStack.joinToString("/")}"
-
-            session.sendMessage(TextMessage("current dir = $updatedWorkingDir"))
-            session.sendMessage(TextMessage("cmd end"))
-
-            session.attributes["workingDir"] = dirStack
-            return
-        }
-
-        session.sendMessage(TextMessage("cmd start"))
-
+    override fun initContainerTty(application: Application, session: WebSocketSession) =
         containerPort.execute {
-            executeCmd(application, workingDir, cmd) { output ->
-                session.sendMessage(TextMessage(output))
-            }
-        }
-
-        session.sendMessage(TextMessage("current dir = $workingDir"))
-        session.sendMessage(TextMessage("cmd end"))
-
-        session.close()
+            attachContainer(application) { response ->
+                if (session.isOpen) {
+                    println("ws test1: ${response}")
+                    session.sendMessage(TextMessage(response))
     }
-
-    private fun updateWorkingDir(dirStack: Stack<String>, newDir: String) {
-        when {
-            newDir == "/" -> dirStack.removeAllElements()
-            newDir == ".." -> if (dirStack.isNotEmpty()) dirStack.pop()
-            newDir.startsWith("/") -> {
-                dirStack.removeAllElements()
-                dirStack.push(newDir)
             }
-            newDir == "." -> return
-            newDir.isBlank() -> return
-            else -> { dirStack.push(newDir) }
-        }
-    }
+        }?.let {
+            containerInputStreams[session.id] = it
+        } ?: throw RuntimeException("컨테이너에 연결되지 않았습니다.")
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCase.kt
@@ -36,8 +36,20 @@ class ExecuteCommandUseCase(
     }
 
     fun initContainerTty(applicationId: String, session: WebSocketSession) {
+        val accessToken = (session.attributes["accessToken"] as? String
+            ?: throw InvalidConnectionInfoException("세션에 인증 정보가 존재하지 않음", CloseStatus.PROTOCOL_ERROR))
+
+        val userId = parseTokenPort.getUserId(accessToken)
+
         val application = (queryApplicationPort.findById(applicationId)
             ?: throw ApplicationNotFoundException())
+
+        if (application.status != ApplicationStatus.RUNNING)
+            throw InvalidApplicationStatusException()
+
+        if (userId != application.workspace.owner.id)
+            throw WorkspaceOwnerNotSameException()
+
         execContainerService.initContainerTty(application, session)
     }
 

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCase.kt
@@ -35,6 +35,12 @@ class ExecuteCommandUseCase(
         return CommandResultResDto(result)
     }
 
+    fun initContainerTty(applicationId: String, session: WebSocketSession) {
+        val application = (queryApplicationPort.findById(applicationId)
+            ?: throw ApplicationNotFoundException())
+        execContainerService.initContainerTty(application, session)
+    }
+
     fun execute(applicationId: String, session: WebSocketSession, cmd: String) {
         validateCmd(cmd)
 
@@ -61,7 +67,7 @@ class ExecuteCommandUseCase(
 
         val pattern = Regex("^(?:(?!(;|\\|\\||&&)|rm\\s+-rf\\s+\\/|(wget|curl)\\s+.*\\|\\s*(sh|bash|zsh|ksh)|cat\\s+/etc/passwd|(cat|grep|awk|sed)\\s+/.*ssh/.*(id_rsa|authorized_keys|known_hosts)).)*$")
 
-        if (pattern.matches(cmd).not())
+        if (!pattern.containsMatchIn(cmd))
             throw InvalidCmdException()
     }
 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/ExecuteCommandUseCase.kt
@@ -35,24 +35,6 @@ class ExecuteCommandUseCase(
         return CommandResultResDto(result)
     }
 
-    fun initContainerTty(applicationId: String, session: WebSocketSession) {
-        val accessToken = (session.attributes["accessToken"] as? String
-            ?: throw InvalidConnectionInfoException("세션에 인증 정보가 존재하지 않음", CloseStatus.PROTOCOL_ERROR))
-
-        val userId = parseTokenPort.getUserId(accessToken)
-
-        val application = (queryApplicationPort.findById(applicationId)
-            ?: throw ApplicationNotFoundException())
-
-        if (application.status != ApplicationStatus.RUNNING)
-            throw InvalidApplicationStatusException()
-
-        if (userId != application.workspace.owner.id)
-            throw WorkspaceOwnerNotSameException()
-
-        execContainerService.initContainerTty(application, session)
-    }
-
     fun execute(applicationId: String, session: WebSocketSession, cmd: String) {
         validateCmd(cmd)
 
@@ -71,6 +53,28 @@ class ExecuteCommandUseCase(
             throw WorkspaceOwnerNotSameException()
 
         execContainerService.execCmd(application, session, cmd)
+    }
+
+    fun initContainerTty(applicationId: String, session: WebSocketSession) {
+        val accessToken = (session.attributes["accessToken"] as? String
+            ?: throw InvalidConnectionInfoException("세션에 인증 정보가 존재하지 않음", CloseStatus.PROTOCOL_ERROR))
+
+        val userId = parseTokenPort.getUserId(accessToken)
+
+        val application = (queryApplicationPort.findById(applicationId)
+            ?: throw ApplicationNotFoundException())
+
+        if (application.status != ApplicationStatus.RUNNING)
+            throw InvalidApplicationStatusException()
+
+        if (userId != application.workspace.owner.id)
+            throw WorkspaceOwnerNotSameException()
+
+        execContainerService.initContainerTty(application, session)
+    }
+
+     fun closeContainerTty(session: WebSocketSession) {
+        execContainerService.closeContainerTty(session)
     }
 
     private fun validateCmd(cmd: String) {

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerClientConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerClientConfig.kt
@@ -4,7 +4,7 @@ import com.github.dockerjava.api.DockerClient
 import com.github.dockerjava.core.DefaultDockerClientConfig
 import com.github.dockerjava.core.DockerClientBuilder
 import com.github.dockerjava.core.DockerClientConfig
-import com.github.dockerjava.httpclient5.ApacheDockerHttpClient
+import com.github.dockerjava.zerodep.ZerodepDockerHttpClient
 import com.github.dockerjava.transport.DockerHttpClient
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -15,7 +15,7 @@ class DockerClientConfig {
     fun dockerClient(): DockerClient {
         val config = getDockerConfig()
 
-        val httpClient: DockerHttpClient = ApacheDockerHttpClient.Builder()
+        val httpClient: DockerHttpClient = ZerodepDockerHttpClient.Builder()
             .dockerHost(config.dockerHost)
             .sslConfig(config.sslConfig)
             .build()

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerClientConfig.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerClientConfig.kt
@@ -4,7 +4,7 @@ import com.github.dockerjava.api.DockerClient
 import com.github.dockerjava.core.DefaultDockerClientConfig
 import com.github.dockerjava.core.DockerClientBuilder
 import com.github.dockerjava.core.DockerClientConfig
-import com.github.dockerjava.okhttp.OkDockerHttpClient
+import com.github.dockerjava.httpclient5.ApacheDockerHttpClient
 import com.github.dockerjava.transport.DockerHttpClient
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -15,7 +15,7 @@ class DockerClientConfig {
     fun dockerClient(): DockerClient {
         val config = getDockerConfig()
 
-        val httpClient: DockerHttpClient = OkDockerHttpClient.Builder()
+        val httpClient: DockerHttpClient = ApacheDockerHttpClient.Builder()
             .dockerHost(config.dockerHost)
             .sslConfig(config.sslConfig)
             .build()

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
@@ -213,21 +213,32 @@ class DockerCommandExecutor(
             val execCallback = object : ResultCallback.Adapter<Frame>() {
                 override fun onNext(frame: Frame) {
                     runCatching {
-                        onResponse(String(frame.payload).trim())
-                    }.onFailure { onResponse("Error sending message: ${it.message}") }
+                        val output = String(frame.payload)
+                        if (output.isNotEmpty()) {
+                            onResponse(output)
+                        }
+                    }.onFailure {
+                        onResponse("Error sending message: ${it.message}")
+                    }
                 }
             }
 
-            // 3. 사용자의 입력을 Docker로 전달할 파이프라인 연결
             val pipedOut = PipedOutputStream()
             val pipedIn = PipedInputStream(pipedOut)
 
-            // Docker Exec 프로세스 시작
-            dockerClient.execStartCmd(execId)
-                .withStdIn(pipedIn)
-                .withTty(true)
-                .exec(execCallback)
+            // 별도 스레드에서 exec 시작
+            Thread {
+                try {
+                    dockerClient.execStartCmd(execId)
+                        .withStdIn(pipedIn)
+                        .withTty(true)
+                        .exec(execCallback)
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                }
+            }.start()
 
+            Thread.sleep(100)
             return pipedOut
         }
 

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
@@ -35,6 +35,7 @@ import java.io.PipedInputStream
 import java.io.PipedOutputStream
 import java.io.OutputStream
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.CompletableFuture
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
 import org.slf4j.LoggerFactory
@@ -225,6 +226,7 @@ class DockerCommandExecutor(
 
             val pipedOut = PipedOutputStream()
             val pipedIn = PipedInputStream(pipedOut)
+            val startSignal = CompletableFuture<Unit>()
 
             // 별도 스레드에서 exec 시작
             Thread {
@@ -233,12 +235,13 @@ class DockerCommandExecutor(
                         .withStdIn(pipedIn)
                         .withTty(true)
                         .exec(execCallback)
+                    startSignal.complete(Unit)
                 } catch (e: Exception) {
-                    throw e
+                    startSignal.completeExceptionally(e)
                 }
             }.start()
 
-            Thread.sleep(100)
+            startSignal.get(5, TimeUnit.SECONDS)
             return pipedOut
         }
 

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
@@ -234,7 +234,7 @@ class DockerCommandExecutor(
                         .withTty(true)
                         .exec(execCallback)
                 } catch (e: Exception) {
-                    e.printStackTrace()
+                    throw e
                 }
             }.start()
 

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
@@ -31,6 +31,9 @@ import com.github.dockerjava.api.model.Volume
 import com.github.dockerjava.api.model.BuildResponseItem
 import com.github.dockerjava.api.model.WaitResponse
 import com.github.dockerjava.api.command.BuildImageResultCallback
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.io.OutputStream
 import java.util.concurrent.TimeUnit
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
@@ -194,6 +197,38 @@ class DockerCommandExecutor(
             } catch (e: Exception) {
                 throw DockerCommandException(application, FailureCase.DELETE_IMAGE_FAILURE, e.message)
             }
+        }
+
+        override fun attachContainer(application: Application, onResponse: (String) -> Unit): OutputStream {
+            val execCreateCmdResponse = dockerClient.execCreateCmd(application.containerName)
+                .withAttachStdin(true)
+                .withAttachStdout(true)
+                .withAttachStderr(true)
+                .withTty(true)
+                .withCmd("/bin/sh")
+                .exec()
+
+            val execId = execCreateCmdResponse.id
+
+            val execCallback = object : ResultCallback.Adapter<Frame>() {
+                override fun onNext(frame: Frame) {
+                    runCatching {
+                        onResponse(String(frame.payload).trim())
+                    }.onFailure { onResponse("Error sending message: ${it.message}") }
+                }
+            }
+
+            // 3. 사용자의 입력을 Docker로 전달할 파이프라인 연결
+            val pipedOut = PipedOutputStream()
+            val pipedIn = PipedInputStream(pipedOut)
+
+            // Docker Exec 프로세스 시작
+            dockerClient.execStartCmd(execId)
+                .withStdIn(pipedIn)
+                .withTty(true)
+                .exec(execCallback)
+
+            return pipedOut
         }
 
         override fun executeCmd(application: Application, workingDir: String, cmd: String, onResponse: (String) -> Unit) {

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationSocketHandler.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationSocketHandler.kt
@@ -15,6 +15,13 @@ class ApplicationSocketHandler(
     private val executeCommandUseCase: ExecuteCommandUseCase
 ) : SocketHandler() {
     @Throws(Exception::class)
+    override fun afterConnectionEstablished(session: WebSocketSession) {
+        val applicationId = (session.attributes["applicationId"] as? String
+                ?: throw ApplicationNotFoundException())
+        executeCommandUseCase.initContainerTty(applicationId, session)
+    }
+
+    @Throws(Exception::class)
     override fun handleTextMessage(session: WebSocketSession, message: TextMessage) {
         val applicationId = (session.attributes["applicationId"] as? String
             ?: throw ApplicationNotFoundException())

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationSocketHandler.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationSocketHandler.kt
@@ -58,4 +58,8 @@ class ApplicationSocketHandler(
 
         session.close(closeStatus)
     }
+
+    override fun afterConnectionClosed(session: WebSocketSession, status: CloseStatus) {
+        executeCommandUseCase.closeContainerTty(session)
+    }
 }


### PR DESCRIPTION
## 개요
* 컨테이너 접속시 입출력 스트림을 활용해서 명령을 수행해서 bash프로세스를 유지하도록 리펙토링합니다.
## 작업내용
* docker java api에서 요청시 apache httpClient를 사용하도록 수정
* 실제 tty처럼 동작하게끔 스트림을 세팅할 컨테이너 액션 메서드 추가
* 컨테이너 tty 설정을 초기화하는 메서드 추가
* 웹소켓 연결이 완료되고, tty 설정을 초기화 하는 핸들링 메서드 오버라이딩
* 커맨드 실행시 스트림으로 명령을 보내도록 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 컨테이너 TTY 초기화, 세션별 스트림 등록 및 스트림 기반 명령 전송 기능 추가
  * WebSocket 연결/종료 시 자동으로 컨테이너 TTY를 초기화하고 세션 스트림을 관리하도록 도입

* **Bug Fixes**
  * 컨테이너 미연결 상황에 대한 명확한 오류 처리(새 예외 및 에러 코드 추가)

* **Chores**
  * Docker 클라이언트 구현체 및 관련 의존성 정리
  * .gitignore에 dcd-info 항목 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dolong2/dcd/pull/792?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->