### PR TITLE
:twisted_rightwards_arrows: :: [#813] - 애플리케이션 수정시 이름이 수정된 경우 컨테이너 생성 안됨

### DIFF
--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCase.kt
@@ -59,12 +59,6 @@ class UpdateApplicationUseCase(
             launch {
                 eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.PENDING, updatedApplication))
 
-                // 이름이 변경되기 전 애플리케이션의 이미지및, 컨테이너 제거
-                containerPort.execute {
-                    deleteContainer(application)
-                    deleteImage(application)
-                }
-
                 // 이름이 변경된 애플리케이션의 이미지및, 컨테이너 생성
                 val applicationType = updatedApplication.applicationType
                 when(applicationType) {
@@ -83,6 +77,12 @@ class UpdateApplicationUseCase(
                 }
 
                 deleteApplicationDirectoryService.deleteApplicationDirectory(updatedApplication)
+
+                // 이름이 변경되기 전 애플리케이션의 이미지및, 컨테이너 제거
+                containerPort.execute {
+                    deleteContainer(application)
+                    deleteImage(application)
+                }
 
                 eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.STOPPED, updatedApplication))
             }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCase.kt
@@ -57,11 +57,15 @@ class UpdateApplicationUseCase(
 
         if (application.name != updateApplicationReqDto.name) {
             launch {
+                eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.PENDING, updatedApplication))
+
+                // 이름이 변경되기 전 애플리케이션의 이미지및, 컨테이너 제거
                 containerPort.execute {
                     deleteContainer(application)
                     deleteImage(application)
                 }
 
+                // 이름이 변경된 애플리케이션의 이미지및, 컨테이너 생성
                 val applicationType = updatedApplication.applicationType
                 when(applicationType) {
                     ApplicationType.SPRING_BOOT, ApplicationType.NEST_JS, ApplicationType.GIN -> {
@@ -79,6 +83,8 @@ class UpdateApplicationUseCase(
                 }
 
                 deleteApplicationDirectoryService.deleteApplicationDirectory(updatedApplication)
+
+                eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.STOPPED, updatedApplication))
             }
         }
     }

--- a/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCase.kt
+++ b/src/main/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCase.kt
@@ -8,18 +8,28 @@ import com.dcd.server.core.domain.application.event.ChangeApplicationStatusEvent
 import com.dcd.server.core.domain.application.exception.AlreadyRunningException
 import com.dcd.server.core.domain.application.exception.ApplicationNotFoundException
 import com.dcd.server.core.domain.application.model.enums.ApplicationStatus
+import com.dcd.server.core.domain.application.model.enums.ApplicationType
 import com.dcd.server.core.domain.application.service.InitialScriptService
+import com.dcd.server.core.domain.application.service.DeleteApplicationDirectoryService
+import com.dcd.server.core.domain.application.spi.ApplicationImageFilePort
+import com.dcd.server.core.domain.application.spi.ApplicationRemoteRepoPort
 import com.dcd.server.core.domain.application.spi.CommandApplicationPort
 import com.dcd.server.core.domain.application.spi.QueryApplicationPort
