### PR TITLE
:twisted_rightwards_arrows: :: [#805] - 애플리케이션 도커파일에 멀티 스테이징 빌드 적용

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
@@ -27,7 +27,7 @@ object FileContent {
         FROM amazoncorretto:${version} AS builder
         WORKDIR /builder
         COPY . .
-        RUN ./gradlew bootJar
+        RUN chmod +x ./gradlew && ./gradlew bootJar
         RUN rm -f build/libs/*-plain.jar && mv build/libs/*.jar build/libs/app.jar
 
         FROM amazoncorretto:${version}-alpine

--- a/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
@@ -41,13 +41,20 @@ object FileContent {
 
     private fun getNestJsDockerFileContent(version: String, port: Int, env: Map<String, String>, initialScripts: List<String>): String =
         """
-        FROM node:${version}
+        FROM node:${version} AS builder
+        WORKDIR /builder
+        COPY package*.json ./
+        RUN npm ci
+        COPY . .
+        RUN npm run build
+
+        FROM node:${version}-alpine
         WORKDIR /app
         ${getEnvString(env)}
         ${getInitialScriptsString(initialScripts)}
         COPY package*.json ./
-        COPY dist ./dist
         RUN npm ci --production=true
+        COPY --from=builder /builder/dist ./dist
         EXPOSE $port
         CMD ["sh", "-c", "TZ=Asia/Seoul node dist/main.js"]
         """.trimIndent()

--- a/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
@@ -61,13 +61,20 @@ object FileContent {
 
     private fun getGinDockerFileContent(version: String, port: Int, env: Map<String, String>, initialScripts: List<String>): String =
         """
-        FROM golang:${version}
-        WORKDIR /app
-        ${getEnvString(env)}
-        ${getInitialScriptsString(initialScripts)}
+        FROM golang:${version} AS builder
+        WORKDIR /builder
+        COPY go.mod go.sum ./
+        RUN go mod download
         COPY . .
         RUN go mod tidy
-        RUN go build -o main .
+        RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main .
+
+        FROM golang:${version}-alpine
+        WORKDIR /app
+        RUN apk --no-cache add ca-certificates tzdata
+        ${getEnvString(env)}
+        ${getInitialScriptsString(initialScripts)}
+        COPY --from=builder /builder/main .
         EXPOSE $port
         CMD ["./main"]
         """.trimIndent()

--- a/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/file/FileContent.kt
@@ -24,15 +24,19 @@ object FileContent {
 
     private fun getSpringBootDockerFileContent(version: String, port: Int, env: Map<String, String>, initialScripts: List<String>): String =
         """
-        FROM openjdk:${version}-jdk
+        FROM amazoncorretto:${version} AS builder
+        WORKDIR /builder
+        COPY . .
+        RUN ./gradlew bootJar
+        RUN rm -f build/libs/*-plain.jar && mv build/libs/*.jar build/libs/app.jar
+
+        FROM amazoncorretto:${version}-alpine
         WORKDIR /app
-        COPY build/libs/*.jar build/libs/
-        RUN rm -f build/libs/*-plain.jar
-        RUN mv build/libs/*.jar build/libs/app.jar
+        COPY --from=builder /builder/build/libs/app.jar app.jar
         EXPOSE $port
         ${getEnvString(env)}
         ${getInitialScriptsString(initialScripts)}
-        CMD ["java", "-jar", "build/libs/app.jar"]
+        CMD ["java", "-jar", "app.jar"]
         """.trimIndent()
 
     private fun getNestJsDockerFileContent(version: String, port: Int, env: Map<String, String>, initialScripts: List<String>): String =

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetApplicationVersionServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/GetApplicationVersionServiceImpl.kt
@@ -36,7 +36,7 @@ class GetApplicationVersionServiceImpl(
 
     override fun getAvailableVersion(applicationType: ApplicationType): List<String> {
         val (baseImageName, minVersion) = when (applicationType) {
-            ApplicationType.SPRING_BOOT -> "openjdk" to SemVer.parse("12")
+            ApplicationType.SPRING_BOOT -> "amazoncorretto" to SemVer.parse("12")
             ApplicationType.NEST_JS -> "node" to SemVer.parse("17")
             ApplicationType.GIN -> "golang" to SemVer.parse("1")
             ApplicationType.MARIA_DB -> "mariadb" to SemVer.parse("10")

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/GetApplicationVersionServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/GetApplicationVersionServiceImplTest.kt
@@ -16,7 +16,7 @@ class GetApplicationVersionServiceImplTest : BehaviorSpec({
 
     given("Docker 태그 목록이 주어졌을 때") {
 
-        every { imageVersionPort.fetchAllVersions("openjdk") } returns listOf(
+        every { imageVersionPort.fetchAllVersions("amazoncorretto") } returns listOf(
             "8",
             "11",
             "12",
@@ -46,7 +46,7 @@ class GetApplicationVersionServiceImplTest : BehaviorSpec({
 
             then("올바른 이미지명이 Port에 전달된다") {
                 verify(exactly = 1) {
-                    imageVersionPort.fetchAllVersions("openjdk")
+                    imageVersionPort.fetchAllVersions("amazoncorretto")
                 }
             }
         }


### PR DESCRIPTION
## 개요
* 애플리케이션 빌드가 필요한 타입의 도커파일에 멀티스테이징 빌드를 적용합니다.
## 작업내용
* spring boot 애플리케이션 타입의 베이스 이미지를 `amazoncorretto`로 수정
  * openjdk가 deprecated 됨.
* spring boot 애플리케이션 도커 파일에 멀티스테이징 적용
* nest 애플리케이션 도커 파일에 멀티스테이징 적용
* gin 애플리케이션 도커 파일에 멀티스테이징 적용
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * Docker 이미지 빌드 방식을 멀티 스테이지로 최적화하여 생성되는 이미지 크기 감소
  * Spring Boot 기본 런타임을 Amazon Corretto로 변경하여 성능 및 안정성 향상
  * NestJS, Go 등 다른 런타임도 경량 이미지 기반으로 통일

<!-- end of auto-generated comment: release notes by coderabbit.ai -->