### PR TITLE
:twisted_rightwards_arrows: :: [#801] - 애플리케이션 응답을 반대로 내려주는 부분 수정

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCase.kt
@@ -3,21 +3,17 @@ package com.dcd.server.core.domain.application.usecase
 import com.dcd.server.core.common.annotation.UseCase
 import com.dcd.server.core.common.data.WorkspaceInfo
 import com.dcd.server.core.common.data.dto.response.ListResDto
-import com.dcd.server.core.domain.application.dto.extenstion.toDto
-import com.dcd.server.core.domain.application.dto.response.ApplicationDetailResDto
-import com.dcd.server.core.domain.application.spi.QueryApplicationInitialScriptPort
+import com.dcd.server.core.domain.application.dto.extenstion.toResDto
+import com.dcd.server.core.domain.application.dto.response.ApplicationResDto
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
-import com.dcd.server.core.domain.env.spi.QueryApplicationEnvPort
 import com.dcd.server.core.domain.workspace.exception.WorkspaceNotFoundException
 
 @UseCase(readOnly = true)
 class GetAllApplicationUseCase(
     private val queryApplicationPort: QueryApplicationPort,
     private val workspaceInfo: WorkspaceInfo,
-    private val queryApplicationEnvPort: QueryApplicationEnvPort,
-    private val queryApplicationInitialScriptPort: QueryApplicationInitialScriptPort,
 ) {
-    fun execute(labels: List<String>?): ListResDto<ApplicationDetailResDto> {
+    fun execute(labels: List<String>?): ListResDto<ApplicationResDto> {
         val workspace = workspaceInfo.workspace
             ?: throw WorkspaceNotFoundException()
 
@@ -25,9 +21,7 @@ class GetAllApplicationUseCase(
             queryApplicationPort
                 .findAllByWorkspace(workspace, labels)
                 .map {
-                    val applicationEnvList = queryApplicationEnvPort.findByApplication(it)
-                    val initialScripts = queryApplicationInitialScriptPort.findAllByApplication(it)
-                    it.toDto(applicationEnvList, initialScripts)
+                    it.toResDto()
                 }
         )
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCase.kt
@@ -1,8 +1,8 @@
 package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.annotation.UseCase
-import com.dcd.server.core.domain.application.dto.extenstion.toResDto
-import com.dcd.server.core.domain.application.dto.response.ApplicationResDto
+import com.dcd.server.core.domain.application.dto.extenstion.toDto
+import com.dcd.server.core.domain.application.dto.response.ApplicationDetailResDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.spi.QueryApplicationInitialScriptPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
@@ -14,9 +14,11 @@ class GetOneApplicationUseCase(
     private val queryApplicationEnvPort: QueryApplicationEnvPort,
     private val queryApplicationInitialScriptPort: QueryApplicationInitialScriptPort
 ) {
-    fun execute(id: String): ApplicationResDto {
+    fun execute(id: String): ApplicationDetailResDto {
         val application = (queryApplicationPort.findById(id)
             ?: throw ApplicationNotFoundException())
-        return application.toResDto()
+        val applicationEnvList = queryApplicationEnvPort.findByApplication(application)
+        val initialScripts = queryApplicationInitialScriptPort.findAllByApplication(application)
+        return application.toDto(applicationEnvList, initialScripts)
     }
 }

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
@@ -71,7 +71,7 @@ class ApplicationWebAdapter(
 
     @GetMapping("/{applicationId}")
     @WorkspaceOwnerVerification("#workspaceId")
-    fun getOneApplication(@PathVariable workspaceId: String, @PathVariable applicationId: String): ResponseEntity<ApplicationResponse> =
+    fun getOneApplication(@PathVariable workspaceId: String, @PathVariable applicationId: String): ResponseEntity<ApplicationDetailResponse> =
         getOneApplicationUseCase.execute(applicationId)
             .let { ResponseEntity.ok(it.toResponse()) }
 

--- a/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapter.kt
@@ -65,7 +65,7 @@ class ApplicationWebAdapter(
     fun getAllApplication(
         @PathVariable workspaceId: String,
         @RequestParam(required = false) labels: List<String>? = null
-    ): ResponseEntity<ListResponse<ApplicationDetailResponse>> =
+    ): ResponseEntity<ListResponse<ApplicationResponse>> =
         getAllApplicationUseCase.execute(labels)
             .let { ResponseEntity.ok(it.toResponse { resDto -> resDto.toResponse() }) }
 

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetAllApplicationUseCaseTest.kt
@@ -2,7 +2,7 @@ package com.dcd.server.core.domain.application.usecase
 
 import com.dcd.server.core.common.data.WorkspaceInfo
 import com.dcd.server.core.common.data.dto.response.ListResDto
-import com.dcd.server.core.domain.application.dto.extenstion.toDto
+import com.dcd.server.core.domain.application.dto.extenstion.toResDto
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
 import com.dcd.server.core.domain.user.spi.QueryUserPort
 import com.dcd.server.core.domain.workspace.spi.QueryWorkspacePort
@@ -41,7 +41,7 @@ class GetAllApplicationUseCaseTest(
 
         `when`("usecase를 실행할때") {
             val result = getAllApplicationUseCase.execute(null)
-            val target = ListResDto(applicationList.map { it.toDto(listOf(), listOf()) })
+            val target = ListResDto(applicationList.map { it.toResDto() })
             then("result는 target이랑 같아야함") {
                 result shouldBe target
             }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/GetOneApplicationUseCaseTest.kt
@@ -1,6 +1,6 @@
 package com.dcd.server.core.domain.application.usecase
 
-import com.dcd.server.core.domain.application.dto.extenstion.toResDto
+import com.dcd.server.core.domain.application.dto.extenstion.toDto
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.user.spi.QueryUserPort
@@ -36,7 +36,7 @@ class GetOneApplicationUseCaseTest(
             val result = getOneApplicationUseCase.execute(application.id)
 
             then("result는 application의 내용이랑 같아야함") {
-                result shouldBeEqualToComparingFields application.toResDto()
+                result shouldBeEqualToComparingFields application.toDto(emptyList(), emptyList())
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -84,7 +84,7 @@ class ApplicationWebAdapterTest : BehaviorSpec({
 
     given("ApplicationResponseDto가 주어지고") {
         val testId = "testId"
-        val applicationResponse = ApplicationResDto(
+        val applicationResponse = ApplicationDetailResDto(
             id = testId,
             name = "test",
             description = "test",
@@ -95,6 +95,10 @@ class ApplicationWebAdapterTest : BehaviorSpec({
             version = "latest",
             status = ApplicationStatus.STOPPED,
             labels = listOf(),
+            env = emptyMap(),
+            initialScripts = emptyList(),
+            failureReason = null,
+            failureReasonDetail = null,
         )
         `when`("getOneApplication 메서드를 실행할때") {
             every { getOneApplicationUseCase.execute(testId) } returns applicationResponse

--- a/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/presentation/domain/application/ApplicationWebAdapterTest.kt
@@ -57,21 +57,17 @@ class ApplicationWebAdapterTest : BehaviorSpec({
     }
 
     given("ApplicationListResponse가 주어지고") {
-        val applicationResponse = ApplicationDetailResDto(
+        val applicationResponse = ApplicationResDto(
             id = "testId",
             name = "test",
             description = "test",
             applicationType = ApplicationType.SPRING_BOOT,
-            env = mapOf(),
             githubUrl = "testUrl",
             port = 8080,
             externalPort = 8080,
             version = "latest",
             status = ApplicationStatus.STOPPED,
-            labels = listOf(),
-            failureReason = null,
-            failureReasonDetail = null,
-            initialScripts = emptyList(),
+            labels = listOf()
         )
         val list = listOf(applicationResponse)
         val responseDto = ListResDto(list)


### PR DESCRIPTION
## 개요
* 애플리케이션 조회 응답을 반대로 응답하는 부분을 수정합니다
## 작업내용
* 애플리케이션 조회시 의도한 응답 객체를 내려주도록 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?