+import com.dcd.server.core.domain.volume.spi.QueryVolumePort
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.launch
 import org.springframework.context.ApplicationEventPublisher
 
 @UseCase
 class UpdateApplicationUseCase(
     private val queryApplicationPort: QueryApplicationPort,
     private val commandApplicationPort: CommandApplicationPort,
+    private val applicationRemoteRepoPort: ApplicationRemoteRepoPort,
+    private val applicationImageFilePort: ApplicationImageFilePort,
+    private val deleteApplicationDirectoryService: DeleteApplicationDirectoryService,
+    private val queryVolumePort: QueryVolumePort,
     private val containerPort: ContainerPort,
     private val eventPublisher: ApplicationEventPublisher,
     private val initialScriptService: InitialScriptService
@@ -31,14 +41,6 @@ class UpdateApplicationUseCase(
 
         if (application.status == ApplicationStatus.RUNNING)
             throw AlreadyRunningException()
-
-        if (application.name != updateApplicationReqDto.name) {
-            containerPort.execute {
-                deleteContainer(application)
-                deleteImage(application)
-                eventPublisher.publishEvent(ChangeApplicationStatusEvent(ApplicationStatus.STOPPED, application))
-            }
-        }
 
         val updatedApplication =
             application.copy(
@@ -52,5 +54,32 @@ class UpdateApplicationUseCase(
         commandApplicationPort.save(updatedApplication)
 
         initialScriptService.write(updatedApplication, updateApplicationReqDto.initialScripts)
+
+        if (application.name != updateApplicationReqDto.name) {
+            launch {
+                containerPort.execute {
+                    deleteContainer(application)
+                    deleteImage(application)
+                }
+
+                val applicationType = updatedApplication.applicationType
+                when(applicationType) {
+                    ApplicationType.SPRING_BOOT, ApplicationType.NEST_JS, ApplicationType.GIN -> {
+                        applicationRemoteRepoPort.cloneApplicationRemoteRepo(updatedApplication)
+                    }
+                    else -> {}
+                }
+
+                applicationImageFilePort.createImageFile(updatedApplication)
+
+                containerPort.execute {
+                    buildImage(updatedApplication)
+                    val volumeMounts = queryVolumePort.findAllMountByApplication(updatedApplication)
+                    createContainer(updatedApplication, volumeMounts)
+                }
+
+                deleteApplicationDirectoryService.deleteApplicationDirectory(updatedApplication)
+            }
+        }
     }
 }

--- a/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCaseTest.kt
+++ b/src/test/kotlin/com/dcd/server/core/domain/application/usecase/UpdateApplicationUseCaseTest.kt
@@ -38,7 +38,7 @@ class UpdateApplicationUseCaseTest(
 ) : BehaviorSpec({
     val targetUserId = "923a6407-a5f8-4e1e-bffd-0621910ddfc8"
 
-    val updateReqDto = UpdateApplicationReqDto(name = "updated application", description = "dldl", applicationType = ApplicationType.SPRING_BOOT, githubUrl = null, version = "11", port = 8080, initialScripts = listOf("echo test"))
+    val updateReqDto = UpdateApplicationReqDto(name = "testName", description = "dldl", applicationType = ApplicationType.SPRING_BOOT, githubUrl = null, version = "11", port = 8080, initialScripts = listOf("echo test"))
 
     given("애플리케이션 아이디가 주어지고") {
         val targetUser = queryUserPort.findById(targetUserId)!!
@@ -59,7 +59,6 @@ class UpdateApplicationUseCaseTest(
                 result?.port shouldBe updateReqDto.port
                 result?.githubUrl shouldBe updateReqDto.githubUrl
                 result?.version shouldBe updateReqDto.version
-                coVerify { containerPort.execute<Any>(any()) }
             }
 
             then("변경된 초기화 스크립트를 가지고 있어야함") {


### PR DESCRIPTION
## 개요
* 애플리케이션 수정시 이름이 수정되는 경우 기존 이미지와 컨테이너는 제거하지만, 수정된 이름의 이미지와 컨테이너가 생성되지 않음
## 작업내용
* 이름이 수정된 경우 새 이름의 이미지및 컨테이너를 생성하도록 수정
## 체크리스트
> 탬플릿외에 필요한 항목이 있으면 추가해주세요.
* [x] 로컬에서 빌드가 성공하나요?
* [x] 추가(수정)한 코드가 정상적으로 동작하나요?
* [x] pr 타켓 브랜치가 맞게 설정되어 있나요?
* [x] pr에서 작업할 내용만 작업됐나요?
* [ ] 기존 API와 호환되지 않는 사항이 있나요?
## 기타
* 생성부의 공통되는 로직을 따로 분리하는것도 괜찮을듯

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 애플리케이션 이름 변경 처리 흐름을 비동기 오케스트레이션으로 전환해 변경 시 리소스 정리와 환경 구성 과정을 단계적으로 수행하도록 개선했습니다.  
* **사용성 개선**
  * 이름 변경 시 즉시 상태가 반영되고(대기 상태 이벤트), 백그라운드에서 이미지/컨테이너 정리·재구성이 완료되면 중지 상태 이벤트가 발행되어 응답성이 향상됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->