### PR TITLE
:twisted_rightwards_arrows: :: [#809] - 애플리케이션 디렉토리 이름을 유니크 값으로 설정하도록 수정

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/common/spi/ContainerActions.kt
+++ b/src/main/kotlin/com/dcd/server/core/common/spi/ContainerActions.kt
@@ -16,7 +16,7 @@ interface ContainerActions {
     fun deleteImage(application: Application)
     fun getContainer(status: ContainerStatus): List<String>
     fun getContainerLogs(application: Application): List<String>
-    fun buildImage(application: Application, dockerfilePath: String)
+    fun buildImage(application: Application)
     fun attachContainer(application: Application, onResponse: (String) -> Unit): OutputStream
     fun executeCmd(application: Application, workingDir: String, cmd: String, onResponse: (String) -> Unit)
     fun executeCmd(containerName: String, cmd: String)

--- a/src/main/kotlin/com/dcd/server/core/domain/application/event/listener/ApplicationEventListener.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/event/listener/ApplicationEventListener.kt
@@ -63,7 +63,7 @@ class ApplicationEventListener(
                 applicationImageFilePort.createImageFile(application)
                 
                 containerPort.execute {
-                    buildImage(application, "./${application.name}/Dockerfile")
+                    buildImage(application)
                     val volumeMounts = queryVolumePort.findAllMountByApplication(application)
                     createContainer(application, volumeMounts)
                 }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/model/Application.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/model/Application.kt
@@ -19,6 +19,7 @@ data class Application(
     val deploymentResult: DeploymentResult = DeploymentResult.SUCCESS,
     val labels: List<String>
 ) {
+    val directoryName = "${name.replace(" ", "-")}-$id"
     val containerName = "${name.replace(" ", "_").lowercase()}-$id"
 
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteApplicationDirectoryServiceImpl.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/service/impl/DeleteApplicationDirectoryServiceImpl.kt
@@ -22,7 +22,7 @@ class DeleteApplicationDirectoryServiceImpl(
     override suspend fun deleteApplicationDirectory(application: Application) {
         withContext(Dispatchers.IO) {
             try {
-                fileOperationPort.deleteDirectory(Paths.get(application.name))
+                fileOperationPort.deleteDirectory(Paths.get(application.directoryName))
             } catch (e: FileOperationException) {
                 eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application, FailureCase.DELETE_DIRECTORY_FAILURE))
                 this.cancel()

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/CreateApplicationUseCase.kt
@@ -63,7 +63,7 @@ class CreateApplicationUseCase(
             applicationImageFilePort.createImageFile(application)
 
             containerPort.execute {
-                buildImage(application, "./${application.name}/Dockerfile")
+                buildImage(application)
                 val volumeMounts = queryVolumePort.findAllMountByApplication(application)
                 createContainer(application, volumeMounts)
             }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/DeployApplicationUseCase.kt
@@ -98,7 +98,7 @@ class DeployApplicationUseCase(
                 applicationImageFilePort.createImageFile(application)
             }
 
-            buildImage(application, "./${application.name}/Dockerfile")
+            buildImage(application)
             val volumeMounts = queryVolumePort.findAllMountByApplication(application)
             createContainer(application, volumeMounts)
 

--- a/src/main/kotlin/com/dcd/server/infrastructure/domain/application/adapter/ApplicationGitRepoAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/domain/application/adapter/ApplicationGitRepoAdapter.kt
@@ -24,7 +24,7 @@ class ApplicationGitRepoAdapter(
             
             Git.cloneRepository()
                 .setURI(application.githubUrl)
-                .setDirectory(File("./${application.name}"))
+                .setDirectory(File("./${application.directoryName}"))
                 .call().use { log.debug("Git clone completed for application: ${application.name}") }
         } catch (e: Exception) {
             val cloneFailureEvent = ChangeApplicationStatusEvent(ApplicationStatus.FAILURE, application, FailureCase.CLONE_FAILURE, e.message)

--- a/src/main/kotlin/com/dcd/server/infrastructure/domain/application/adapter/ApplicationImageFileAdapter.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/domain/application/adapter/ApplicationImageFileAdapter.kt
@@ -39,7 +39,7 @@ class ApplicationImageFileAdapter(
 
     private fun createFile(application: Application, coroutineScope: CoroutineScope) {
         val version = application.version
-        val applicationPath = Paths.get(application.name)
+        val applicationPath = Paths.get(application.directoryName)
         val applicationEnv =
             queryApplicationEnvPort.findByApplication(application)
                 .flatMap { it.details }

--- a/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
+++ b/src/main/kotlin/com/dcd/server/infrastructure/global/thirdparty/docker/DockerCommandExecutor.kt
@@ -175,7 +175,8 @@ class DockerCommandExecutor(
             }
         }
 
-        override fun buildImage(application: Application, dockerfilePath: String) {
+        override fun buildImage(application: Application) {
+            val dockerfilePath = "./${application.directoryName}/Dockerfile"
             try {
                 dockerClient.buildImageCmd()
                     .withDockerfile(java.io.File(dockerfilePath))

--- a/src/test/kotlin/com/dcd/server/core/domain/application/service/DeleteApplicationDirectoryServiceImplTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/service/DeleteApplicationDirectoryServiceImplTest.kt
@@ -21,7 +21,7 @@ class DeleteApplicationDirectoryServiceImplTest : BehaviorSpec({
             service.deleteApplicationDirectory(application)
 
             then("fileOperationPort.deleteDirectory가 실행되어야함") {
-                verify { fileOperationPort.deleteDirectory(Paths.get(application.name)) }
+                verify { fileOperationPort.deleteDirectory(Paths.get(application.directoryName)) }
             }
         }
     }

--- a/src/test/kotlin/com/dcd/server/infrastructure/domain/application/adapter/ApplicationImageFileAdapterTest.kt
+++ b/src/test/kotlin/com/dcd/server/infrastructure/domain/application/adapter/ApplicationImageFileAdapterTest.kt
@@ -57,7 +57,7 @@ class ApplicationImageFileAdapterTest : BehaviorSpec({
 
                 verify {
                     fileOperationPort.writeFile(
-                        Paths.get(application.name, "Dockerfile"),
+                        Paths.get(application.directoryName, "Dockerfile"),
                         expectedContent
                     )
                 }
@@ -88,7 +88,7 @@ class ApplicationImageFileAdapterTest : BehaviorSpec({
 
                 verify {
                     fileOperationPort.writeFile(
-                        Paths.get(application.name, "Dockerfile"),
+                        Paths.get(application.directoryName, "Dockerfile"),
                         expectedContent
                     )
                 }
@@ -119,7 +119,7 @@ class ApplicationImageFileAdapterTest : BehaviorSpec({
 
                 verify {
                     fileOperationPort.writeFile(
-                        Paths.get(application.name, "Dockerfile"),
+                        Paths.get(application.directoryName, "Dockerfile"),
                         expectedContent
                     )
                 }
@@ -150,7 +150,7 @@ class ApplicationImageFileAdapterTest : BehaviorSpec({
 
                 verify {
                     fileOperationPort.writeFile(
-                        Paths.get(application.name, "Dockerfile"),
+                        Paths.get(application.directoryName, "Dockerfile"),
                         expectedContent
                     )
                 }
@@ -181,7 +181,7 @@ class ApplicationImageFileAdapterTest : BehaviorSpec({
 
                 verify {
                     fileOperationPort.writeFile(
-                        Paths.get(application.name, "Dockerfile"),
+                        Paths.get(application.directoryName, "Dockerfile"),
                         expectedContent
                     )
                 }
@@ -212,7 +212,7 @@ class ApplicationImageFileAdapterTest : BehaviorSpec({
 
                 verify {
                     fileOperationPort.writeFile(
-                        Paths.get(application.name, "Dockerfile"),
+                        Paths.get(application.directoryName, "Dockerfile"),
                         expectedContent
                     )
                 }
@@ -243,7 +243,7 @@ class ApplicationImageFileAdapterTest : BehaviorSpec({
 
                 verify {
                     fileOperationPort.writeFile(
-                        Paths.get(application.name, "Dockerfile"),
+                        Paths.get(application.directoryName, "Dockerfile"),
                         expectedContent
                     )
                 }
@@ -291,7 +291,7 @@ class ApplicationImageFileAdapterTest : BehaviorSpec({
 
                 verify {
                     fileOperationPort.writeFile(
-                        Paths.get(application.name, "Dockerfile"),
+                        Paths.get(application.directoryName, "Dockerfile"),
                         expectedContent
                     )
                 }
@@ -333,7 +333,7 @@ class ApplicationImageFileAdapterTest : BehaviorSpec({
 
                 verify {
                     fileOperationPort.writeFile(
-                        Paths.get(application.name, "Dockerfile"),
+                        Paths.get(application.directoryName, "Dockerfile"),
                         expectedContent
                     )
                 }


### PR DESCRIPTION
## 개요
* 애플리케이션 디렉토리 이름을 id와 애플리케이션 이름을 조합해서 설정하도록 수정합니다.
  * 다른 워크스페이스에 위치한 같은 이름의 애플리케이션이 동시에 배포된다면, 충돌이 발생할 수 있음.
## 작업내용
* 애플리케이션 도메인에 directoryName 필드 추가
* 애플리케이션 디렉토리 삭제, 저장소 복제, 이미지 생성, 이미지 빌드시에 direcotryName을 사용하도록 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 애플리케이션 배포 시 디렉터리 명명 방식을 표준화하여 안정성 향상
  * Docker 이미지 빌드 프로세스를 간소화로 배포 흐름 개선
  * 파일 및 경로 관리의 일관성 강화로 시스템 신뢰성 증대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->